### PR TITLE
Fix reviewer grid styling

### DIFF
--- a/controllers/api/task/SendReminderLinkAction.inc.php
+++ b/controllers/api/task/SendReminderLinkAction.inc.php
@@ -37,7 +37,7 @@ class SendReminderLinkAction extends LinkAction {
 		parent::LinkAction(
 			'sendReminder',
 			$ajaxModal,
-			null,
+			__('editor.review.sendReminder'),
 			'overdue'
 		);
 	}

--- a/controllers/api/task/SendThankYouLinkAction.inc.php
+++ b/controllers/api/task/SendThankYouLinkAction.inc.php
@@ -36,7 +36,7 @@ class SendThankYouLinkAction extends LinkAction {
 		// Configure the link action.
 		parent::LinkAction(
 			'thankReviewer', $ajaxModal,
-			__('common.accepted'),
+			__('editor.review.thankReviewer'),
 			'accepted'
 		);
 	}

--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -162,7 +162,7 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 			case 'reviewReady':
 				$user = $request->getUser();
 				import('lib.pkp.controllers.review.linkAction.ReviewNotesLinkAction');
-				return array(new ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, 'new'));
+				return array(new ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, true));
 			case '':
 			case 'declined':
 			case 'unfinished':

--- a/controllers/review/linkAction/ReviewNotesLinkAction.inc.php
+++ b/controllers/review/linkAction/ReviewNotesLinkAction.inc.php
@@ -24,9 +24,9 @@ class ReviewNotesLinkAction extends LinkAction {
 	 * to show information about.
 	 * @param $submission Submission The reviewed submission.
 	 * @param $user User The user.
-	 * @param $icon String the icon to use
+	 * @param status String Review's read status
 	 */
-	function ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, $icon = null) {
+	function ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, $status = null) {
 		// Instantiate the information center modal.
 		$router = $request->getRouter();
 		import('lib.pkp.classes.linkAction.request.AjaxModal');
@@ -49,13 +49,12 @@ class ReviewNotesLinkAction extends LinkAction {
 		$viewsDao = DAORegistry::getDAO('ViewsDAO');
 		$lastViewDate = $viewsDao->getLastViewDate(ASSOC_TYPE_REVIEW_RESPONSE, $reviewAssignment->getId(), $user->getId());
 
-		if (!$icon) {
-			$icon = ($lastViewDate) ? 'notes' : 'notes_new';
-		}
+		$label = !$lastViewDate || $status == 'new' ? __('editor.review.readNewReview') : __('editor.review.readReview');
+
 		// Configure the link action.
 		parent::LinkAction(
 			'readReview', $ajaxModal,
-			'', $icon
+			$label
 		);
 	}
 }

--- a/controllers/review/linkAction/ReviewNotesLinkAction.inc.php
+++ b/controllers/review/linkAction/ReviewNotesLinkAction.inc.php
@@ -24,9 +24,9 @@ class ReviewNotesLinkAction extends LinkAction {
 	 * to show information about.
 	 * @param $submission Submission The reviewed submission.
 	 * @param $user User The user.
-	 * @param $is_unread bool Has a review been read
+	 * @param $isUnread bool Has a review been read
 	 */
-	function ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, $is_unread = null) {
+	function ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, $isUnread = null) {
 		// Instantiate the information center modal.
 		$router = $request->getRouter();
 		import('lib.pkp.classes.linkAction.request.AjaxModal');
@@ -49,7 +49,7 @@ class ReviewNotesLinkAction extends LinkAction {
 		$viewsDao = DAORegistry::getDAO('ViewsDAO');
 		$lastViewDate = $viewsDao->getLastViewDate(ASSOC_TYPE_REVIEW_RESPONSE, $reviewAssignment->getId(), $user->getId());
 
-		$label = !$lastViewDate || $is_unread ? __('editor.review.readNewReview') : __('editor.review.readReview');
+		$label = !$lastViewDate || $isUnread ? __('editor.review.readNewReview') : __('editor.review.readReview');
 
 		// Configure the link action.
 		parent::LinkAction(

--- a/controllers/review/linkAction/ReviewNotesLinkAction.inc.php
+++ b/controllers/review/linkAction/ReviewNotesLinkAction.inc.php
@@ -24,9 +24,9 @@ class ReviewNotesLinkAction extends LinkAction {
 	 * to show information about.
 	 * @param $submission Submission The reviewed submission.
 	 * @param $user User The user.
-	 * @param status String Review's read status
+	 * @param $is_unread bool Has a review been read
 	 */
-	function ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, $status = null) {
+	function ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, $is_unread = null) {
 		// Instantiate the information center modal.
 		$router = $request->getRouter();
 		import('lib.pkp.classes.linkAction.request.AjaxModal');
@@ -49,7 +49,7 @@ class ReviewNotesLinkAction extends LinkAction {
 		$viewsDao = DAORegistry::getDAO('ViewsDAO');
 		$lastViewDate = $viewsDao->getLastViewDate(ASSOC_TYPE_REVIEW_RESPONSE, $reviewAssignment->getId(), $user->getId());
 
-		$label = !$lastViewDate || $status == 'new' ? __('editor.review.readNewReview') : __('editor.review.readReview');
+		$label = !$lastViewDate || $is_unread ? __('editor.review.readNewReview') : __('editor.review.readReview');
 
 		// Configure the link action.
 		parent::LinkAction(

--- a/locale/en_US/editor.xml
+++ b/locale/en_US/editor.xml
@@ -61,6 +61,8 @@
 	<message key="editor.review.thankReviewerError">Error sending thank you to reviewer</message>
 	<message key="editor.review.skipEmail">Do not send Reviewer email</message>
 	<message key="editor.review.sendReminder">Send Reminder</message>
+	<message key="editor.review.readReview">Read Review</message>
+	<message key="editor.review.readNewReview">Read New Review</message>
 	<message key="editor.review.reviewDueDate">Review Due Date</message>
 	<message key="editor.review.reviewCompleted">Review Completed</message>
 	<message key="editor.review.reviewerComments">Reviewer Comments</message>

--- a/styles/pages/workflow.less
+++ b/styles/pages/workflow.less
@@ -184,6 +184,13 @@ div[id^=formatsGridContainer] tbody:not(.empty) td:first-child,
 	margin-top: 0;
 }
 
+// Removes file id styling from the reviewer's grid
+[id^="reviewersGrid"] .gridCellContainer .label.before_actions {
+	padding: 0;
+	background: transparent;
+	font-size: @font-base;
+}
+
 // @todo
 .pkp_page_header {
 


### PR DESCRIPTION
Addresses [this comment](https://github.com/pkp/pkp-lib/commit/2fbdfcc52c3b2e0aee63c4e49b51732d87dc629a#commitcomment-13275645).

It also restores some icons for reading a review that went missing in the new UI. And it makes some adjustments to language to clear a few things up.

Digging into this grid raised a bunch of issues for me and this commit is kind of the best I could do without some more reform, which I've outlined [here](https://github.com/pkp/pkp-lib/issues/758).