### PR TITLE
pkp/pkp-lib#276: Defer processing of REQUEST_URI and QUERY_STRING in a protocol redirect until the target page.

### DIFF
--- a/classes/core/PKPRequest.inc.php
+++ b/classes/core/PKPRequest.inc.php
@@ -105,8 +105,10 @@ class PKPRequest {
 	function redirectSSL() {
 		$_this =& PKPRequest::_checkThis();
 
-		$url = 'https://' . $_this->getServerHost() . $_this->getRequestPath();
-		$queryString = $_this->getQueryString();
+		// Note that we are intentionally skipping PKP processing of REQUEST_URI and QUERY_STRING for a protocol redirect
+		// This processing is deferred to the redirected (target) URI
+		$url = 'https://' . $_this->getServerHost() . $_SERVER['REQUEST_URI];
+		$queryString = $_SERVER['QUERY_STRING'];
 		if (!empty($queryString)) $url .= "?$queryString";
 		$_this->redirectUrl($url);
 	}
@@ -117,8 +119,10 @@ class PKPRequest {
 	function redirectNonSSL() {
 		$_this =& PKPRequest::_checkThis();
 
-		$url = 'http://' . $_this->getServerHost() . $_this->getRequestPath();
-		$queryString = $_this->getQueryString();
+		// Note that we are intentionally skipping PKP processing of REQUEST_URI and QUERY_STRING for a protocol redirect
+		// This processing is deferred to the redirected (target) URI
+		$url = 'http://' . $_this->getServerHost() . $_SERVER['REQUEST_URI];
+		$queryString = $_SERVER['QUERY_STRING'];
 		if (!empty($queryString)) $url .= "?$queryString";
 		$_this->redirectUrl($url);
 	}


### PR DESCRIPTION
A protocol redirect should simply pass the request unmodified from HTTP to HTTPS (or vice-versa).  Processing the request path and query string (and appropriate hook calls) can happen at the target page.