### PR TITLE
pkp/pkp-lib#768: Enable outgoing webservice request support for PUT

### DIFF
--- a/classes/webservice/WebService.inc.php
+++ b/classes/webservice/WebService.inc.php
@@ -18,6 +18,7 @@ define('WEBSERVICE_RETRIES', 2);
 define('WEBSERVICE_MICROSECONDS_BEFORE_RETRY', 100000);
 
 define('WEBSERVICE_RESPONSE_OK', 200);
+define('WEBSERVICE_RESPONSE_CREATED', 201);
 
 import('lib.pkp.classes.webservice.WebServiceRequest');
 
@@ -69,12 +70,15 @@ class WebService {
 	function &call(&$webServiceRequest) {
 		assert(is_a($webServiceRequest, 'WebServiceRequest'));
 
+		$usePut = false;
 		switch($webServiceRequest->getMethod()) {
+			case 'PUT':
+				$usePut = true;
 			case 'POST':
 				if ($webServiceRequest->getAsync()) {
-					$result = $this->_callPostWebServiceAsync($webServiceRequest);
+					$result = $this->_callPostWebServiceAsync($webServiceRequest, $usePut);
 				} else {
-					$result = $this->_callPostWebService($webServiceRequest);
+					$result = $this->_callPostWebService($webServiceRequest, $usePut);
 				}
 				break;
 
@@ -83,7 +87,7 @@ class WebService {
 				break;
 
 			default:
-				// We currently only support GET and POST requests
+				// TODO: implement DELETE
 				assert(false);
 		}
 
@@ -107,11 +111,12 @@ class WebService {
 	// Private helper methods
 	//
 	/**
-	 * Call a POST based web services
+	 * Call a POST (or PUT) based web services
 	 * @param $webServiceRequest WebServiceRequest
+	 * @param $usePut boolean
 	 * @return string the web service result or null on failure
 	 */
-	function _callPostWebService($webServiceRequest) {
+	function _callPostWebService($webServiceRequest, $usePut = false) {
 		$url = $webServiceRequest->getUrl();
 		$postOptions = $webServiceRequest->getParams();
 
@@ -123,7 +128,11 @@ class WebService {
 		}
 		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_POST, 1);
+		if ($usePut) {
+			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+		} else {
+			curl_setopt($ch, CURLOPT_POST, 1);
+		}
 
 		// Bug #8518 safety work-around
 		if (is_array($postOptions)) foreach ($postOptions as $paramValue) {
@@ -211,9 +220,10 @@ class WebService {
 	 * to the client closing the connection.
 	 *
 	 * @param $webServiceRequest WebServiceRequest
+	 * @param $usePut boolean
 	 * @return string the web service result or null on failure
 	 */
-	function _callPostWebServiceAsync($webServiceRequest) {
+	function _callPostWebServiceAsync($webServiceRequest, $usePut = false) {
 		// Parse the request URL.
 		$url = $webServiceRequest->getUrl();
 		$urlParts = parse_url($url);
@@ -248,7 +258,7 @@ class WebService {
 		} else {
 			$path = $urlParts['path'] . (isset($urlParts['query']) ? '?' . $urlParts['query'] : '');
 			$host = $urlParts['host'] . ':' . (isset($urlParts['port']) ? $urlParts['port'] : '80');
-			$out = "POST " . $path . " HTTP/1.1\r\n";
+			$out = ($usePut ? "PUT " : "POST ") . $path . " HTTP/1.1\r\n";
 			$out.= "Host: " . $host . "\r\n";
 			foreach ($headers as $header) {
 				$out.= "$header\r\n";

--- a/classes/webservice/WebService.inc.php
+++ b/classes/webservice/WebService.inc.php
@@ -154,6 +154,9 @@ class WebService {
 			// Wait for a short interval before trying again
 			usleep(WEBSERVICE_MICROSECONDS_BEFORE_RETRY);
 		}
+		if (curl_errno($ch)) {
+			trigger_error(curl_error($ch), E_USER_ERROR);
+		}
 
 		$this->_lastResponseStatus = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
@@ -202,6 +205,9 @@ class WebService {
 
 			// Wait for a short interval before trying again
 			usleep(WEBSERVICE_MICROSECONDS_BEFORE_RETRY);
+		}
+		if (curl_errno($ch)) {
+			trigger_error(curl_error($ch), E_USER_ERROR);
 		}
 
 		$this->_lastResponseStatus = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
CURL treats PUT with the same parametrization as POST, so re-use the existing methods.
