### PR TITLE
Standardized locale names

### DIFF
--- a/locale/da_DK/admin.xml
+++ b/locale/da_DK/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/common.xml
+++ b/locale/da_DK/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/grid.xml
+++ b/locale/da_DK/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/installer.xml
+++ b/locale/da_DK/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/manager.xml
+++ b/locale/da_DK/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/reader.xml
+++ b/locale/da_DK/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/submission.xml
+++ b/locale/da_DK/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/user.xml
+++ b/locale/da_DK/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/el_GR/admin.xml
+++ b/locale/el_GR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/common.xml
+++ b/locale/el_GR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/installer.xml
+++ b/locale/el_GR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/manager.xml
+++ b/locale/el_GR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/reader.xml
+++ b/locale/el_GR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/submission.xml
+++ b/locale/el_GR/submission.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="submission.agencies">Φορείς/Γραφεία</message>
 	<message key="submission.abstractViews">Προβολές Περίληψης</message>
 	<message key="submission.accepted">Δεκτό</message>

--- a/locale/el_GR/user.xml
+++ b/locale/el_GR/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/eu_ES/admin.xml
+++ b/locale/eu_ES/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/common.xml
+++ b/locale/eu_ES/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/installer.xml
+++ b/locale/eu_ES/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/manager.xml
+++ b/locale/eu_ES/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/reader.xml
+++ b/locale/eu_ES/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/submission.xml
+++ b/locale/eu_ES/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/user.xml
+++ b/locale/eu_ES/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/fa_IR/admin.xml
+++ b/locale/fa_IR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/common.xml
+++ b/locale/fa_IR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/installer.xml
+++ b/locale/fa_IR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/manager.xml
+++ b/locale/fa_IR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/reader.xml
+++ b/locale/fa_IR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/submission.xml
+++ b/locale/fa_IR/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/user.xml
+++ b/locale/fa_IR/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fr_FR/admin.xml
+++ b/locale/fr_FR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_FR (Français) locale.
+  * Localization strings for the fr_FR (Français (France)) locale.
   *
   -->
 

--- a/locale/fr_FR/common.xml
+++ b/locale/fr_FR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_FR (Français) locale.
+  * Localization strings for the fr_FR (Français (France)) locale.
   *
   -->
 

--- a/locale/fr_FR/installer.xml
+++ b/locale/fr_FR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_FR (Français) locale.
+  * Localization strings for the fr_FR (Français (France)) locale.
   *
   -->
 

--- a/locale/fr_FR/manager.xml
+++ b/locale/fr_FR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_FR (Français) locale.
+  * Localization strings for the fr_FR (Français (France)) locale.
   *
   -->
 

--- a/locale/fr_FR/reader.xml
+++ b/locale/fr_FR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_FR (Français) locale.
+  * Localization strings for the fr_FR (Français (France)) locale.
   *
   -->
 

--- a/locale/fr_FR/submission.xml
+++ b/locale/fr_FR/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_FR (Français) locale.
+  * Localization strings for the fr_FR (Français (France)) locale.
   *
   -->
 

--- a/locale/fr_FR/user.xml
+++ b/locale/fr_FR/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_FR (Français) locale.
+  * Localization strings for the fr_FR (Français (France)) locale.
   *
   -->
 

--- a/locale/gl_ES/admin.xml
+++ b/locale/gl_ES/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. Para completar a información  cómpre ver o arquivo docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/common.xml
+++ b/locale/gl_ES/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. Para completar a información  cómpre ver o arquivo docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/installer.xml
+++ b/locale/gl_ES/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/manager.xml
+++ b/locale/gl_ES/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/reader.xml
+++ b/locale/gl_ES/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/submission.xml
+++ b/locale/gl_ES/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/user.xml
+++ b/locale/gl_ES/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/ml_IN/admin.xml
+++ b/locale/ml_IN/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/common.xml
+++ b/locale/ml_IN/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/grid.xml
+++ b/locale/ml_IN/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/installer.xml
+++ b/locale/ml_IN/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/manager.xml
+++ b/locale/ml_IN/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/reader.xml
+++ b/locale/ml_IN/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/submission.xml
+++ b/locale/ml_IN/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   -->
 
 <locale name="ml_IN" full_name = "Malayalam">

--- a/locale/ml_IN/user.xml
+++ b/locale/ml_IN/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   -->
 
 <locale name="ml_IN" full_name = "Malayalam">

--- a/locale/no_NO/admin.xml
+++ b/locale/no_NO/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   *
   -->
 

--- a/locale/no_NO/common.xml
+++ b/locale/no_NO/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   *
   -->
 

--- a/locale/no_NO/installer.xml
+++ b/locale/no_NO/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   *
   -->
 

--- a/locale/no_NO/manager.xml
+++ b/locale/no_NO/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   *
   -->
 

--- a/locale/no_NO/reader.xml
+++ b/locale/no_NO/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   *
   -->
 

--- a/locale/no_NO/submission.xml
+++ b/locale/no_NO/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   *
   -->
 

--- a/locale/no_NO/user.xml
+++ b/locale/no_NO/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   *
   -->
 

--- a/locale/pt_PT/admin.xml
+++ b/locale/pt_PT/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/common.xml
+++ b/locale/pt_PT/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/installer.xml
+++ b/locale/pt_PT/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/manager.xml
+++ b/locale/pt_PT/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/reader.xml
+++ b/locale/pt_PT/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/submission.xml
+++ b/locale/pt_PT/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/user.xml
+++ b/locale/pt_PT/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/ro_RO/admin.xml
+++ b/locale/ro_RO/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/common.xml
+++ b/locale/ro_RO/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ro_RO/countries.xml
+++ b/locale/ro_RO/countries.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/currencies.xml
+++ b/locale/ro_RO/currencies.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/grid.xml
+++ b/locale/ro_RO/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ro_RO/installer.xml
+++ b/locale/ro_RO/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ro_RO/manager.xml
+++ b/locale/ro_RO/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/reader.xml
+++ b/locale/ro_RO/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/submission.xml
+++ b/locale/ro_RO/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/user.xml
+++ b/locale/ro_RO/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ru_RU/admin.xml
+++ b/locale/ru_RU/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/ru_RU/common.xml
+++ b/locale/ru_RU/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/ru_RU/default.xml
+++ b/locale/ru_RU/default.xml
@@ -12,7 +12,7 @@
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<!-- Группы по умолчанию -->
 	<message key="default.groups.name.siteAdmin">Администратор сайта</message>
 	<message key="default.groups.plural.siteAdmin">Администраторы сайта</message>

--- a/locale/ru_RU/grid.xml
+++ b/locale/ru_RU/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/ru_RU/installer.xml
+++ b/locale/ru_RU/installer.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2009 Konstantin L. Metlov
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/ru_RU/manager.xml
+++ b/locale/ru_RU/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/ru_RU/reader.xml
+++ b/locale/ru_RU/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/ru_RU/reviewer.xml
+++ b/locale/ru_RU/reviewer.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<!-- Используется в процессе рецензирования -->
 	<message key="reviewer.reviewSteps.request">1. Запрос</message>
 	<message key="reviewer.reviewSteps.guidelines">2. Руководство</message>

--- a/locale/ru_RU/submission.xml
+++ b/locale/ru_RU/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/ru_RU/user.xml
+++ b/locale/ru_RU/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 

--- a/locale/sr_SR/admin.xml
+++ b/locale/sr_SR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/common.xml
+++ b/locale/sr_SR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/countries.xml
+++ b/locale/sr_SR/countries.xml
@@ -9,7 +9,7 @@
   *
   * Localized list of countries.
   *
-  * Localization strings for the sr_SR (Srpski) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   * Translation: Igor Lekić igor.lekic@ff.uns.ac.rs
   *

--- a/locale/sr_SR/currencies.xml
+++ b/locale/sr_SR/currencies.xml
@@ -10,7 +10,7 @@
   *
   * Localized list of currencies.
   *
-  * Localization strings for the sr_SR (Srpski) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   * Translation: Igor Lekić igor.lekic@ff.uns.ac.rs
   *

--- a/locale/sr_SR/grid.xml
+++ b/locale/sr_SR/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/installer.xml
+++ b/locale/sr_SR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/manager.xml
+++ b/locale/sr_SR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/reader.xml
+++ b/locale/sr_SR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/submission.xml
+++ b/locale/sr_SR/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   -->
 
 <locale name="sr_SR" full_name = "Serbian">

--- a/locale/sr_SR/user.xml
+++ b/locale/sr_SR/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   -->
 
 <locale name="sr_SR" full_name = "Serbian">

--- a/locale/sv_SE/admin.xml
+++ b/locale/sv_SE/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/common.xml
+++ b/locale/sv_SE/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/installer.xml
+++ b/locale/sv_SE/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/manager.xml
+++ b/locale/sv_SE/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/reader.xml
+++ b/locale/sv_SE/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/submission.xml
+++ b/locale/sv_SE/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/user.xml
+++ b/locale/sv_SE/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/tr_TR/admin.xml
+++ b/locale/tr_TR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/common.xml
+++ b/locale/tr_TR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/grid.xml
+++ b/locale/tr_TR/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Turkish) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/installer.xml
+++ b/locale/tr_TR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/manager.xml
+++ b/locale/tr_TR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/reader.xml
+++ b/locale/tr_TR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/submission.xml
+++ b/locale/tr_TR/submission.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2013-2015 Simon Fraser University Library
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   -->
 
 <locale name="tr_TR" full_name = "Türkiye Türkçesi">

--- a/locale/tr_TR/user.xml
+++ b/locale/tr_TR/user.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2013-2015 Simon Fraser University Library
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   -->
 
 <locale name="tr_TR" full_name = "Türkiye Türkçesi">

--- a/locale/uk_UA/admin.xml
+++ b/locale/uk_UA/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/common.xml
+++ b/locale/uk_UA/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/countries.xml
+++ b/locale/uk_UA/countries.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2010-2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/currencies.xml
+++ b/locale/uk_UA/currencies.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2010-2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/grid.xml
+++ b/locale/uk_UA/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/installer.xml
+++ b/locale/uk_UA/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/languages.xml
+++ b/locale/uk_UA/languages.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2010-2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/manager.xml
+++ b/locale/uk_UA/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/reader.xml
+++ b/locale/uk_UA/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/submission.xml
+++ b/locale/uk_UA/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/user.xml
+++ b/locale/uk_UA/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/zh_CN/manager.xml
+++ b/locale/zh_CN/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (Simplified Chinese) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   *
   -->
 

--- a/plugins/citationLookup/crossref/locale/da_DK/locale.xml
+++ b/plugins/citationLookup/crossref/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationLookup.crossref.displayName">CrossRef Database Connector</message>
 	<message key="plugins.citationLookup.crossref.description">Etablerer forbindelse til CrossRef's bibliografiske database.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/es_ES/locale.xml
+++ b/plugins/citationLookup/crossref/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationLookup.crossref.displayName">Conector de bases de datos CrossRef</message>
+<locale name="es_ES" full_name="Español (España)">Conector de bases de datos CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Conecta con la base de datos bibliográfica CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/crossref/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationLookup.crossref.displayName">Connecteur aux bases de données CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Connecte aux bases de données bibliographiques CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/fr_FR/locale.xml
+++ b/plugins/citationLookup/crossref/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationLookup.crossref.displayName">Connecteur aux bases de données CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Connecte aux bases de données bibliographiques CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/crossref/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationLookup.crossref.displayName">Konektor Database CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Koneksi ke database bibliografi CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/crossref/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationLookup.crossref.displayName">Connector de base de dados CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Conecta à base de dados bibliográfica CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/pt_PT/locale.xml
+++ b/plugins/citationLookup/crossref/locale/pt_PT/locale.xml
@@ -8,8 +8,8 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 </locale>

--- a/plugins/citationLookup/crossref/locale/ru_RU/locale.xml
+++ b/plugins/citationLookup/crossref/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationLookup.crossref.displayName">Модуль подключения к базе данных CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Подключается к библиографической базе данных CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/crossref/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationLookup.crossref.displayName">CrossRef Database Connector</message>
 	<message key="plugins.citationLookup.crossref.description">Povezuje CrossRef bibliografsku bazu podataka.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/crossref/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationLookup.crossref.displayName">CrossRef Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.crossref.description">CrossRef bibliyografik veri tabanına bağlan.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/crossref/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationLookup.crossref.displayName">Шлюз бази даних CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Забезпечує зв'язок з бібліографічною базою даних CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/zh_CN/locale.xml
+++ b/plugins/citationLookup/crossref/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationLookup.crossref.displayName">CrossRef 数据连接器</message>
 	<message key="plugins.citationLookup.crossref.description">连接到 CrossRef 文献数据库。</message>
 </locale>

--- a/plugins/citationLookup/isbndb/locale/da_DK/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">ISBNdb Database Connector</message>
 	<message key="plugins.citationLookup.isbndb.description">Etablerer forbindelse til ISBNdb's bibliografiske database.</message>

--- a/plugins/citationLookup/isbndb/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Connecteur aux bases de données CrossRef</message>
 	<message key="plugins.citationLookup.isbndb.description">Connecte aux bases de données bibliographiques CrossRef.</message>

--- a/plugins/citationLookup/isbndb/locale/fr_FR/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Connecteur aux bases de données CrossRef</message>
 	<message key="plugins.citationLookup.isbndb.description">Connecte aux bases de données bibliographiques CrossRef.</message>

--- a/plugins/citationLookup/isbndb/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Konektor Database ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Koneksi ke database bibliografi ISBNdb.</message>

--- a/plugins/citationLookup/isbndb/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Conector à base de dados ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Conecta à base de dados bibliográfica ISBNdb.</message>

--- a/plugins/citationLookup/isbndb/locale/pt_PT/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/pt_PT/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<!-- plug-in -->
 
 </locale>

--- a/plugins/citationLookup/isbndb/locale/ru_RU/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<!-- плагин -->
 	<message key="plugins.citationLookup.isbndb.displayName">Модуль подключения к базе данных ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Подключается к библиографической базе данных ISBNdb.</message>

--- a/plugins/citationLookup/isbndb/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">ISBNdb Database Connector</message>
 	<message key="plugins.citationLookup.isbndb.description">Povezuje se na ISBNdb bibliografsku bazu podataka.</message>

--- a/plugins/citationLookup/isbndb/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">CrossRef Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.isbndb.description">CrossRef bibliyografik veri tabanına bağlan.</message>

--- a/plugins/citationLookup/isbndb/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Шлюз бази даних ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Забезпечує зв'язок з бібліографічною базою даних ISBNdb.</message>

--- a/plugins/citationLookup/isbndb/locale/zh_CN/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">ISBNdb 数据库连接器</message>
 	<message key="plugins.citationLookup.isbndb.description">连接到 ISBNdb 文献数据库。</message>

--- a/plugins/citationLookup/pubmed/locale/da_DK/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationLookup.pubmed.displayName">PubMed Database Connector</message>
 	<message key="plugins.citationLookup.pubmed.description">Etablerer forbindelse til PubMed's bibliografiske database.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/es_ES/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationLookup.pubmed.displayName">Conector de bases de datos PubMed</message>
+<locale name="es_ES" full_name="Español (España)">Conector de bases de datos PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Conecta con la base de datos bibliográfica PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationLookup.pubmed.displayName">Connecteur aux bases de données PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Connecte aux bases de données bibliographiques PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/fr_FR/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationLookup.pubmed.displayName">Connecteur aux bases de données PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Connecte aux bases de données bibliographiques PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationLookup.pubmed.displayName">Konektor database PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Koneksi ke database bibliografi PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationLookup.pubmed.displayName">Conector à base de dados PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Conecta à base de dados bibliográfica do PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/pt_PT/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 
 </locale>

--- a/plugins/citationLookup/pubmed/locale/ru_RU/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationLookup.pubmed.displayName">Модуль подключения к базе данных PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Подключается к библиографической базе данных PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationLookup.pubmed.displayName">PubMed Database Connector</message>
 	<message key="plugins.citationLookup.pubmed.description">Povezuje se na PubMed bibliografsku bazu podataka.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationLookup.pubmed.displayName">PubMed Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.pubmed.description">PubMed bibliyografik veri tabanına bağlan.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationLookup.pubmed.displayName">Шлюз бази даних PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Забезпечує зв'язок з бібліографічною базою даних PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/zh_CN/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationLookup.pubmed.displayName">PubMed 资料库连接器</message>
 	<message key="plugins.citationLookup.pubmed.description">连接到 PubMed 文献数据库。</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/da_DK/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationLookup.worldcat.displayName">WorldCat Database Connector</message>
 	<message key="plugins.citationLookup.worldcat.description">Etablerer forbindelse til WorldCat's bibliografiske database.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/es_ES/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationLookup.worldcat.displayName">Conector de bases de datos WorldCat</message>
+<locale name="es_ES" full_name="Español (España)">Conector de bases de datos WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Conecta con la base de datos bibliográfica WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationLookup.worldcat.displayName">Connecteur aux bases de données Worldcat</message>
 	<message key="plugins.citationLookup.worldcat.description">Connecte aux bases de données bibliographiques WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/fr_FR/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationLookup.worldcat.displayName">Connecteur aux bases de données Worldcat</message>
 	<message key="plugins.citationLookup.worldcat.description">Connecte aux bases de données bibliographiques WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationLookup.worldcat.displayName">Konektor database WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Koneksi ke database bibliografi WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationLookup.worldcat.displayName">Conector de base de dados WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Conecta à base bibliográfica WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/pt_PT/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 
 </locale>

--- a/plugins/citationLookup/worldcat/locale/ru_RU/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationLookup.worldcat.displayName">Модуль подключения к базе данных WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Подключается к библиографической базе данных WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationLookup.worldcat.displayName">WorldCat Database Connector</message>
 	<message key="plugins.citationLookup.worldcat.description">Povezuje se na  WorldCat bibliografsku bazu podataka.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationLookup.worldcat.displayName">WorldCat Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.worldcat.description">WorldCat bibliyografik veri tabanına bağlan.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationLookup.worldcat.displayName">Шлюз бази даних WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Забезпечує зв'язок з бібліографічною базою даних WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/zh_CN/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationLookup.worldcat.displayName">WorldCat 数据库连接器</message>
 	<message key="plugins.citationLookup.worldcat.description">连接到 WorldCat 文献数据库。</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/da_DK/locale.xml
+++ b/plugins/citationOutput/abnt/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT citationsformat</message>
 	<message key="plugins.citationOutput.abnt.description">Implementerer ABNT citationsformatet.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/de_DE/locale.xml
+++ b/plugins/citationOutput/abnt/locale/de_DE/locale.xml
@@ -11,7 +11,7 @@
   * Please contact Marco Tullney, marco.tullney@fu-berlin.de, with any questions regarding this translation.
   -->
 
-<locale name="de_DE" full_name="Deutsch (Deutschland))">
+<locale name="de_DE" full_name="Deutsch (Deutschland)">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT-Zitationsstil</message>
 	<message key="plugins.citationOutput.abnt.description">Stellt den ABNT-Zitationsstil bereit.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/es_ES/locale.xml
+++ b/plugins/citationOutput/abnt/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationOutput.abnt.displayName">Estilo de cita ABNT</message>
+<locale name="es_ES" full_name="Español (España)">Estilo de cita ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Introduce el estilo de cita ABNT.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/abnt/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationOutput.abnt.displayName">Style de citation ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Implante le style de citation ABNT.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/fr_FR/locale.xml
+++ b/plugins/citationOutput/abnt/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationOutput.abnt.displayName">Style de citation ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Implante le style de citation ABNT.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/abnt/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.abnt.displayName">Gaya sitiran ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Implementasikan gaya sitiran ABNT</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/abnt/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.abnt.displayName">Estilo de citação ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Implementa o estilo de citação ABNT.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/pt_PT/locale.xml
+++ b/plugins/citationOutput/abnt/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 
 </locale>

--- a/plugins/citationOutput/abnt/locale/ru_RU/locale.xml
+++ b/plugins/citationOutput/abnt/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationOutput.abnt.displayName">Стиль оформления ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Реализует стиль оформления ABNT.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/abnt/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT Citation Style</message>
 	<message key="plugins.citationOutput.abnt.description">Uvodi ABNT stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/abnt/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT Atıf Sitili</message>
 	<message key="plugins.citationOutput.abnt.description">ABNT atıf sitilini uygular.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/abnt/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.abnt.displayName">Формат цитат ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Дозволяє використання формату цитат ABNT.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/zh_CN/locale.xml
+++ b/plugins/citationOutput/abnt/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT 引用格式</message>
 	<message key="plugins.citationOutput.abnt.description">应用 ABNT 引用格式。</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/da_DK/locale.xml
+++ b/plugins/citationOutput/apa/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationOutput.apa.displayName">APA citationsformat</message>
 	<message key="plugins.citationOutput.apa.description">Implementerer APA citationsformatet.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/es_ES/locale.xml
+++ b/plugins/citationOutput/apa/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationOutput.apa.displayName">Estilo de cita APA</message>
+<locale name="es_ES" full_name="Español (España)">Estilo de cita APA</message>
 	<message key="plugins.citationOutput.apa.description">Introduce el estilo de cita APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/apa/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationOutput.apa.displayName">Style de citation APA</message>
 	<message key="plugins.citationOutput.apa.description">Implante le style de citation APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/fr_FR/locale.xml
+++ b/plugins/citationOutput/apa/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationOutput.apa.displayName">Style de citation APA</message>
 	<message key="plugins.citationOutput.apa.description">Implante le style de citation APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/apa/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.apa.displayName">Gaya sitiran APA</message>
 	<message key="plugins.citationOutput.apa.description">Implementasikan gaya sitiran APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/apa/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.apa.displayName">Estilo de citação APA</message>
 	<message key="plugins.citationOutput.apa.description">Implementa o estilo de citação APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/pt_PT/locale.xml
+++ b/plugins/citationOutput/apa/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 
 </locale>

--- a/plugins/citationOutput/apa/locale/ru_RU/locale.xml
+++ b/plugins/citationOutput/apa/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationOutput.apa.displayName">Стиль оформления APA</message>
 	<message key="plugins.citationOutput.apa.description">Реализует стиль оформления APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/apa/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.apa.displayName">APA Citation Style</message>
 	<message key="plugins.citationOutput.apa.description">Uvodi APA stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/apa/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.apa.displayName">APA Atıf Biçimi</message>
 	<message key="plugins.citationOutput.apa.description">APA atıf biçimini uygular.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/apa/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.apa.displayName">Формат цитат APA</message>
 	<message key="plugins.citationOutput.apa.description">Дозволяє використання формату цитат APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/zh_CN/locale.xml
+++ b/plugins/citationOutput/apa/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationOutput.apa.displayName">APA 引用格式</message>
 	<message key="plugins.citationOutput.apa.description">应用APA引用格式。</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/da_DK/locale.xml
+++ b/plugins/citationOutput/mla/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationOutput.mla.displayName">MLA citationsformat</message>
 	<message key="plugins.citationOutput.mla.description">Implementerer MLA citationsformatet.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/es_ES/locale.xml
+++ b/plugins/citationOutput/mla/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationOutput.mla.displayName">Estilo de cita MLA</message>
+<locale name="es_ES" full_name="Español (España)">Estilo de cita MLA</message>
 	<message key="plugins.citationOutput.mla.description">Introduce el estilo de cita MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/mla/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationOutput.mla.displayName">Style de citation MLA</message>
 	<message key="plugins.citationOutput.mla.description">Implante le style de citation MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/fr_FR/locale.xml
+++ b/plugins/citationOutput/mla/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationOutput.mla.displayName">Style de citation MLA</message>
 	<message key="plugins.citationOutput.mla.description">Applique le style de citation MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/mla/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.mla.displayName">Gaya sitiran MLA</message>
 	<message key="plugins.citationOutput.mla.description">Implementasikan gaya sitiran MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/mla/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.mla.displayName">Estilo de citação MLA</message>
 	<message key="plugins.citationOutput.mla.description">Implementa o estilo de citação MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/pt_PT/locale.xml
+++ b/plugins/citationOutput/mla/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 
 </locale>

--- a/plugins/citationOutput/mla/locale/ru_RU/locale.xml
+++ b/plugins/citationOutput/mla/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationOutput.mla.displayName">Стиль оформления MLA</message>
 	<message key="plugins.citationOutput.mla.description">Реализует стиль оформления MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/mla/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.mla.displayName">MLA Citation Style</message>
 	<message key="plugins.citationOutput.mla.description">Uvodi MLA stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/mla/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.mla.displayName">MLA Atıf Biçimi</message>
 	<message key="plugins.citationOutput.mla.description">MLA atıf biçimini uygular.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/mla/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.mla.displayName">Формат цитат MLA</message>
 	<message key="plugins.citationOutput.mla.description">Дозволяє використання формату цитат MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/zh_CN/locale.xml
+++ b/plugins/citationOutput/mla/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationOutput.mla.displayName">MLA 引用格式</message>
 	<message key="plugins.citationOutput.mla.description">应用 MLA 引用格式。</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/da_DK/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationOutput.vancouver.displayName">Vancouver citationsformat</message>
 	<message key="plugins.citationOutput.vancouver.description">Implementerer Vancouver citationsformatet.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/es_ES/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationOutput.vancouver.displayName">Estilo de cita Vancouver</message>
+<locale name="es_ES" full_name="Español (España)">Estilo de cita Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Introduce el estilo de cita Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationOutput.vancouver.displayName">Style de citation Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Implante le style de citation Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/fr_FR/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationOutput.vancouver.displayName">Style de citation Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Implante le style de citation Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.vancouver.displayName">Gaya sitiran Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Implementasikan gaya sitiran Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.vancouver.displayName">Estilo de citação Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Implementa o estilo de citação Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/pt_PT/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 
 </locale>

--- a/plugins/citationOutput/vancouver/locale/ru_RU/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationOutput.vancouver.displayName">Стиль оформления Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Реализует стиль оформления Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.vancouver.displayName">Vancouver Citation Style</message>
 	<message key="plugins.citationOutput.vancouver.description">Uvodi Vancouver stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.vancouver.displayName">Vancouver Atıf Biçimi</message>
 	<message key="plugins.citationOutput.vancouver.description">Vancouver atıf biçimini uygular.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.vancouver.displayName">Формат цитат Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Дозволяє використання формату цитат Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/zh_CN/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationOutput.vancouver.displayName">Vancouver 引用格式</message>
 	<message key="plugins.citationOutput.vancouver.description">应用 Vancouver 引用格式。</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/da_DK/locale.xml
+++ b/plugins/citationParser/freecite/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationParser.freecite.displayName">FreeCite Citation Extractor</message>
 	<message key="plugins.citationParser.freecite.description">Extracts fields from plain text citations via the FreeCite service.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/es_ES/locale.xml
+++ b/plugins/citationParser/freecite/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationParser.freecite.displayName">Extractor de cita FreeCite</message>
+<locale name="es_ES" full_name="Español (España)">Extractor de cita FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Extrae campos de citas de texto sin formato a través de FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/freecite/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationParser.freecite.displayName">Extracteur de citation FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Extraction de champs de citations en texte brut via le service FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/fr_FR/locale.xml
+++ b/plugins/citationParser/freecite/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationParser.freecite.displayName">Extracteur de citation FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Extraction de champs de citations en texte brut via le service FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/id_ID/locale.xml
+++ b/plugins/citationParser/freecite/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.freecite.displayName">Ekstraksi Sitiran FreeCite Citation Extractor</message>
 	<message key="plugins.citationParser.freecite.description">Ekstrak field dari teks sitasi biasa melalui layanan FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/freecite/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.freecite.displayName">Extrator de citação FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Extrai campos de citações em texto puro por meio do serviço FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/pt_PT/locale.xml
+++ b/plugins/citationParser/freecite/locale/pt_PT/locale.xml
@@ -8,8 +8,8 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 </locale>

--- a/plugins/citationParser/freecite/locale/ru_RU/locale.xml
+++ b/plugins/citationParser/freecite/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationParser.freecite.displayName">Модуль извлечения ссылок FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Извлекает поля из ссылки в виде простого текста с помощью службы FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/freecite/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.freecite.displayName">FreeCite Citation Extractor</message>
 	<message key="plugins.citationParser.freecite.description">Izdvaja polja iz teksta citata putem FreeCite servisa.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/freecite/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.freecite.displayName">FreeCite Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.freecite.description">FreeCite servisi üzerinden düz metin alıntıları alanlarını ayırır.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/freecite/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.freecite.displayName">Синтаксичний аналізатор цитат FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Аналізує поля неструктурованих текстових цитат через службу FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/zh_CN/locale.xml
+++ b/plugins/citationParser/freecite/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationParser.freecite.displayName">FreeCite 引用提取器</message>
 	<message key="plugins.citationParser.freecite.description">通过FreeCite 服务提取纯文本引用。</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/da_DK/locale.xml
+++ b/plugins/citationParser/paracite/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationParser.paracite.displayName">ParaCite Citation Extractor</message>
 	<message key="plugins.citationParser.paracite.description">Extracts fields from plain text citations via the ParaCite service.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/es_ES/locale.xml
+++ b/plugins/citationParser/paracite/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationParser.paracite.displayName">Extractor de cita ParaCite</message>
+<locale name="es_ES" full_name="Español (España)">Extractor de cita ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Extrae campos de citas de texto sin formato a través de ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/paracite/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationParser.paracite.displayName">Extracteur de citation ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Extraction de champs de citations en texte brut via le service ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/fr_FR/locale.xml
+++ b/plugins/citationParser/paracite/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationParser.paracite.displayName">Extracteur de citation ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Extraction de champs de citations en texte brut via le service ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/id_ID/locale.xml
+++ b/plugins/citationParser/paracite/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.paracite.displayName">Ekstraksi Sitiran ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Ekstrak field dari teks sitasi biasa melalui layanan ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/paracite/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.paracite.displayName">Extrator de citação ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Extrai campos de citações em texto puro por meio do serviço ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/pt_PT/locale.xml
+++ b/plugins/citationParser/paracite/locale/pt_PT/locale.xml
@@ -8,8 +8,8 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 </locale>

--- a/plugins/citationParser/paracite/locale/ru_RU/locale.xml
+++ b/plugins/citationParser/paracite/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationParser.paracite.displayName">Модуль извлечения ссылок ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Извлекает поля из ссылки в виде простого текста с помощью службы ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/paracite/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.paracite.displayName">ParaCite Citation Extractor</message>
 	<message key="plugins.citationParser.paracite.description">Izdvaja polja iz teksta citata putem ParaCite servisa.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/paracite/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.paracite.displayName">ParaCite Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.paracite.description">ParaCite servisi üzerinden düz metin atıf alanlarını ayıklar.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/paracite/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.paracite.displayName">Синтаксичний аналізатор цитат ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Аналізує поля неструктурованих текстових цитат через службу ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/zh_CN/locale.xml
+++ b/plugins/citationParser/paracite/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationParser.paracite.displayName">ParaCite 引用提取器</message>
 	<message key="plugins.citationParser.paracite.description">通过 ParaCite 服务提取纯文本引用。</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/da_DK/locale.xml
+++ b/plugins/citationParser/parscit/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationParser.parscit.displayName">ParsCit Citation Extractor</message>
 	<message key="plugins.citationParser.parscit.description">Extracts fields from plain text citations via the ParsCit service.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/es_ES/locale.xml
+++ b/plugins/citationParser/parscit/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationParser.parscit.displayName">Extractor de cita ParsCit</message>
+<locale name="es_ES" full_name="Español (España)">Extractor de cita ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Extrae campos de citas de texto sin formato a través de ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/parscit/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationParser.parscit.displayName">Extracteur de citation ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Extraction de champs de citations en texte brut via le service ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/fr_FR/locale.xml
+++ b/plugins/citationParser/parscit/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationParser.parscit.displayName">Extracteur de citation ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Extraction de champs de citations en texte brut via le service ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/id_ID/locale.xml
+++ b/plugins/citationParser/parscit/locale/id_ID/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.parscit.displayName">Ekstraksi Sitiran ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Ekstrak field dari teks sitasi biasa melalui layanan ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/parscit/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.parscit.displayName">Extrator de citação ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Extrai campos de citações de texto puro por meio do serviço ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/pt_PT/locale.xml
+++ b/plugins/citationParser/parscit/locale/pt_PT/locale.xml
@@ -8,8 +8,8 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 </locale>

--- a/plugins/citationParser/parscit/locale/ru_RU/locale.xml
+++ b/plugins/citationParser/parscit/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationParser.parscit.displayName">Модуль извлечения ссылок ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Извлекает поля из ссылки в виде простого текста с помощью службы ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/parscit/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.parscit.displayName">ParsCit Citation Extractor</message>
 	<message key="plugins.citationParser.parscit.description">Izdvaja polja iz teksta citata putem ParsCit servisa.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/parscit/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.parscit.displayName">ParsCit Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.parscit.description">ParsCit servisi üzerinden düz metin atıf alanlarını ayırır.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/parscit/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.parscit.displayName">Синтаксичний аналізатор цитат ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Аналізує поля неструктурованих текстових цитат через службу ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/zh_CN/locale.xml
+++ b/plugins/citationParser/parscit/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationParser.parscit.displayName">ParsCit 引用提取</message>
 	<message key="plugins.citationParser.parscit.description">通过ParsCit 服务提取纯文本引用。</message>
 </locale>

--- a/plugins/citationParser/regex/locale/da_DK/locale.xml
+++ b/plugins/citationParser/regex/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.citationParser.regex.displayName">Regular Expressions Citation Extractor</message>
 	<message key="plugins.citationParser.regex.description">Extracts fields from plain text citations via regular expressions.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/es_ES/locale.xml
+++ b/plugins/citationParser/regex/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.citationParser.regex.displayName">Extractor de citas de expresiones regulares</message>
+<locale name="es_ES" full_name="Español (España)">Extractor de citas de expresiones regulares</message>
 	<message key="plugins.citationParser.regex.description">Extrae campos de citas de texto sin formato a través de expresiones regulares.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/regex/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.citationParser.regex.displayName">Extracteur de citation par expression regulière</message>
 	<message key="plugins.citationParser.regex.description">Extraction de champs de citations en texte brut via des expressions régulières.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/fr_FR/locale.xml
+++ b/plugins/citationParser/regex/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.citationParser.regex.displayName">Extracteur de citation par expression regulière</message>
 	<message key="plugins.citationParser.regex.description">Extraction de champs de citations en texte brut via des expressions régulières.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/id_ID/locale.xml
+++ b/plugins/citationParser/regex/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.regex.displayName">Ekstraksi Sitiran Regular Expressions</message>
 	<message key="plugins.citationParser.regex.description">Ekstrak field dari teks sitasi biasa melalui layanan regular expressions.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/regex/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.regex.displayName">Extração de citações por Expressões Regulares</message>
 	<message key="plugins.citationParser.regex.description">Extrai campos de citações de texto puro por meio de expressões regulares.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/pt_PT/locale.xml
+++ b/plugins/citationParser/regex/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 
 </locale>

--- a/plugins/citationParser/regex/locale/ru_RU/locale.xml
+++ b/plugins/citationParser/regex/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.citationParser.regex.displayName">Модуль извлечения ссылок RegEx</message>
 	<message key="plugins.citationParser.regex.description">Извлекает поля из ссылки в виде простого текста с помощью регулярных выражений.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/regex/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.regex.displayName">Regular Expressions Citation Extractor</message>
 	<message key="plugins.citationParser.regex.description">Izdvaja polja iz teksta citata preko ustaljenih izraza.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/regex/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.regex.displayName">Düzenli İfadeler Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.regex.description">Düzenli ifadeler yoluyla düz metin alıntıları alanlanlarınıı ayıklar.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/regex/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.regex.displayName">Аналізатор регулярних виразів</message>
 	<message key="plugins.citationParser.regex.description">Аналізує поля неструктурованих текстових цитат за допомогою регулярних виразів.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/zh_CN/locale.xml
+++ b/plugins/citationParser/regex/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.citationParser.regex.displayName">正则表达式引用提取器。</message>
 	<message key="plugins.citationParser.regex.description">通过正则表达式提取纯文本引用。</message>
 </locale>

--- a/plugins/metadata/dc11/locale/da_DK/locale.xml
+++ b/plugins/metadata/dc11/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
  
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Dublin Core 1.1 meta-data</message>
 	<message key="plugins.metadata.dc11.description">Leverer Dublin Core 1.1 tilpasnings-skemaer og -applikationer.</message>

--- a/plugins/metadata/dc11/locale/fr_CA/locale.xml
+++ b/plugins/metadata/dc11/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Métadonnées Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Met à disposition des schémas et des adaptateurs d'application Dublin Core en version 1.1</message>

--- a/plugins/metadata/dc11/locale/fr_FR/locale.xml
+++ b/plugins/metadata/dc11/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Métadonnées Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Met à disposition des schémas et des adaptateurs d'application Dublin Core en version 1.1</message>

--- a/plugins/metadata/dc11/locale/id_ID/locale.xml
+++ b/plugins/metadata/dc11/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Metadata Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Berkontribusi terhadap skema dan adapter aplikasi Dublin Core versi 1.1.</message>

--- a/plugins/metadata/dc11/locale/pt_BR/locale.xml
+++ b/plugins/metadata/dc11/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Metadados Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Contribui com esquemas Dublin Core versão 1.1 e adaptadores de aplicação.</message>

--- a/plugins/metadata/dc11/locale/pt_PT/locale.xml
+++ b/plugins/metadata/dc11/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
  
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<!-- plug-in -->
 </locale>

--- a/plugins/metadata/dc11/locale/ru_RU/locale.xml
+++ b/plugins/metadata/dc11/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<!-- плагин -->
 	<message key="plugins.metadata.dc11.displayName">Метаданные Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Реализует схемы и адаптеры приложений Dublin Core версии 1.1.</message>

--- a/plugins/metadata/dc11/locale/sr_SR/locale.xml
+++ b/plugins/metadata/dc11/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Dublin Core 1.1 meta-data</message>
 	<message key="plugins.metadata.dc11.description">Dodaje Dublin Core version 1.1 šeme i adaptere aplikacije</message>

--- a/plugins/metadata/dc11/locale/tr_TR/locale.xml
+++ b/plugins/metadata/dc11/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Dublin Core 1.1 Üst Veri</message>
 	<message key="plugins.metadata.dc11.description">Dublin Core 1.1 sürüm şemaları ve uygulama adaptörlerine katkıda bulun.</message>

--- a/plugins/metadata/dc11/locale/uk_UA/locale.xml
+++ b/plugins/metadata/dc11/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Метадані Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Підтримка схем та шаблонів Dublin Core версії 1.1.</message>

--- a/plugins/metadata/dc11/locale/zh_CN/locale.xml
+++ b/plugins/metadata/dc11/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
  
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Dublin Core 1.1 元数据</message>
 	<message key="plugins.metadata.dc11.description">有助于 Dublin Core 版本1.1 模式和应用配适器。</message>

--- a/plugins/metadata/mods34/locale/da_DK/locale.xml
+++ b/plugins/metadata/mods34/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">MODS 3.4 meta-data</message>
 	<message key="plugins.metadata.mods34.description">Leverer MODS 3.4 tilpasnings-skemaer og –applikationer.</message>

--- a/plugins/metadata/mods34/locale/fr_CA/locale.xml
+++ b/plugins/metadata/mods34/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Métadonnées MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Met à disposition des schémas et des logiciels d'adaptation MODS 3.4.</message>

--- a/plugins/metadata/mods34/locale/fr_FR/locale.xml
+++ b/plugins/metadata/mods34/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Métadonnées MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Met à disposition des schémas et des logiciels d'adaptation MODS 3.4.</message>

--- a/plugins/metadata/mods34/locale/id_ID/locale.xml
+++ b/plugins/metadata/mods34/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Metadata MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Berkontribusi terhadap skema dan adapter aplikasi MODS 3.4.</message>

--- a/plugins/metadata/mods34/locale/pt_BR/locale.xml
+++ b/plugins/metadata/mods34/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Metadados MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Contribui com esquemas MODS 3.4 e adaptadores de aplicação.</message>

--- a/plugins/metadata/mods34/locale/pt_PT/locale.xml
+++ b/plugins/metadata/mods34/locale/pt_PT/locale.xml
@@ -8,9 +8,9 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<!-- plug-in -->
 </locale>

--- a/plugins/metadata/mods34/locale/ru_RU/locale.xml
+++ b/plugins/metadata/mods34/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<!-- плагин -->
 	<message key="plugins.metadata.mods34.displayName">Метаданные MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Реализует схемы и адаптеры приложений MODS 3.4.</message>

--- a/plugins/metadata/mods34/locale/sr_SR/locale.xml
+++ b/plugins/metadata/mods34/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">MODS 3.4 meta-data</message>
 	<message key="plugins.metadata.mods34.description">Dodaje MODS 3.4 šeme i adaptere aplikacije.</message>

--- a/plugins/metadata/mods34/locale/tr_TR/locale.xml
+++ b/plugins/metadata/mods34/locale/tr_TR/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">MODS 3.4 Üst Veri</message>
 	<message key="plugins.metadata.mods34.description">MODS 3.4 şemaları ve uygulama adaptörlerine katkıda bulunun.</message>

--- a/plugins/metadata/mods34/locale/uk_UA/locale.xml
+++ b/plugins/metadata/mods34/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Метадані MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Підтримка схем та шаблонів MODS 3.4.</message>

--- a/plugins/metadata/mods34/locale/zh_CN/locale.xml
+++ b/plugins/metadata/mods34/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">MODS 3.4 元数据</message>
 	<message key="plugins.metadata.mods34.description">有助于 MODS 3.4 模式和应用配适器。</message>

--- a/plugins/metadata/nlm30/locale/da_DK/locale.xml
+++ b/plugins/metadata/nlm30/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
  
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">NLM 3.0 meta-data</message>
 	<message key="plugins.metadata.nlm30.description">Contributes NLM 3.0 schemas and application adapters.</message>

--- a/plugins/metadata/nlm30/locale/fr_CA/locale.xml
+++ b/plugins/metadata/nlm30/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Métadonnées NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Met à disposition des schémas et des logiciels d'adaptation NLM 3.0.</message>

--- a/plugins/metadata/nlm30/locale/fr_FR/locale.xml
+++ b/plugins/metadata/nlm30/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Métadonnées NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Met à disposition des schémas et des logiciels d'adaptation NLM 3.0.</message>

--- a/plugins/metadata/nlm30/locale/id_ID/locale.xml
+++ b/plugins/metadata/nlm30/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Metadata NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Berkontribusi terhadap dan adapter aplikasi NLM 3.0.</message>

--- a/plugins/metadata/nlm30/locale/pt_BR/locale.xml
+++ b/plugins/metadata/nlm30/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Metadados NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Contribui com esquemas NLM 3.0 e adaptadores de aplicação.</message>

--- a/plugins/metadata/nlm30/locale/pt_PT/locale.xml
+++ b/plugins/metadata/nlm30/locale/pt_PT/locale.xml
@@ -8,8 +8,8 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
  
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 </locale>

--- a/plugins/metadata/nlm30/locale/ru_RU/locale.xml
+++ b/plugins/metadata/nlm30/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<!-- плагин -->
 	<message key="plugins.metadata.nlm30.displayName">Метаданные NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Реализует схемы и адаптеры приложений NLM 3.0.</message>

--- a/plugins/metadata/nlm30/locale/sr_SR/locale.xml
+++ b/plugins/metadata/nlm30/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">NLM 3.0 meta-data</message>
 	<message key="plugins.metadata.nlm30.description">Dodaje NLM 3.0 šeme i adaptere aplikacije.</message>

--- a/plugins/metadata/nlm30/locale/tr_TR/locale.xml
+++ b/plugins/metadata/nlm30/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.metadata.nlm30.displayName">NLM 3.0 Üst Veri</message>
 	<message key="plugins.metadata.nlm30.citationAdapter.displayName">NLM 3.0 Atıf Adaptörü</message>
 	<message key="plugins.metadata.nlm30.description">NLM 3.0 şema ve uygulama adaptörü destekçisi</message>

--- a/plugins/metadata/nlm30/locale/uk_UA/locale.xml
+++ b/plugins/metadata/nlm30/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings for the uk_UA locale.
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Метадані NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Підтримка схем та шаблонів NLM 3.0.</message>

--- a/plugins/metadata/nlm30/locale/zh_CN/locale.xml
+++ b/plugins/metadata/nlm30/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
  
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">NLM 3.0 元数据</message>
 	<message key="plugins.metadata.nlm30.description">有助于NLM 3.0 模式 和应用配适器。</message>

--- a/plugins/metadata/openurl10/locale/da_DK/locale.xml
+++ b/plugins/metadata/openurl10/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.metadata.openurl10.displayName">OpenURL 1.0 meta-data</message>
 	<message key="plugins.metadata.openurl10.description">Leverer OpenURL 1.0 tilpasnings-skemaer og –applikationer.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/es_ES/locale.xml
+++ b/plugins/metadata/openurl10/locale/es_ES/locale.xml
@@ -12,6 +12,6 @@
   * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.metadata.openurl10.displayName">Metadatos OpenURL 1.0</message>
+<locale name="es_ES" full_name="Español (España)">Metadatos OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Contribuye con los esquemas y adaptadores de aplicación de OpenURL 1.0.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/fr_CA/locale.xml
+++ b/plugins/metadata/openurl10/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.metadata.openurl10.displayName">Métadonnées OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Met à disposition des schémas et des logiciels d'adaptation OpenURL 1.0</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/fr_FR/locale.xml
+++ b/plugins/metadata/openurl10/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.metadata.openurl10.displayName">Métadonnées OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Met à disposition des schémas et des logiciels d'adaptation OpenURL 1.0</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/id_ID/locale.xml
+++ b/plugins/metadata/openurl10/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.metadata.openurl10.displayName">Metadata OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Berkontribusi terhadap skema dan adapter aplikasi OpenURL 1.0.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/pt_BR/locale.xml
+++ b/plugins/metadata/openurl10/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.metadata.openurl10.displayName">Metadados OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Contribui com esquemas OpenURL 1.0 e adaptadores de aplicação.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/pt_PT/locale.xml
+++ b/plugins/metadata/openurl10/locale/pt_PT/locale.xml
@@ -8,8 +8,8 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 </locale>

--- a/plugins/metadata/openurl10/locale/ru_RU/locale.xml
+++ b/plugins/metadata/openurl10/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.metadata.openurl10.displayName">Метаданные OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Реализует схемы и адаптеры приложений OpenURL 1.0.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/sr_SR/locale.xml
+++ b/plugins/metadata/openurl10/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.metadata.openurl10.displayName">OpenURL 1.0 meta-data</message>
 	<message key="plugins.metadata.openurl10.description">Dodaje OpenURL 1.0 šeme i adaptere aplikacije.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/tr_TR/locale.xml
+++ b/plugins/metadata/openurl10/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.metadata.openurl10.displayName">OpenURL 1.0 Üst Veri</message>
 	<message key="plugins.metadata.openurl10.description">OpenURL 1.0 şemaları ve uygulama adaptörlerine katkıda bulunur.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/uk_UA/locale.xml
+++ b/plugins/metadata/openurl10/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.metadata.openurl10.displayName">Метадані OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Підтримка схем та шаблонів OpenURL 1.0.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/zh_CN/locale.xml
+++ b/plugins/metadata/openurl10/locale/zh_CN/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.metadata.openurl10.displayName">OpenURL 1.0 元数据</message>
 	<message key="plugins.metadata.openurl10.description">有助于 OpenURL 1.0 模式和应用配适器。</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/da_DK/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/da_DK/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
  
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Metadata Format</message>
 	<message key="plugins.oaiMetadata.dc.description">Strukturerer metadata i overensstemmelse med Dublin Core-formatet.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/el_GR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/el_GR/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
  
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Σχήμα Μεταδεδομένων</message>
 	<message key="plugins.oaiMetadata.dc.description">Μορφοποεί τα μεταδεδομένα ώστε να είναι συμβατά με την μορφή DC.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/es_ES/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/es_ES/locale.xml
@@ -13,6 +13,6 @@
   *
   -->
  
-<locale name="es_ES" full_name="Español (España)">	<message key="plugins.oaiMetadata.dc.displayName">Formato de metadatos DC</message>
+<locale name="es_ES" full_name="Español (España)">Formato de metadatos DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Estructura los metadatos de una manera consistente con el formato Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/fa_IR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/fa_IR/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
  
-<locale name="fa_IR" full_name="Persian">
+<locale name="fa_IR" full_name="فارسی">
 	<message key="plugins.oaiMetadata.dc.displayName">فرمت متاداده دی سی</message>
 	<message key="plugins.oaiMetadata.dc.description">ساختار متاداده باید با فرمت دوبلین کور سازگار باشد</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/fr_CA/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/fr_CA/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.oaiMetadata.dc.displayName">Format de métadonnées DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Structure les métadonnées afin de les rendre conformes au format Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/fr_FR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/fr_FR/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.oaiMetadata.dc.displayName">Format de métadonnées DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Structure les métadonnées afin de les rendre conformes au format Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/id_ID/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/id_ID/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   *
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.oaiMetadata.dc.displayName">Format Metadata DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Struktur metadata yang konsisten dengan format Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/pt_PT/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/pt_PT/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
  
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.oaiMetadata.dc.displayName">Formato Meta-dados DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Estrutura os meta-dados de modo a serem consistentes com o formato Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/ro_RO/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/ro_RO/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   *
   -->
  
-<locale name="ro_RO" full_name="Română">
+<locale name="ro_RO" full_name="Limba Română">
 	<message key="plugins.oaiMetadata.dc.displayName">Formant de metadate DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Structurează metadatele într-un mod conform cu formatul Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/ru_RU/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.oaiMetadata.dc.displayName">Формат метаданных DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Структурирует метаданные таким образом, что они соответствуют формату Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/sr_SR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/sr_SR/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Metadata Format</message>
 	<message key="plugins.oaiMetadata.dc.description">Struktuira metapodatke tako da su u skladu sa Dublin Core formatom.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/tr_TR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Üst Veri Biçimi</message>
 	<message key="plugins.oaiMetadata.dc.description">Üst veri yapısı bir bakıma Dublin Core biçimi ile tutarlı olmanın yoludur.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/uk_UA/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/uk_UA/locale.xml
@@ -8,13 +8,13 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
        <message key="plugins.oaiMetadata.dc.displayName">Формат метаданих Дублинського ядра (DC)</message>
        <message key="plugins.oaiMetadata.dc.description">Модуль структурує метадані у формат метаданих Дублинського ядра (Dublin Core).</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/zh_CN/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/zh_CN/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   *
   -->
  
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.oaiMetadata.dc.displayName">DC 元数据格式</message>
 	<message key="plugins.oaiMetadata.dc.description">Structures 元数据在某种程度上与Dublin Core格式一致</message>
 </locale>


### PR DESCRIPTION
All locales (translations) are now named in their language. Following https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes.

This also addresses pkp/pkp-lib#765. 