### PR TITLE
*8854* Add config variable to declare X_FORWARDED_FOR header as trusted or untrusted

### DIFF
--- a/classes/core/PKPRequest.inc.php
+++ b/classes/core/PKPRequest.inc.php
@@ -386,6 +386,7 @@ class PKPRequest {
 		static $ipaddr;
 		if (!isset($ipaddr)) {
 			if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) &&
+				Config::getVar('general', 'trust_x_forwarded_for', true) &&
 				preg_match_all('/([0-9.a-fA-F:]+)/', $_SERVER['HTTP_X_FORWARDED_FOR'], $matches)) {
 			} else if (isset($_SERVER['REMOTE_ADDR']) &&
 				preg_match_all('/([0-9.a-fA-F:]+)/', $_SERVER['REMOTE_ADDR'], $matches)) {


### PR DESCRIPTION
Use a trusted X_FORWARDED_FOR if you are behind a reverse proxy and control the header; Use untrusted otherwise.
