### PR TITLE
Fixed wrong translation for Afghanistan in pt-BR

### DIFF
--- a/locale/pt_BR/countries.xml
+++ b/locale/pt_BR/countries.xml
@@ -11,7 +11,7 @@
   *
   -->
 <countries>
-	<country name="Afganistão" code="AF"/>
+	<country name="Afeganistão" code="AF"/>
 	<country name="Åland, Ilhas" code="AX"/>
 	<country name="Albania" code="AL"/>
 	<country name="Argélia" code="DZ"/>


### PR DESCRIPTION
Original: Afganistão
Correct way: Afeganistão