### PR TITLE
*6924* Overflow on subsequent lines hidden for first column in grid

### DIFF
--- a/styles/controllers/grid/grid.less
+++ b/styles/controllers/grid/grid.less
@@ -91,14 +91,15 @@ div.pkp_controllers_grid {
 
 	.row_container {
 		position: relative; /* Required to anchor absolute row actions positioning below. */
-		padding-top: 10px;
+		padding-top: 10px; 
 		padding-left: 40px;
 		padding-right: 30px;
 		overflow: hidden;
-		height: 40px;
-		word-wrap: break-word;
+		min-height: 40px;
+		height: auto;
+		/* word-wrap: break-word; */
 		/* min-height: 40px; */
-		line-height: auto;
+		line-height: auto; 
 		vertical-align: middle;
 	}
 
@@ -107,6 +108,7 @@ div.pkp_controllers_grid {
 		top: 0;
 		left: 0;
 		width: 24px;
+		height: 200px;
 	}
 
 	.row_actions a {
@@ -115,10 +117,11 @@ div.pkp_controllers_grid {
 	}
 
 	.row_file {
-		width: 100%;		
+		width: 100%;
 	}
 
 	.row_file a {
+		margin-top: 10px;
 		float:left;
 		margin-right: 20px;
 	}
@@ -136,7 +139,7 @@ div.pkp_controllers_grid {
 	.row_controls td {
 		padding-left: 30px;
 		line-height: 25px;
-   		height: 25px;
+		height: 25px;
 	}
 
 	.row_controls a {
@@ -241,6 +244,6 @@ div.pkp_controllers_grid {
 	}
 	
 	.ordering:hover {
-		background: #EAF3F8 !important;  
-	} 
+		background: #EAF3F8 !important;
+	}
 }

--- a/styles/sprites.less
+++ b/styles/sprites.less
@@ -26,7 +26,7 @@ a.sprite {
 	&.notify:before { margin-right:4px; background-position: -24px 0; }
 	&.notify:hover:before { background-position: -24px -24px; }
 
-	&.settings:before { margin-top: 8px; background-position: -408px 0; }
+	&.settings:before { margin-top: 10px; background-position: -408px 0; }
 	&.settings:hover:before { background-position: -408px -24px; }
 
 	&.information:before { background-position: -194px 0; }
@@ -47,13 +47,13 @@ a.sprite {
 	&.participants:before { background-position: -314px 0; }
 	&.participants:hover:before { background-position: -314px -24px; }
 
-	&.notes:before { margin-top: 7px; background-position: -264px 0; }
+	&.notes:before { margin-top: -5px; background-position: -264px 0; }
 	&.notes:hover:before { background-position: -264px -24px; }
 
-	&.notes_new:before { margin-top: 7px; background-position: -1224px 0; }
+	&.notes_new:before { margin-top: -5px; background-position: -1224px 0; }
 	&.notes_new:hover:before { background-position: -1224px -24px; }
 
-	&.notes_none:before { margin-top: 7px; background-position: -1200px 0; }
+	&.notes_none:before { margin-top: -5px; background-position: -1200px 0; }
 	&.notes_none:hover:before { background-position: -1200px -24px; }
 
 	&.add:before { margin-right:4px; background-position: -504px 0; }
@@ -65,7 +65,7 @@ a.sprite {
 	&.add_category:before { margin-right:4px; background-position: -552px 0; }
 	&.add_category:hover:before { background-position: -552px -24px; }
 
-	&.add_item:before { margin-top:1px; margin-right:4px; background-position: -576px 0; }
+	&.add_item:before { margin-right:4px; background-position: -576px 0; }
 	&.add_item:hover:before { background-position: -576px -24px; }
 
 	&.remove_item:before { background-position: -600px 0; }
@@ -98,25 +98,25 @@ a.sprite {
 	&.import:before { margin-right:4px; background-position: -816px 0; }
 	&.import:hover:before { background-position: -816px -24px; }
 
-	&.pdf:before { margin-top: 8px; margin-right:4px; background-position: -840px 0; }
+	&.pdf:before { margin-top: -5px; margin-right:4px; background-position: -840px 0; }
 	&.pdf:hover:before { background-position: -840px -24px; }
 
-	&.html:before { margin-top: 8px; margin-right:4px; background-position: -864px 0; }
+	&.html:before { margin-top: -5px; margin-right:4px; background-position: -864px 0; }
 	&.html:hover:before { background-position: -864px -24px; }
 
-	&.word:before { margin-top: 8px; margin-right:4px; background-position: -888px 0; }
+	&.word:before { margin-top: -5px; margin-right:4px; background-position: -888px 0; }
 	&.word:hover:before { background-position: -888px -24px; }
 
-	&.image:before { margin-top: 8px; margin-right:4px; background-position: -912px 0; }
+	&.image:before { margin-top: -5px; margin-right:4px; background-position: -912px 0; }
 	&.image:hover:before { background-position: -912px -24px; }
 
-	&.excel:before { margin-top: 8px; margin-right:4px; background-position: -936px 0; }
+	&.excel:before { margin-top: -5px; margin-right:4px; background-position: -936px 0; }
 	&.excel:hover:before { background-position: -936px -24px; }
 
-	&.default:before { margin-top: 8px; margin-right:4px; background-position: -960px 0; }
+	&.default:before { margin-top: -5px; margin-right:4px; background-position: -960px 0; }
 	&.default:hover:before { background-position: -960px -24px; }
 
-	&.zip:before { margin-top: 8px; margin-right:4px; background-position: -984px 0; }
+	&.zip:before { margin-top: -5px; margin-right:4px; background-position: -984px 0; }
 	&.zip:hover:before { background-position: -984px -24px; }
 
 	&.warning:before { margin-right:4px; background-position: -1008px 0; }


### PR DESCRIPTION
*Cleaned all extraneous spaces from code.

This should address the overflow issue.

As long as the actual field doesn't exceed 200px (at that point the edit
sprite's background will show a gap.)

A failed routing issue to github yesterday caused some issues with pushing this commit.

