### PR TITLE
pkp/pkp-lib#656 Restore .gridPagingScrolling to infinite scroll grids

### DIFF
--- a/js/classes/features/InfiniteScrollingFeature.js
+++ b/js/classes/features/InfiniteScrollingFeature.js
@@ -47,8 +47,8 @@
 			function($gridElement, options) {
 		var castOptions = /** @type {{pagingMarkup: string?,
 					loadingContainer: string?}} */ (options);
-		$gridElement.find('div.grid_header_bar h3').after(castOptions.pagingMarkup);
-		$gridElement.find('div.scrollable').append(castOptions.loadingContainer);
+		$gridElement.find('div.scrollable').append(castOptions.loadingContainer)
+			.after(castOptions.pagingMarkup);
 	};
 
 

--- a/styles/controllers/grid/grid.less
+++ b/styles/controllers/grid/grid.less
@@ -333,6 +333,14 @@
 			}
 		}
 	}
+
+	// Items shown for infinite scrolling
+	.gridPagingScrolling {
+		font-size: @font-sml;
+		color: @text-light;
+		color: @text-light-rgba;
+		text-align: right;
+	}
 }
 
 // Categorized grids
@@ -477,14 +485,6 @@
 
 	tbody.ui-sortable-helper {
 		display:table;
-	}
-
-	span.gridPagingScrolling {
-		font-size: 85%;
-		margin-left: 10px;
-		color: #888;
-		position: relative;
-		top: 3px;
 	}
 }
 

--- a/templates/controllers/grid/feature/infiniteScrolling.tpl
+++ b/templates/controllers/grid/feature/infiniteScrolling.tpl
@@ -8,6 +8,6 @@
  * Grid infinite scrolling markup.
  *}
 
-<span class="gridPagingScrolling">
+<div class="gridPagingScrolling">
 		{translate key="navigation.items.shownTotal" shown=$shown total=$iterator->getCount()}
-</span>
+</div>


### PR DESCRIPTION
This only restores the paging information to address the test blocker. Infinite scrolling is still broken (never loads).