### PR TITLE
Install plugins from xz compressed tarball

### DIFF
--- a/classes/plugins/PluginHelper.inc.php
+++ b/classes/plugins/PluginHelper.inc.php
@@ -45,7 +45,7 @@ class PluginHelper {
 		// equal plugin directory name and plugin files must be in a
 		// directory named after the plug-in (potentially with version)
 		$matches = array();
-		String::regexp_match_get('/^[a-zA-Z0-9]+/', basename($originalFileName, '.tar.gz'), $matches);
+		String::regexp_match_get('/^[a-zA-Z0-9]+/', basename($originalFileName, '.tar.xz'), $matches);
 		$pluginShortName = array_pop($matches);
 		if (!$pluginShortName) {
 			$errorMsg = __('manager.plugins.invalidPluginArchive');
@@ -59,7 +59,7 @@ class PluginHelper {
 		// Test whether the tar binary is available for the export to work
 		$tarBinary = Config::getVar('cli', 'tar');
 		if (!empty($tarBinary) && file_exists($tarBinary)) {
-			exec($tarBinary.' -xzf ' . escapeshellarg($filePath) . ' -C ' . escapeshellarg($pluginExtractDir));
+			exec($tarBinary.' -xJf ' . escapeshellarg($filePath) . ' -C ' . escapeshellarg($pluginExtractDir));
 		} else {
 			$errorMsg = __('manager.plugins.tarCommandNotFound');
 		}
@@ -74,7 +74,7 @@ class PluginHelper {
 			// Failing that, look for a directory named after the
 			// archive. (Typically also contains the version number
 			// e.g. with github generated release archives.)
-			String::regexp_match_get('/^[a-zA-Z0-9.-]+/', basename($originalFileName, '.tar.gz'), $matches);
+			String::regexp_match_get('/^[a-zA-Z0-9.-]+/', basename($originalFileName, '.tar.xz'), $matches);
 			if (is_dir($tryDir = $pluginExtractDir . '/' . array_pop($matches))) {
 				// We found a directory named after the archive
 				// within the extracted archive. (Typically also


### PR DESCRIPTION
This PR makes OJS 3 accept plugins installations from a xz compressed tarball.

The .xz format has a better compression ratio than bz, reducing network traffic during the upload of the plugins.