### PR TITLE
Remove spurious duplicates of the grid.action.restoreDefaults key

### DIFF
--- a/locale/ar_IQ/grid.xml
+++ b/locale/ar_IQ/grid.xml
@@ -57,7 +57,6 @@
 	<message key="grid.action.sendToProduction">أرسل طلب النشر هذا لمرحلة الإنتاج</message>
 	<message key="grid.action.settings">الإعدادات</message>
 	<message key="grid.action.importexport">استيراد أو تصدير محتوى أو بيانات الموقع</message>
-	<message key="grid.action.restoreDefaults">استعادة الإفتراضات</message>
 	<message key="grid.action.orderItems">تمكين نمط الفرز</message>
 	<message key="grid.action.editSubmissionChecklist">تعديل فقرة التأشير هذه</message>
 	<message key="grid.action.deleteSubmissionChecklist">حذف فقرة التأشير هذه</message>

--- a/locale/ca_ES/grid.xml
+++ b/locale/ca_ES/grid.xml
@@ -57,7 +57,6 @@
 	<message key="grid.action.sendToProduction">Envia aquesta tramesa a producció</message>
 	<message key="grid.action.settings">Configuració</message>
 	<message key="grid.action.importexport">Importa o exporta continguts o dades del lloc web</message>
-	<message key="grid.action.restoreDefaults">Restaura els valors per defecte</message>
 	<message key="grid.action.orderItems">Habilita el mode d'ordenació</message>
 	<message key="grid.action.editSubmissionChecklist">Edita aquest element de la llista de verificació</message>
 	<message key="grid.action.deleteSubmissionChecklist">Elimina aquest element de la llista de verificació</message>

--- a/locale/en_US/grid.xml
+++ b/locale/en_US/grid.xml
@@ -57,7 +57,6 @@
 	<message key="grid.action.sendToProduction">Send this submission to production</message>
 	<message key="grid.action.settings">Settings</message>
 	<message key="grid.action.importexport">Import or export content or site data</message>
-	<message key="grid.action.restoreDefaults">Restore defaults</message>
 	<message key="grid.action.orderItems">Enable ordering mode</message>
 	<message key="grid.action.editSubmissionChecklist">Edit this checklist item</message>
 	<message key="grid.action.deleteSubmissionChecklist">Delete this checklist item</message>

--- a/locale/es_AR/grid.xml
+++ b/locale/es_AR/grid.xml
@@ -57,7 +57,6 @@
 	<message key="grid.action.sendToProduction">Enviar esta publicación a producción</message>
 	<message key="grid.action.settings">Configuracion</message>
 	<message key="grid.action.importexport">Exportar o Importar contenido o datos del sitio</message>
-	<message key="grid.action.restoreDefaults">Restore defaults</message>
 	<message key="grid.action.orderItems">Habilitar el modo de orden</message>
 	<message key="grid.action.editSubmissionChecklist">Editar los item de la lista de aspectos a chequear</message>
 	<message key="grid.action.deleteSubmissionChecklist">Eliminar este elemento de la lista</message>

--- a/locale/es_ES/grid.xml
+++ b/locale/es_ES/grid.xml
@@ -58,7 +58,6 @@
 	<message key="grid.action.sendToProduction">Enviar el envío para producción</message>
 	<message key="grid.action.settings">Configuración</message>
 	<message key="grid.action.importexport">Importar o exportar contenido o datos del sitio</message>
-	<message key="grid.action.restoreDefaults">Restaurar valores predeterminados</message>
 	<message key="grid.action.orderItems">Habilitar modo pedido</message>
 	<message key="grid.action.editSubmissionChecklist">Editar elemento de la lista de comprobación</message>
 	<message key="grid.action.deleteSubmissionChecklist">Eliminar elemento de la lista de comprobación</message>

--- a/locale/ru_RU/grid.xml
+++ b/locale/ru_RU/grid.xml
@@ -57,7 +57,6 @@
 	<message key="grid.action.sendToProduction">Отправить этот материал в работу</message>
 	<message key="grid.action.settings">Настройки</message>
 	<message key="grid.action.importexport">Импорт/экспорт контента или данных сайта</message>
-	<message key="grid.action.restoreDefaults">Восстановить настройки по умолчанию</message>
 	<message key="grid.action.orderItems">Включить режим упорядочивания</message>
 	<message key="grid.action.editSubmissionChecklist">Редактировать этот элемент контрольного списка</message>
 	<message key="grid.action.deleteSubmissionChecklist">Удалить этот элемент контрольного списка</message>

--- a/locale/vi_VN/grid.xml
+++ b/locale/vi_VN/grid.xml
@@ -58,7 +58,6 @@
 	<message key="grid.action.sendToProduction">Gửi bài nộp này đi chế bản</message>
 	<message key="grid.action.settings">Thiết lập</message>
 	<message key="grid.action.importexport">Nhập hoặc xuất nội dung hoặc dữ liệu website</message>
-	<message key="grid.action.restoreDefaults">Restore defaults</message>
 	<message key="grid.action.orderItems">Kích hoạt chế độ sắp thứ tự</message>
 	<message key="grid.action.editSubmissionChecklist">Sửa mục này trong danh sách kiểm</message>
 	<message key="grid.action.deleteSubmissionChecklist">Xóa học này trong danh sách kiểm</message>


### PR DESCRIPTION
These keys either duplicate the existing value, or provide an English value in a non-English locale.

The **de_DE also contains a duplicate key**, but the values are non-unique:
https://github.com/pkp/pkp-lib/blob/ojs-dev-2_4/locale/de_DE/grid.xml#L31
vs.
https://github.com/pkp/pkp-lib/blob/ojs-dev-2_4/locale/de_DE/grid.xml#L60
