### PR TITLE
Add a UUID generator (version 4) to the String library.

### DIFF
--- a/classes/core/String.inc.php
+++ b/classes/core/String.inc.php
@@ -1122,8 +1122,8 @@ class String {
 		$hyphen = '-';
 		$uuid = substr($charid, 0, 8).$hyphen
 				.substr($charid, 8, 4).$hyphen
-				.'4'.substr($charid,13, 4).$hyphen
-				.strtoupper(dechex(hexdec(ord(substr($charid,16,1))) % 4 + 8)).substr($charid,17, 4).$hyphen
+				.'4'.substr($charid,13, 3).$hyphen
+				.strtoupper(dechex(hexdec(ord(substr($charid,16,1))) % 4 + 8)).substr($charid,17, 3).$hyphen
 				.substr($charid,20,12);
 		return $uuid;
 	}

--- a/classes/core/String.inc.php
+++ b/classes/core/String.inc.php
@@ -1111,6 +1111,22 @@ class String {
 	function enumerateAlphabetically($steps) {
 		return chr(ord('A') + $steps);
 	}
+
+	/**
+	 * Create a new UUID (version 4)
+	 * @return string
+	 */
+	function generateUUID() {
+		mt_srand((double)microtime()*10000);
+		$charid = strtoupper(md5(uniqid(rand(), true)));
+		$hyphen = '-';
+		$uuid = substr($charid, 0, 8).$hyphen
+				.substr($charid, 8, 4).$hyphen
+				.'4'.substr($charid,13, 4).$hyphen
+				.strtoupper(dechex(hexdec(ord(substr($charid,16,1))) % 4 + 8)).substr($charid,17, 4).$hyphen
+				.substr($charid,20,12);
+		return $uuid;
+	}
 }
 
 ?>


### PR DESCRIPTION
Moving this function from the OJS 2.4 PLN plugin; also correcting to create valid version 4 UUIDs.