### PR TITLE
Re apply *3696* fix for moving TinyMCE cache

### DIFF
--- a/lib/tinymce/jscripts/tiny_mce/tiny_mce_gzip.php
+++ b/lib/tinymce/jscripts/tiny_mce/tiny_mce_gzip.php
@@ -17,10 +17,10 @@ if (TinyMCE_Compressor::getParam("js")) {
 	 * Add any site-specific defaults here that you may wish to implement. For example:
 	 *
 	 * 	"languages" => "en",
-	 *  "cache_dir" => realpath(dirname(__FILE__) . "/../../_cache"),
 	 *  "files"     => "somescript,anotherscript",
 	 *  "expires"   => "1m",
 	 */
+	    "cache_dir" => realpath(dirname(__FILE__) . "/../../../../../../cache"),
 	));
 
 	// Handle request, compress and stream to client


### PR DESCRIPTION
This patch re applies the _3696_ patch to cache the TinyMCE gzip file into cache folder.
