### PR TITLE
pkp/pkp-lib#437 : strict in_array() breaks legacy subscription functionality ...

### DIFF
--- a/classes/validation/ValidatorInSet.inc.php
+++ b/classes/validation/ValidatorInSet.inc.php
@@ -42,7 +42,7 @@ class ValidatorInSet extends Validator {
 		if (!is_array($this->_acceptedValues)) {
 			return false;
 		}
-		return in_array($value, $this->_acceptedValues, true);
+		return in_array($value, $this->_acceptedValues);
 	}
 
 }

--- a/tests/classes/validation/ValidatorInSetTest.php
+++ b/tests/classes/validation/ValidatorInSetTest.php
@@ -23,12 +23,15 @@ class ValidatorInSetTest extends PKPTestCase {
 	 * @covers Validator
 	 */
 	public function testValidatorInSet() {
-		$validator = new ValidatorInSet(array(0, 1, 'a', 'B'));
-		self::assertTrue($validator->isValid(0)); // Valid for logically false variable
-		self::assertTrue($validator->isValid(1)); // Valid
-		self::assertFalse($validator->isValid('b')); // Loose in_array() checking
+		$validator = new ValidatorInSet(array(1, 2, 'a', 'B'));
+		self::assertTrue($validator->isValid(0)); // Warning: depends on loose in_array(), so a value of 0 will match any string
+		self::assertTrue($validator->isValid(1)); // Value in set
+		self::assertFalse($validator->isValid('b')); // Value not in set
+		self::assertTrue($validator->isValid('1')); // Loose in_array() checking matches strings to numerics
 		$validator = new ValidatorInSet(array());
 		self::assertFalse($validator->isValid(1)); // Any value in empty set
+		$validator = new ValidatorInSet(array(0, 'anything')); // Warning: depends on loose in_array(), so a value of 0 will match any string
+		self::assertTrue($validator->isValid('something')); // Any string value
 	}
 }
 


### PR DESCRIPTION
... which depends on equalities of int($v) = "$v". Revert to loose in_array() checking.

Not keen on it, but here it is.