### PR TITLE
Monitor memory usage with each file processed by FileLoader::executeActions()

### DIFF
--- a/locale/en_US/admin.xml
+++ b/locale/en_US/admin.xml
@@ -97,5 +97,6 @@
 	<message key="admin.fileLoader.pathNotAccessible">Folder {$path} is not a directory or is not readable.</message>
 	<message key="admin.fileLoader.moveFileFailed">File {$filename} could not be moved from {$currentFilePath} to {$destinationPath}</message>
 	<message key="admin.fileLoader.fileProcessed">File {$filename} was processed and archived.</message>
+	<message key="admin.fileLoader.memoryToleranceExceeded">The loader process consumed memory too close to PHP's memory limit and was terminated early.</message>
 	<message key="admin.fileLoader">File loader</message>
 </locale>


### PR DESCRIPTION
Abort early if usage might exceed the PHP memory limit.  Resolves pkp/pkp-lib#245.