### PR TITLE
*8893* call parent getLocaleFieldNames from SubmissionDAO

### DIFF
--- a/classes/submission/SubmissionDAO.inc.php
+++ b/classes/submission/SubmissionDAO.inc.php
@@ -57,7 +57,7 @@ class SubmissionDAO extends DAO {
 	 * @return array
 	 */
 	function getLocaleFieldNames() {
-		return array(
+		return parent::getLocaleFieldNames() + array(
 			'title', 'cleanTitle', 'abstract', 'prefix', 'subtitle',
 			'discipline', 'subjectClass', 'subject',
 			'coverageGeo', 'coverageChron', 'coverageSample',


### PR DESCRIPTION
I am loathe to make too many changes to this pattern right before release, but putting this specific fix into OJS 2.4 will fix James' plugin.
