### PR TITLE
*6395* Fix bad announcement redirect

### DIFF
--- a/pages/announcement/PKPAnnouncementHandler.inc.php
+++ b/pages/announcement/PKPAnnouncementHandler.inc.php
@@ -72,10 +72,10 @@ class PKPAnnouncementHandler extends Handler {
 				$templateMgr->append('pageHierarchy', array($request->url(null, 'announcement'), 'announcement.announcements'));
 				$templateMgr->display('announcement/view.tpl');
 			} else {
-				$request->redirect(null, null, 'announcement');
+				$request->redirect(null, 'announcement');
 			}
 		} else {
-			$request->redirect(null, null, 'announcement');
+			$request->redirect(null, 'announcement');
 		}
 	}
 


### PR DESCRIPTION
Part one of two for this bugzilla entry. http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=6395
