### PR TITLE
Use app-specific template for the frontend primary navigation menu

### DIFF
--- a/templates/common/frontend/header.tpl
+++ b/templates/common/frontend/header.tpl
@@ -80,50 +80,9 @@
 			</script>
 			<nav class="pkp_navigation_primary_row">
 				<div class="pkp_navigation_primary_wrapper">
-					<ul id="navigationPrimary" class="pkp_navigation_primary pkp_nav_list">
 
-						{if $enableAnnouncements}
-							<li>
-								<a href="{url router=$smarty.const.ROUTE_PAGE page="announcement"}">
-									{translate key="announcement.announcements"}
-								</a>
-							</li>
-						{/if}
-
-						{if $currentJournal}
-
-							{if $currentJournal->getSetting('publishingMode') != $smarty.const.PUBLISHING_MODE_NONE}
-								<li>
-									<a href="{url router=$smarty.const.ROUTE_PAGE page="issue" op="current"}">
-										{translate key="navigation.current"}
-									</a>
-								</li>
-								<li>
-									<a href="{url router=$smarty.const.ROUTE_PAGE page="issue" op="archive"}">
-										{translate key="navigation.archives"}
-									</a>
-								</li>
-							{/if}
-
-							<li class="has-submenu">
-								<a href="{url router=$smarty.const.ROUTE_PAGE page="about"}">
-									{translate key="navigation.about"}
-								</a>
-								<ul>
-									<li>
-										<a href="{url router=$smarty.const.ROUTE_PAGE page="about" op="editorialTeam"}">
-											{translate key="about.editorialTeam"}
-										</a>
-									</li>
-									<li>
-										<a href="{url router=$smarty.const.ROUTE_PAGE page="about" op="submissions"}">
-											{translate key="about.submissions"}
-										</a>
-									</li>
-								</ul>
-							</li>
-						{/if}
-					</ul>
+					{* Primary navigation menu for current application *}
+					{include file="header/primaryNavMenu.tpl"}
 
 					{* Search form *}
 					{if !$noContextsConfigured}


### PR DESCRIPTION
Extracting the primary nav menu into a template to be housed under OMP/OJS, so that each app can have a primary nav menu that is specific to it.