### PR TITLE
*8358* Disable genre selector for reviewer file attachment uploads

### DIFF
--- a/classes/file/SubmissionFileManager.inc.php
+++ b/classes/file/SubmissionFileManager.inc.php
@@ -265,18 +265,22 @@ class SubmissionFileManager extends BaseSubmissionFileManager {
 
 		// Retrieve the submission file DAO.
 		$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO'); /* @var $submissionFileDao SubmissionFileDAO */
-		// We either need a genre id or a revised file, otherwise
-		// we cannot identify the target file implementation.
-		assert($genreId || $revisedFileId);
-		if (!$genreId || $revisedFileId) {
-			// Retrieve the revised file. (null $fileStage in case the revision is from a previous stage).
-			$revisedFile = $submissionFileDao->getLatestRevision($revisedFileId, null, $this->getSubmissionId());
-			if (!is_a($revisedFile, 'SubmissionFile')) return $nullVar;
+
+		// Except for reviewer file attchments we either need a genre id or a
+		// revised file, otherwise we cannot identify the target file
+		// implementation.
+		if ($fileStage != SUBMISSION_FILE_REVIEW_ATTACHMENT) {
+			assert($genreId || $revisedFileId);
+			if (!$genreId || $revisedFileId) {
+				// Retrieve the revised file. (null $fileStage in case the revision is from a previous stage).
+				$revisedFile = $submissionFileDao->getLatestRevision($revisedFileId, null, $this->getSubmissionId());
+				if (!is_a($revisedFile, 'SubmissionFile')) return $nullVar;
+			}
 		}
 
 		// If we don't have a genre then use the genre from the
 		// existing file.
-		if (!$genreId) {
+		if ($revisedFile and !$genreId) {
 			$genreId = $revisedFile->getGenreId();
 		}
 

--- a/classes/submission/PKPSubmissionFileDAO.inc.php
+++ b/classes/submission/PKPSubmissionFileDAO.inc.php
@@ -625,15 +625,22 @@ class PKPSubmissionFileDAO extends PKPFileDAO {
 		static $genreCache = array();
 
 		if (!isset($genreCache[$genreId])) {
-			// We have to instantiate the genre to find out about
-			// its category.
-			$genreDao = DAORegistry::getDAO('GenreDAO'); /* @var $genreDao GenreDAO */
-			$genre =& $genreDao->getById($genreId);
+			if (is_null($genreId)) {
+				// If no genreId is given fall back to the document category
+				$genreCategory = GENRE_CATEGORY_DOCUMENT;
+
+			} else {
+				// We have to instantiate the genre to find out about
+				// its category.
+				$genreDao = DAORegistry::getDAO('GenreDAO'); /* @var $genreDao GenreDAO */
+				$genre =& $genreDao->getById($genreId);
+				$genreCategory = $genre->getCategory();
+			}
 
 			// Identify the file implementation.
 			$genreMapping = $this->getGenreCategoryMapping();
-			assert(isset($genreMapping[$genre->getCategory()]));
-			$genreCache[$genreId] = $genreMapping[$genre->getCategory()];
+			assert(isset($genreMapping[$genreCategory]));
+			$genreCache[$genreId] = $genreMapping[$genreCategory];
 		}
 
 		return $genreCache[$genreId];

--- a/controllers/grid/files/fileList/FileGenreGridColumn.inc.php
+++ b/controllers/grid/files/fileList/FileGenreGridColumn.inc.php
@@ -44,6 +44,7 @@ class FileGenreGridColumn extends GridColumn {
 		// Retrieve the genre label for the submission file.
 		$genreDao = DAORegistry::getDAO('GenreDAO');
 		$genre = $genreDao->getById($submissionFile->getGenreId());
+		if (!is_a($genre, 'Genre')) { return array('label' => null); }
 		return array('label' => $genre->getLocalizedName());
 	}
 }

--- a/controllers/wizard/fileUpload/form/PKPSubmissionFilesUploadForm.inc.php
+++ b/controllers/wizard/fileUpload/form/PKPSubmissionFilesUploadForm.inc.php
@@ -53,6 +53,11 @@ class PKPSubmissionFilesUploadForm extends SubmissionFilesUploadBaseForm {
 			$request, 'controllers/wizard/fileUpload/form/fileUploadForm.tpl',
 			$submissionId, $stageId, $fileStage, $revisionOnly, $reviewRound, $revisedFileId, $assocType, $assocId
 		);
+
+		// Disable the genre selector for review file attachments
+		if ($fileStage == SUBMISSION_FILE_REVIEW_ATTACHMENT) {
+			$this->setData('reviewAttachment', true);
+		}
 	}
 
 
@@ -101,8 +106,10 @@ class PKPSubmissionFilesUploadForm extends SubmissionFilesUploadBaseForm {
 		// Retrieve the request context.
 		$router = $request->getRouter();
 		$context = $router->getContext($request);
-
-		if (!$revisedFileId) {
+		if (
+			$this->getData('fileStage') != SUBMISSION_FILE_REVIEW_ATTACHMENT and
+			!$revisedFileId
+		) {
 			// Add an additional check for the genre to the form.
 			$this->addCheck(
 				new FormValidatorCustom(

--- a/templates/controllers/wizard/fileUpload/form/fileUploadForm.tpl
+++ b/templates/controllers/wizard/fileUpload/form/fileUploadForm.tpl
@@ -109,6 +109,8 @@
 		{* Use case 3: Upload a new file or a revision *}
 		{assign var="showFileSelector" value=true}
 	{/if}
+	{* Disable the genre selector for reviewer attachements *}
+	{if $reviewAttachment}{assign var="showGenreSelector" value=false}{/if}
 {/if}
 
 {if $revisionOnlyWithoutFileOptions}
@@ -129,7 +131,9 @@
 				// File genres currently assigned to submission files.
 				fileGenres: {ldelim}
 					{foreach name=currentSubmissionFileGenres from=$currentSubmissionFileGenres key=submissionFileId item=fileGenre}
-						{$submissionFileId}: {$fileGenre}{if !$smarty.foreach.currentSubmissionFileGenres.last},{/if}
+						{if !empty($fileGenre)}
+							{$submissionFileId}: {$fileGenre}{if !$smarty.foreach.currentSubmissionFileGenres.last},{/if}
+						{/if}
 					{/foreach}
 				{rdelim},
 				$uploader: $('#plupload'),


### PR DESCRIPTION
Bugzilla ticket: http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=8358

I had to analyze all the classes involved in file uploading to make sure I don't break anything. I will attach my notes here for safekeeping:

```
_SubmissionFileDAODelegate_

ArtworkFileDAODelegate extends SubmissionArtworkFileDAODelegate (final) - no genre

SubmissionArtworkFileDAODelegate extends SubmissionFileDAODelegate - no genre
ArticleFileDAODelegate extends SubmissionFileDAODelegate (final) - no genre

SubmissionFileDAODelegate extends DAO

    * 3 references to genre (get/setters)
        No rewrite required null handling is already implemented

DAO - no genre


_PKPFileDAO_

SubmissionFileDAO extends PKPSubmissionFileDAO (final)

    * function getGenreCategoryMapping()
        overwrites PKPSubmissionFileDAO::getGenreCategoryMapping
        no rewrite required fall back to GENRE_CATEGORY_DOCUMENT

PKPSubmissionFileDAO extends PKPFileDAO

    * function &insertObject(&$submissionFile, $sourceFile, $isUpload = false) {
        utilizes: _castToGenre and _getFileImplementationForGenreId
        no changes required (resolved by changing _getFileImplementationForGenreId)

    * function &updateObject(&$updatedFile, $previousFileId = null, $previousRevision = null) {
        utilizes: _castToGenre and _getFileImplementationForGenreId
        calls: setGenreId getGenreId
        no changes required (resolved by changing _getFileImplementationForGenreId)

    * function &setAsLatestRevision($revisedFileId, $newFileId, $submissionId, $fileStage) {
        used in ./lib/pkp/controllers/wizard/fileUpload/form/SubmissionFilesUploadConfirmationForm.inc.php
        no rewrite required

    * function newDataObjectByGenreId($genreId)
        used in ./lib/pkp/classes/file/SubmissionFileManager.inc.php
        no changes required (resolved by changing _getFileImplementationForGenreId)

    * function getGenreCategoryMapping() {
        placeholder to ensure that child class implements method
        no rewrite required

    * function &_getFileImplementationForGenreId($genreId) {
        no external references
        IMPLEMENTED fall back to GENRE_CATEGORY_DOCUMENT

    * function &_getDaoDelegateForGenreId($genreId) {
        no external references
        no changes required (resolved by changing _getFileImplementationForGenreId)

    * function &_castToGenre($submissionFile) {
        no external references
        no changes required (resolved by changing _getFileImplementationForGenreId)



ArticleFileDAO extends PKPFileDAO (final) - no genre
IssueFileDAO extends PKPFileDAO (final) - no genre

PKPFileDAO extends DAO - no genre
DAO - no genre


_PKPFile_

ArtworkFile extends ArticleFile - no genre
ArticleFile extends SubmissionFile

    * function _generateFileName()
        No rewrite required works with genreId null too

SubmissionFile extends PKPFile

    * function setGenreId($genreId)
        No rewrite required null values are already implemented
    * function getGenreId()
        No rewrite required null values are already implemented
    * function _generateFileName()
        genrates file name based on genre
        No rewrite required works with genreId null too

PKPFile extends DataObject - no genre
DataObject - no genre
```
