### PR TITLE
*8919* Add window target options to RedirectRequest

### DIFF
--- a/classes/linkAction/request/RedirectAction.inc.php
+++ b/classes/linkAction/request/RedirectAction.inc.php
@@ -19,13 +19,23 @@ class RedirectAction extends LinkActionRequest {
 	/** @var string The URL this action will invoke */
 	var $_url;
 
+	/** @var string The name of the window */
+	var $_name;
+
+	/** @var string The specifications of the window */
+	var $_specs;
+
 	/**
 	 * Constructor
 	 * @param $url string Target URL
+	 * @param $name string Name of window to direct (defaults to current window)
+	 * @param $specs string Optional set of window specs (see window.open JS reference)
 	 */
-	function RedirectAction($url) {
+	function RedirectAction($url, $name = '_self', $specs = '') {
 		parent::LinkActionRequest();
 		$this->_url = $url;
+		$this->_name = $name;
+		$this->_specs = $specs;
 	}
 
 
@@ -38,6 +48,24 @@ class RedirectAction extends LinkActionRequest {
 	 */
 	function getUrl() {
 		return $this->_url;
+	}
+
+	/**
+	 * Get the target name.
+	 * See JS reference for the name parameter to "window.open".
+	 * @return string
+	 */
+	function getName() {
+		return $this->_name;
+	}
+
+	/**
+	 * Get the target specifications.
+	 * See JS reference for the specs parameter to "window.open".
+	 * @return string
+	 */
+	function getSpecs() {
+		return $this->_specs;
 	}
 
 
@@ -55,7 +83,11 @@ class RedirectAction extends LinkActionRequest {
 	 * @see LinkActionRequest::getLocalizedOptions()
 	 */
 	function getLocalizedOptions() {
-		return array('url' => $this->getUrl());
+		return array(
+			'url' => $this->getUrl(),
+			'name' => $this->getName(),
+			'specs' => $this->getSpecs()
+		);
 	}
 }
 

--- a/js/classes/linkAction/RedirectRequest.js
+++ b/js/classes/linkAction/RedirectRequest.js
@@ -43,7 +43,7 @@
 			function(element, event) {
 
 		var options = this.getOptions();
-		window.location = options.url;
+		window.open(options.url, options.name, options.specs);
 
 		return /** @type {boolean} */ this.parent('activate', element, event);
 	};


### PR DESCRIPTION
Use window.open instead of window.location to redirect users. This permits the optional specification of a new/different window.
