### PR TITLE
*8843* Fix localhost and non-standard port domain use

### DIFF
--- a/classes/core/PKPRequest.inc.php
+++ b/classes/core/PKPRequest.inc.php
@@ -314,11 +314,14 @@ class PKPRequest {
 	}
 
 	/**
-	 * Get the server hostname in the request. May optionally include the
-	 * port number if non-standard.
+	 * Get the server hostname in the request.
+	 * @param $default string Default hostname (defaults to localhost)
+	 * @param $includePort boolean Whether to include non-standard port number; default true
 	 * @return string
 	 */
-	function getServerHost($default = 'localhost') {
+	function getServerHost($default = null, $includePort = true) {
+		if ($default === null) $default = 'localhost';
+
 		$_this =& PKPRequest::_checkThis();
 
 		if (!isset($_this->_serverHost)) {
@@ -326,7 +329,11 @@ class PKPRequest {
 				: (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST']
 				: (isset($_SERVER['HOSTNAME']) ? $_SERVER['HOSTNAME']
 				: $default));
-			HookRegistry::call('Request::getServerHost', array(&$_this->_serverHost));
+			HookRegistry::call('Request::getServerHost', array(&$_this->_serverHost, &$default, &$includePort));
+		}
+		if (!$includePort) {
+			// Strip the port number, if one is included. (#3912)
+			return preg_replace("/:\d*$/", '', $_this->_serverHost);
 		}
 		return $_this->_serverHost;
 	}

--- a/classes/mail/SMTPMailer.inc.php
+++ b/classes/mail/SMTPMailer.inc.php
@@ -70,7 +70,7 @@ class SMTPMailer {
 			return $this->disconnect('Did not receive expected 220');
 
 		// Send HELO/EHLO command
-		$serverHost = preg_replace("/:\d*$/", '', Request::getServerHost());
+		$serverHost = Request::getServerHost(null, false);
 		if (!$this->send($this->auth ? 'EHLO' : 'HELO', $serverHost))
 			return $this->disconnect('Could not send HELO/HELO');
 


### PR DESCRIPTION
Two problems with the previous pull request #169:
- Using non-standard ports, the port number would come in with the domain and cause all logins to fail.
- With Chrome (and possibly others), a domain of 'localhost' is rejected by the browser (see http://stackoverflow.com/questions/1134290/cookies-on-localhost-with-explicit-domain)
