### PR TITLE
Consider Windows special chars when creating cache file names.

### DIFF
--- a/classes/cache/FileCache.inc.php
+++ b/classes/cache/FileCache.inc.php
@@ -37,7 +37,11 @@ class FileCache extends GenericCache {
 	function FileCache($context, $cacheId, $fallback, $path) {
 		parent::GenericCache($context, $cacheId, $fallback);
 
-		$this->filename = $path . DIRECTORY_SEPARATOR . "fc-$context-" . str_replace('/', '.', $cacheId) . '.php';
+		$replaceSymbols = array('/', '\\', ':');
+		$this->filename = $path . DIRECTORY_SEPARATOR;
+		$this->filename .= "fc-$context-";
+		$this->filename .= str_replace($replaceSymbols, '.', $cacheId);
+		$this->filename .= '.php';
 
 		// Load the cache data if it exists.
 		if (file_exists($this->filename)) {


### PR DESCRIPTION
Add forbidden chars in Windows file names (_\_, _:_) when building file names from full paths in `FileCache.inc.php`

It solves problems like http://pkp.sfu.ca/support/forum/viewtopic.php?f=1&t=11859
