### PR TITLE
Add support for xz compressed plugins

### DIFF
--- a/classes/plugins/PluginHelper.inc.php
+++ b/classes/plugins/PluginHelper.inc.php
@@ -45,7 +45,13 @@ class PluginHelper {
 		// equal plugin directory name and plugin files must be in a
 		// directory named after the plug-in (potentially with version)
 		$matches = array();
-		String::regexp_match_get('/^[a-zA-Z0-9]+/', basename($originalFileName, '.tar.gz'), $matches);
+		$path_parts = pathinfo($originalFileName);
+		switch($path_parts['extension']) {
+		  case "gz":
+		  String::regexp_match_get('/^[a-zA-Z0-9]+/', basename($originalFileName, '.tar.gz'), $matches);
+		  case "xz":
+		  String::regexp_match_get('/^[a-zA-Z0-9]+/', basename($originalFileName, '.tar.xz'), $matches);
+		}
 		$pluginShortName = array_pop($matches);
 		if (!$pluginShortName) {
 			$errorMsg = __('manager.plugins.invalidPluginArchive');
@@ -59,7 +65,7 @@ class PluginHelper {
 		// Test whether the tar binary is available for the export to work
 		$tarBinary = Config::getVar('cli', 'tar');
 		if (!empty($tarBinary) && file_exists($tarBinary)) {
-			exec($tarBinary.' -xzf ' . escapeshellarg($filePath) . ' -C ' . escapeshellarg($pluginExtractDir));
+			exec($tarBinary.' -xf ' . escapeshellarg($filePath) . ' -C ' . escapeshellarg($pluginExtractDir));
 		} else {
 			$errorMsg = __('manager.plugins.tarCommandNotFound');
 		}
@@ -74,7 +80,12 @@ class PluginHelper {
 			// Failing that, look for a directory named after the
 			// archive. (Typically also contains the version number
 			// e.g. with github generated release archives.)
-			String::regexp_match_get('/^[a-zA-Z0-9.-]+/', basename($originalFileName, '.tar.gz'), $matches);
+			switch($path_parts['extension']) {
+			  case "gz":
+			  String::regexp_match_get('/^[a-zA-Z0-9.-]+/', basename($originalFileName, '.tar.gz'), $matches);
+			  case "xz":
+			  String::regexp_match_get('/^[a-zA-Z0-9.-]+/', basename($originalFileName, '.tar.xz'), $matches);
+			}
 			if (is_dir($tryDir = $pluginExtractDir . '/' . array_pop($matches))) {
 				// We found a directory named after the archive
 				// within the extracted archive. (Typically also

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -336,8 +336,7 @@
 	<message key="manager.plugins.doesNotExist">Plugin "{$pluginName}" does not exist</message>
 	<message key="manager.plugins.fileSelectError">Please select a file first</message>
 	<message key="manager.plugins.upload">Upload A New Plugin</message>
-	<message key="manager.plugins.uploadDescription">This form allows you to upload and install a new plugin.  Please ensure the plugin is 
-compressed either as a .tar.gz or a .tar.xz file.</message>
+	<message key="manager.plugins.uploadDescription">This form allows you to upload and install a new plugin.  Please ensure the plugin is compressed either as a .tar.gz or a .tar.xz file.</message>
 	<message key="manager.plugins.uploadFailed">Please ensure a file was selected for upload.</message>
 	<message key="manager.plugins.installed">Installed Plugins</message>
 	<message key="manager.plugins.pluginGallery">Plugin Gallery</message>

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -336,7 +336,8 @@
 	<message key="manager.plugins.doesNotExist">Plugin "{$pluginName}" does not exist</message>
 	<message key="manager.plugins.fileSelectError">Please select a file first</message>
 	<message key="manager.plugins.upload">Upload A New Plugin</message>
-	<message key="manager.plugins.uploadDescription">This form allows you to upload and install a new plugin.  Please ensure the plugin is compressed as a .tar.gz file.</message>
+	<message key="manager.plugins.uploadDescription">This form allows you to upload and install a new plugin.  Please ensure the plugin is 
+compressed either as a .tar.gz or a .tar.xz file.</message>
 	<message key="manager.plugins.uploadFailed">Please ensure a file was selected for upload.</message>
 	<message key="manager.plugins.installed">Installed Plugins</message>
 	<message key="manager.plugins.pluginGallery">Plugin Gallery</message>

--- a/locale/pt_BR/manager.xml
+++ b/locale/pt_BR/manager.xml
@@ -335,8 +335,7 @@ Há casos em que uma única estatística de uso devem ser utilizada, por exemplo
 	<message key="manager.plugins.settings">Configurações</message>
 	<message key="manager.plugins.tarCommandNotFound">O comando tar não está disponível. Por favor, configure-o corretamente em seu "config.inc.php".</message>
 	<message key="manager.plugins.upgrade">Atualizar plugin</message>
-	<message key="manager.plugins.upgradeDescription">Este formulário permite a você atualizar um plugin. Certifique-se o plugin está 
-compactado como um arquivo tar.gz ou tar.xz.</message>
+	<message key="manager.plugins.upgradeDescription">Este formulário permite a você atualizar um plugin. Certifique-se o plugin está compactado como um arquivo tar.gz ou tar.xz.</message>
 	<message key="manager.plugins.upgradeFailed">Falha na atualização. {$errorString}</message>
 	<message key="manager.plugins.upgradeSuccessful">Atualizado com êxito para a versão {$versionString}</message>
 	<message key="manager.plugins.uploadError">Erro enviando arquivo</message>

--- a/locale/pt_BR/manager.xml
+++ b/locale/pt_BR/manager.xml
@@ -335,7 +335,8 @@ Há casos em que uma única estatística de uso devem ser utilizada, por exemplo
 	<message key="manager.plugins.settings">Configurações</message>
 	<message key="manager.plugins.tarCommandNotFound">O comando tar não está disponível. Por favor, configure-o corretamente em seu "config.inc.php".</message>
 	<message key="manager.plugins.upgrade">Atualizar plugin</message>
-	<message key="manager.plugins.upgradeDescription">Este formulário permite a você atualizar um plugin. Certifique-se o plugin está compactado como um arquivo tar.gz..</message>
+	<message key="manager.plugins.upgradeDescription">Este formulário permite a você atualizar um plugin. Certifique-se o plugin está 
+compactado como um arquivo tar.gz ou tar.xz.</message>
 	<message key="manager.plugins.upgradeFailed">Falha na atualização. {$errorString}</message>
 	<message key="manager.plugins.upgradeSuccessful">Atualizado com êxito para a versão {$versionString}</message>
 	<message key="manager.plugins.uploadError">Erro enviando arquivo</message>


### PR DESCRIPTION
This PR adds support for xz compressed plugins, as seem in https://github.com/pkp/pkp-lib/pull/747.

I removed the "z" argument from tar extraction since tar auto detects wether its a .gz or a .xz and this also removes the need to check the file extension at the extraction routine.

Please let me know if you think there's a better approach to keep backwards compatibility (to keep .tar.gz support).