### PR TITLE
Enable minimum and maximum scoping definitions for Date validation; add Form validator for dates.

### DIFF
--- a/classes/form/Form.inc.php
+++ b/classes/form/Form.inc.php
@@ -28,6 +28,7 @@ import('lib.pkp.classes.form.validation.FormValidatorControlledVocab');
 import('lib.pkp.classes.form.validation.FormValidatorCustom');
 import('lib.pkp.classes.form.validation.FormValidatorCaptcha');
 import('lib.pkp.classes.form.validation.FormValidatorReCaptcha');
+import('lib.pkp.classes.form.validation.FormValidatorDate');
 import('lib.pkp.classes.form.validation.FormValidatorEmail');
 import('lib.pkp.classes.form.validation.FormValidatorInSet');
 import('lib.pkp.classes.form.validation.FormValidatorLength');

--- a/classes/form/validation/FormValidatorDate.inc.php
+++ b/classes/form/validation/FormValidatorDate.inc.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file classes/form/validation/FormValidatorDate.inc.php
+ *
+ * Copyright (c) 2013-2014 Simon Fraser University Library
+ * Copyright (c) 2000-2014 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class FormValidatorDate
+ * @ingroup form_validation
+ *
+ * @brief Form validation check that field is a date or date part.
+ */
+
+import('lib.pkp.classes.form.validation.FormValidator');
+import('lib.pkp.classes.validation.ValidatorDate');
+
+class FormValidatorDate extends FormValidator {
+
+	/** 
+	 * @var int Date minimum resolution required
+	 */
+	var $_scopeMin;
+
+	/** 
+	 * @var int Date maximum resolution allowed
+	 */
+	var $_scopeMax;
+	
+	/**
+	 * Constructor.
+	 * @param $form Form the associated form
+	 * @param $field string the name of the associated field
+	 * @param $type string the type of check, either "required" or "optional"
+	 * @param $message string the error message for validation failures (i18n key)
+	 * @param $dateFormat int the ValidatorDate date format to allow
+	 * @param $dateScope string the minimum resolution of a date to allow
+	 * @param $dateScope string the maximum resolution of a date to allow
+	 */
+	function FormValidatorDate(&$form, $field, $type, $message, $dateFormat = DATE_FORMAT_ISO, $dateScopeMin = VALIDATOR_DATE_SCOPE_YEAR, $dateScopeMax = VALIDATOR_DATE_SCOPE_DAY) {
+		$validator = new ValidatorDate($dateFormat);
+		$this->_scopeMin = $dateScopeMin;
+		$this->_scopeMax = $dateScopeMax;
+		parent::FormValidator($form, $field, $type, $message, $validator);
+	}
+
+	//
+	// Implement abstract methods from Validator
+	//
+	/**
+	 * @see Validator::isValid()
+	 * @param $value mixed
+	 * @return boolean
+	 */
+	function isValid() {
+		// check if generally formatted as a date and if required
+		if (!parent::isValid()) return false;
+		// if parent::isValid is true and $value is empty, this value is optional
+		$fieldValue = $this->getFieldValue();
+		if (!$fieldValue) return true;
+
+		$validator = parent::getValidator();
+		return $validator->isValid($fieldValue, $this->_scopeMin, $this->_scopeMax);
+	}
+}
+
+?>

--- a/classes/validation/ValidatorDate.inc.php
+++ b/classes/validation/ValidatorDate.inc.php
@@ -17,6 +17,9 @@
 import('lib.pkp.classes.validation.ValidatorRegExp');
 
 define('DATE_FORMAT_ISO', 0x01);
+define('VALIDATOR_DATE_SCOPE_DAY', 1);
+define('VALIDATOR_DATE_SCOPE_MONTH', 2);
+define('VALIDATOR_DATE_SCOPE_YEAR', 4);
 
 class ValidatorDate extends ValidatorRegExp {
 	/**
@@ -33,24 +36,28 @@ class ValidatorDate extends ValidatorRegExp {
 	/**
 	 * @see Validator::isValid()
 	 * @param $value mixed
+	 * @param $minScope int The minimum date resolution allowed, e.g. VALIDATOR_DATE_SCOPE_MONTH will allow YYYY-MM or YYYY-MM-DD, but not YYYY
+	 * @param $maxScope int The maximum date resolution allowed, e.g. VALIDATOR_DATE_SCOPE_MONTH will allow YYYY or YYYY-MM, but not YYYY-MM-DD
 	 * @return boolean
 	 */
-	function isValid($value) {
+	function isValid($value, $minScope = VALIDATOR_DATE_SCOPE_YEAR, $maxScope = VALIDATOR_DATE_SCOPE_DAY) {
 		if (!parent::isValid($value)) return false;
+		
+		if ($minScope < $maxScope) return false;
 
 		$dateMatches = $this->getMatches();
 		if (isset($dateMatches['month'])) {
-			if ($dateMatches['month'] >= 1 && $dateMatches['month'] <= 12) {
+			if (($dateMatches['month'] >= 1 && $dateMatches['month'] <= 12) || $maxScope == VALIDATOR_DATE_SCOPE_YEAR ) {
 				if (isset($dateMatches['day'])) {
-					return checkdate($dateMatches['month'], $dateMatches['day'], $dateMatches['year']);
+					return (checkdate($dateMatches['month'], $dateMatches['day'], $dateMatches['year']) && $maxScope == VALIDATOR_DATE_SCOPE_DAY);
 				} else {
-					return true;
+					return $maxScope < VALIDATOR_DATE_SCOPE_YEAR && $minScope > VALIDATOR_DATE_SCOPE_DAY;
 				}
 			} else {
 				return false;
 			}
 		} else {
-			return true;
+			return ($minScope == VALIDATOR_DATE_SCOPE_YEAR);
 		}
 	}
 

--- a/tests/classes/validation/ValidatorDateTest.php
+++ b/tests/classes/validation/ValidatorDateTest.php
@@ -27,6 +27,13 @@ class ValidatorDateTest extends PKPTestCase {
 		self::assertTrue($validator->isValid('2010-05-14'));
 		self::assertTrue($validator->isValid('2010-05'));
 		self::assertTrue($validator->isValid('2010'));
+		self::assertFalse($validator->isValid('2010-05-14', VALIDATOR_DATE_SCOPE_YEAR, VALIDATOR_DATE_SCOPE_MONTH)); // Must not resolve to a day
+		self::assertTrue($validator->isValid('2010-05', VALIDATOR_DATE_SCOPE_YEAR, VALIDATOR_DATE_SCOPE_MONTH)); // Must not resolve to a day
+		self::assertFalse($validator->isValid('2010', VALIDATOR_DATE_SCOPE_MONTH, VALIDATOR_DATE_SCOPE_DAY)); // Must resolve to a month or a day
+		self::assertTrue($validator->isValid('2010-05', VALIDATOR_DATE_SCOPE_MONTH, VALIDATOR_DATE_SCOPE_DAY)); // Must resolve to a month or a day
+		self::assertFalse($validator->isValid('2010-05', VALIDATOR_DATE_SCOPE_DAY, VALIDATOR_DATE_SCOPE_DAY)); // Must resolve to a day
+		self::assertTrue($validator->isValid('2010-05-14', VALIDATOR_DATE_SCOPE_DAY, VALIDATOR_DATE_SCOPE_DAY)); // Must resolve to a day
+		self::assertFalse($validator->isValid('2010-05-14', VALIDATOR_DATE_SCOPE_DAY, VALIDATOR_DATE_SCOPE_YEAR)); // Failed parameters: must be at least a day, but not greater than a year
 		self::assertFalse($validator->isValid(''));
 		self::assertFalse($validator->isValid('2010-00'));
 		self::assertFalse($validator->isValid('2010-13'));


### PR DESCRIPTION
I have an application (SUSHI-Lite) which needs to validate the scope of dates provided to it.  For example, BeginDate could be YYYY-MM-DD, or YYYY-MM, or YYYY.  PubYr must be YYYY.

This enhancement allows the minimum and maximum scope of a date to be provided to the validator to enforce these rules.

For backwards compatibility the minimum scope defaults to a year, and the maximum scope defaults to a day.

A new form validator for date entry is provided.
