### PR TITLE
Standardized locale names

### DIFF
--- a/locale/ca_ES/admin.xml
+++ b/locale/ca_ES/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ca_ES (Catalan) locale.
+  * Localization strings for the ca_ES (Català) locale.
   *
   -->
 

--- a/locale/ca_ES/common.xml
+++ b/locale/ca_ES/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ca_ES (Catalan) locale.
+  * Localization strings for the ca_ES (Català) locale.
   *
   -->
 

--- a/locale/ca_ES/installer.xml
+++ b/locale/ca_ES/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ca_ES (Catalan) locale.
+  * Localization strings for the ca_ES (Català) locale.
   *
   -->
 

--- a/locale/ca_ES/manager.xml
+++ b/locale/ca_ES/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ca_ES (Catalan) locale.
+  * Localization strings for the ca_ES (Català) locale.
   *
   -->
 

--- a/locale/ca_ES/reader.xml
+++ b/locale/ca_ES/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ca_ES (Catalan) locale.
+  * Localization strings for the ca_ES (Català) locale.
   *
   -->
 

--- a/locale/ca_ES/submission.xml
+++ b/locale/ca_ES/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ca_ES (Catalan) locale.
+  * Localization strings for the ca_ES (Català) locale.
   *
   -->
 

--- a/locale/ca_ES/user.xml
+++ b/locale/ca_ES/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ca_ES (Catalan) locale.
+  * Localization strings for the ca_ES (Català) locale.
   *
   -->
 

--- a/locale/cs_CZ/admin.xml
+++ b/locale/cs_CZ/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by František Chmelik, frantisek.chmelik 'at' upol.cz
   * Corrections, migration to the OCS 2.3.x by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *

--- a/locale/cs_CZ/common.xml
+++ b/locale/cs_CZ/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by František Chmelik, frantisek.chmelik 'at' upol.cz
   * Corrections, migration to the OCS 2.3.x by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *

--- a/locale/cs_CZ/grid.xml
+++ b/locale/cs_CZ/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *
   -->

--- a/locale/cs_CZ/installer.xml
+++ b/locale/cs_CZ/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by František Chmelik, frantisek.chmelik 'at' upol.cz
   * Corrections, migration to the OCS 2.3.x by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *

--- a/locale/cs_CZ/manager.xml
+++ b/locale/cs_CZ/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by František Chmelik, frantisek.chmelik 'at' upol.cz
   * Corrections, migration to the OCS 2.3.x by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *

--- a/locale/cs_CZ/reader.xml
+++ b/locale/cs_CZ/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by František Chmelik, frantisek.chmelik 'at' upol.cz
   * Corrections, migration to the OCS 2.3.x by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *

--- a/locale/cs_CZ/submission.xml
+++ b/locale/cs_CZ/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by František Chmelik, frantisek.chmelik 'at' upol.cz
   * Corrections, migration to the OCS 2.3.x by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *

--- a/locale/cs_CZ/user.xml
+++ b/locale/cs_CZ/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by František Chmelik, frantisek.chmelik 'at' upol.cz
   * Corrections, migration to the OCS 2.3.x by Ivo Vesely and Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *

--- a/locale/da_DK/admin.xml
+++ b/locale/da_DK/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/common.xml
+++ b/locale/da_DK/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/grid.xml
+++ b/locale/da_DK/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/installer.xml
+++ b/locale/da_DK/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/manager.xml
+++ b/locale/da_DK/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/reader.xml
+++ b/locale/da_DK/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/submission.xml
+++ b/locale/da_DK/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/da_DK/user.xml
+++ b/locale/da_DK/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
 

--- a/locale/de_DE/default.xml
+++ b/locale/de_DE/default.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE locale SYSTEM "../../dtd/locale.dtd">
 
 <!--
-  * locale/en_US/default.xml
+  * locale/de_DE/default.xml
   *
   * Copyright (c) 2014-2015 Simon Fraser University Library
   * Copyright (c) 2003-2015 John Willinsky

--- a/locale/el_GR/admin.xml
+++ b/locale/el_GR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/common.xml
+++ b/locale/el_GR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/grid.xml
+++ b/locale/el_GR/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/installer.xml
+++ b/locale/el_GR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/manager.xml
+++ b/locale/el_GR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/reader.xml
+++ b/locale/el_GR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/el_GR/reviewer.xml
+++ b/locale/el_GR/reviewer.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="reviewer.submission.reviewerFiles">Αρχεία Αξιολογητών</message>
 </locale>
 

--- a/locale/el_GR/submission.xml
+++ b/locale/el_GR/submission.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="submission.agencies">ΦορείςΓραφεία</message>
 	<message key="submission.abstractViews">Προβολές Περίληψης</message>
 	<message key="submission.accepted">Δεκτό</message>

--- a/locale/el_GR/user.xml
+++ b/locale/el_GR/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
 

--- a/locale/es_ES/default.xml
+++ b/locale/es_ES/default.xml
@@ -11,7 +11,7 @@
   * Localization strings for default settings for setup items.
   -->
 
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<!-- Group defaults -->
 	<message key="default.groups.name.siteAdmin">Administradores del sitio</message>
 	<message key="default.groups.plural.siteAdmin">Administradores del sitio</message>

--- a/locale/eu_ES/admin.xml
+++ b/locale/eu_ES/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/common.xml
+++ b/locale/eu_ES/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/installer.xml
+++ b/locale/eu_ES/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/manager.xml
+++ b/locale/eu_ES/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/reader.xml
+++ b/locale/eu_ES/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/submission.xml
+++ b/locale/eu_ES/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/eu_ES/user.xml
+++ b/locale/eu_ES/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
 

--- a/locale/fa_IR/admin.xml
+++ b/locale/fa_IR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/common.xml
+++ b/locale/fa_IR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/installer.xml
+++ b/locale/fa_IR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/manager.xml
+++ b/locale/fa_IR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/reader.xml
+++ b/locale/fa_IR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/submission.xml
+++ b/locale/fa_IR/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/fa_IR/user.xml
+++ b/locale/fa_IR/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
 

--- a/locale/gl_ES/admin.xml
+++ b/locale/gl_ES/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. Para completar a información  cómpre ver o arquivo docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/common.xml
+++ b/locale/gl_ES/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. Para completar a información  cómpre ver o arquivo docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/installer.xml
+++ b/locale/gl_ES/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/manager.xml
+++ b/locale/gl_ES/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/reader.xml
+++ b/locale/gl_ES/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/submission.xml
+++ b/locale/gl_ES/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/gl_ES/user.xml
+++ b/locale/gl_ES/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the gl_ES (Galego (Galiza)) locale.
+  * Localization strings for the gl_ES (Galego) locale.
   *
   -->
 

--- a/locale/ml_IN/admin.xml
+++ b/locale/ml_IN/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/common.xml
+++ b/locale/ml_IN/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/grid.xml
+++ b/locale/ml_IN/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/installer.xml
+++ b/locale/ml_IN/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/manager.xml
+++ b/locale/ml_IN/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/reader.xml
+++ b/locale/ml_IN/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   *
   -->
 

--- a/locale/ml_IN/submission.xml
+++ b/locale/ml_IN/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   -->
 
 <locale name="ml_IN" full_name = "Malayalam">

--- a/locale/ml_IN/user.xml
+++ b/locale/ml_IN/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ml_IN (Malayalam) locale.
+  * Localization strings for the ml_IN (മലയാളം) locale.
   -->
 
 <locale name="ml_IN" full_name = "Malayalam">

--- a/locale/nb_NO/admin.xml
+++ b/locale/nb_NO/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
 

--- a/locale/nb_NO/common.xml
+++ b/locale/nb_NO/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
 

--- a/locale/nb_NO/installer.xml
+++ b/locale/nb_NO/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
 

--- a/locale/nb_NO/manager.xml
+++ b/locale/nb_NO/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
 

--- a/locale/nb_NO/reader.xml
+++ b/locale/nb_NO/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
 

--- a/locale/nb_NO/submission.xml
+++ b/locale/nb_NO/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
 

--- a/locale/nb_NO/user.xml
+++ b/locale/nb_NO/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
 

--- a/locale/pt_PT/admin.xml
+++ b/locale/pt_PT/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/common.xml
+++ b/locale/pt_PT/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/installer.xml
+++ b/locale/pt_PT/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/manager.xml
+++ b/locale/pt_PT/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/reader.xml
+++ b/locale/pt_PT/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/submission.xml
+++ b/locale/pt_PT/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/pt_PT/user.xml
+++ b/locale/pt_PT/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
 

--- a/locale/ro_RO/admin.xml
+++ b/locale/ro_RO/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/common.xml
+++ b/locale/ro_RO/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ro_RO/countries.xml
+++ b/locale/ro_RO/countries.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/currencies.xml
+++ b/locale/ro_RO/currencies.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/grid.xml
+++ b/locale/ro_RO/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ro_RO/installer.xml
+++ b/locale/ro_RO/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ro_RO/manager.xml
+++ b/locale/ro_RO/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/reader.xml
+++ b/locale/ro_RO/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/submission.xml
+++ b/locale/ro_RO/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie. 
   *
   -->

--- a/locale/ro_RO/user.xml
+++ b/locale/ro_RO/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   * Provided by Constantinescu Nicolaie.
   *
   -->

--- a/locale/ru_RU/admin.xml
+++ b/locale/ru_RU/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
 

--- a/locale/ru_RU/common.xml
+++ b/locale/ru_RU/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
 

--- a/locale/ru_RU/installer.xml
+++ b/locale/ru_RU/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2009 Konstantin L. Metlov
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
 

--- a/locale/ru_RU/manager.xml
+++ b/locale/ru_RU/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
 

--- a/locale/ru_RU/reader.xml
+++ b/locale/ru_RU/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
 

--- a/locale/ru_RU/submission.xml
+++ b/locale/ru_RU/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
 

--- a/locale/ru_RU/user.xml
+++ b/locale/ru_RU/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
 

--- a/locale/sr_SR/admin.xml
+++ b/locale/sr_SR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/common.xml
+++ b/locale/sr_SR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/countries.xml
+++ b/locale/sr_SR/countries.xml
@@ -9,7 +9,7 @@
   *
   * Localized list of countries.
   *
-  * Localization strings for the sr_SR (Srpski) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   * Translation: Igor Lekić igor.lekic@ff.uns.ac.rs
   *

--- a/locale/sr_SR/currencies.xml
+++ b/locale/sr_SR/currencies.xml
@@ -10,7 +10,7 @@
   *
   * Localized list of currencies.
   *
-  * Localization strings for the sr_SR (Srpski) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   * Translation: Igor Lekić igor.lekic@ff.uns.ac.rs
   *

--- a/locale/sr_SR/grid.xml
+++ b/locale/sr_SR/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/installer.xml
+++ b/locale/sr_SR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/manager.xml
+++ b/locale/sr_SR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/reader.xml
+++ b/locale/sr_SR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
 

--- a/locale/sr_SR/submission.xml
+++ b/locale/sr_SR/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   -->
 
 <locale name="sr_SR" full_name = "Serbian">

--- a/locale/sr_SR/user.xml
+++ b/locale/sr_SR/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   -->
 
 <locale name="sr_SR" full_name = "Serbian">

--- a/locale/sv_SE/admin.xml
+++ b/locale/sv_SE/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/common.xml
+++ b/locale/sv_SE/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/installer.xml
+++ b/locale/sv_SE/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/manager.xml
+++ b/locale/sv_SE/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/reader.xml
+++ b/locale/sv_SE/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/submission.xml
+++ b/locale/sv_SE/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/sv_SE/user.xml
+++ b/locale/sv_SE/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sv_SE (Swedish) locale.
+  * Localization strings for the sv_SE (Svenska) locale.
   *
   -->
 

--- a/locale/tr_TR/admin.xml
+++ b/locale/tr_TR/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/common.xml
+++ b/locale/tr_TR/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/grid.xml
+++ b/locale/tr_TR/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Turkish) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/installer.xml
+++ b/locale/tr_TR/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/manager.xml
+++ b/locale/tr_TR/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/reader.xml
+++ b/locale/tr_TR/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
 

--- a/locale/tr_TR/submission.xml
+++ b/locale/tr_TR/submission.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2014-2015 Simon Fraser University Library
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   -->
 
 <locale name="tr_TR" full_name = "Türkiye Türkçesi">

--- a/locale/tr_TR/user.xml
+++ b/locale/tr_TR/user.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2014-2015 Simon Fraser University Library
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   -->
 
 <locale name="tr_TR" full_name = "Türkiye Türkçesi">

--- a/locale/uk_UA/admin.xml
+++ b/locale/uk_UA/admin.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/common.xml
+++ b/locale/uk_UA/common.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/countries.xml
+++ b/locale/uk_UA/countries.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2010-2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/currencies.xml
+++ b/locale/uk_UA/currencies.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2010-2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/grid.xml
+++ b/locale/uk_UA/grid.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/installer.xml
+++ b/locale/uk_UA/installer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/languages.xml
+++ b/locale/uk_UA/languages.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2010-2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/manager.xml
+++ b/locale/uk_UA/manager.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/reader.xml
+++ b/locale/uk_UA/reader.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/submission.xml
+++ b/locale/uk_UA/submission.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/locale/uk_UA/user.xml
+++ b/locale/uk_UA/user.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine

--- a/plugins/citationLookup/crossref/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/crossref/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationLookup.crossref.displayName">Konektor Database CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Koneksi ke database bibliografi CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/crossref/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationLookup.crossref.displayName">Connector de base de dados CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Conecta à base de dados bibliográfica CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/crossref/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationLookup.crossref.displayName">CrossRef Database Connector</message>
 	<message key="plugins.citationLookup.crossref.description">Povezuje CrossRef bibliografsku bazu podataka.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/crossref/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationLookup.crossref.displayName">CrossRef Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.crossref.description">CrossRef bibliyografik veri tabanına bağlan.</message>
 </locale>

--- a/plugins/citationLookup/crossref/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/crossref/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationLookup.crossref.displayName">Шлюз бази даних CrossRef</message>
 	<message key="plugins.citationLookup.crossref.description">Забезпечує зв'язок з бібліографічною базою даних CrossRef.</message>
 </locale>

--- a/plugins/citationLookup/isbndb/locale/es_ES/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/es_ES/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the es_ES (Español) locale.
+  * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Conector con la base de datos ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Conecta con la base de datos bibliográfica de ISBNdb.</message>

--- a/plugins/citationLookup/isbndb/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Konektor Database ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Koneksi ke database bibliografi ISBNdb.</message>

--- a/plugins/citationLookup/isbndb/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Conector à base de dados ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Conecta à base de dados bibliográfica ISBNdb.</message>

--- a/plugins/citationLookup/isbndb/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">ISBNdb Database Connector</message>
 	<message key="plugins.citationLookup.isbndb.description">Povezuje se na ISBNdb bibliografsku bazu podataka.</message>

--- a/plugins/citationLookup/isbndb/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">ISBNdb Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.isbndb.description">ISBNdb bibliyografik veri tabanına bağlan.</message>

--- a/plugins/citationLookup/isbndb/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.citationLookup.isbndb.displayName">Шлюз бази даних ISBNdb</message>
 	<message key="plugins.citationLookup.isbndb.description">Забезпечує зв'язок з бібліографічною базою даних ISBNdb.</message>

--- a/plugins/citationLookup/pubmed/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationLookup.pubmed.displayName">Konektor database PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Koneksi ke database bibliografi PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationLookup.pubmed.displayName">Conector à base de dados PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Conecta à base de dados bibliográfica do PubMed.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationLookup.pubmed.displayName">PubMed Database Connector</message>
 	<message key="plugins.citationLookup.pubmed.description">Povezuje se na PubMed bibliografsku bazu podataka.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationLookup.pubmed.displayName">PubMed Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.pubmed.description">PubMed bibliyografik veri tabanına bağlan.</message>
 </locale>

--- a/plugins/citationLookup/pubmed/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationLookup.pubmed.displayName">Шлюз бази даних PubMed</message>
 	<message key="plugins.citationLookup.pubmed.description">Забезпечує зв'язок з бібліографічною базою даних PubMed.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/id_ID/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationLookup.worldcat.displayName">Konektor database WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Koneksi ke database bibliografi WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/pt_BR/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationLookup.worldcat.displayName">Conector de base de dados WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Conecta à base bibliográfica WorldCat.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/sr_SR/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationLookup.worldcat.displayName">WorldCat Database Connector</message>
 	<message key="plugins.citationLookup.worldcat.description">Povezuje se na  WorldCat bibliografsku bazu podataka.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/tr_TR/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationLookup.worldcat.displayName">WorldCat Veri Tabanı Bağlayıcısı</message>
 	<message key="plugins.citationLookup.worldcat.description">WorldCat bibliyografik veri tabanına bağlan.</message>
 </locale>

--- a/plugins/citationLookup/worldcat/locale/uk_UA/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationLookup.worldcat.displayName">Шлюз бази даних WorldCat</message>
 	<message key="plugins.citationLookup.worldcat.description">Забезпечує зв'язок з бібліографічною базою даних WorldCat.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/de_DE/locale.xml
+++ b/plugins/citationOutput/abnt/locale/de_DE/locale.xml
@@ -11,7 +11,7 @@
   * Please contact Marco Tullney, marco.tullney@fu-berlin.de, with any questions regarding this translation.
   -->
 
-<locale name="de_DE" full_name="Deutsch (Deutschland))">
+<locale name="de_DE" full_name="Deutsch (Deutschland)">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT-Zitationsstil</message>
 	<message key="plugins.citationOutput.abnt.description">Stellt den ABNT-Zitationsstil bereit.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/abnt/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.abnt.displayName">Gaya sitiran ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Implementasikan gaya sitiran ABNT</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/abnt/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.abnt.displayName">Estilo de citação ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Implementa o estilo de citação ABNT.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/abnt/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT Citation Style</message>
 	<message key="plugins.citationOutput.abnt.description">Uvodi ABNT stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/abnt/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.abnt.displayName">ABNT Atıf Sitili</message>
 	<message key="plugins.citationOutput.abnt.description">ABNT atıf sitilini uygular.</message>
 </locale>

--- a/plugins/citationOutput/abnt/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/abnt/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.abnt.displayName">Формат цитат ABNT</message>
 	<message key="plugins.citationOutput.abnt.description">Дозволяє використання формату цитат ABNT.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/apa/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.apa.displayName">Gaya sitiran APA</message>
 	<message key="plugins.citationOutput.apa.description">Implementasikan gaya sitiran APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/apa/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.apa.displayName">Estilo de citação APA</message>
 	<message key="plugins.citationOutput.apa.description">Implementa o estilo de citação APA.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/apa/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.apa.displayName">APA Citation Style</message>
 	<message key="plugins.citationOutput.apa.description">Uvodi APA stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/apa/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.apa.displayName">APA Atıf Biçimi</message>
 	<message key="plugins.citationOutput.apa.description">APA atıf biçimini uygular.</message>
 </locale>

--- a/plugins/citationOutput/apa/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/apa/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.apa.displayName">Формат цитат APA</message>
 	<message key="plugins.citationOutput.apa.description">Дозволяє використання формату цитат APA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/mla/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.mla.displayName">Gaya sitiran MLA</message>
 	<message key="plugins.citationOutput.mla.description">Implementasikan gaya sitiran MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/mla/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.mla.displayName">Estilo de citação MLA</message>
 	<message key="plugins.citationOutput.mla.description">Implementa o estilo de citação MLA.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/mla/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.mla.displayName">MLA Citation Style</message>
 	<message key="plugins.citationOutput.mla.description">Uvodi MLA stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/mla/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.mla.displayName">MLA Atıf Biçimi</message>
 	<message key="plugins.citationOutput.mla.description">MLA atıf biçimini uygular.</message>
 </locale>

--- a/plugins/citationOutput/mla/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/mla/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.mla.displayName">Формат цитат MLA</message>
 	<message key="plugins.citationOutput.mla.description">Дозволяє використання формату цитат MLA.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/id_ID/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationOutput.vancouver.displayName">Gaya sitiran Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Implementasikan gaya sitiran Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/pt_BR/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationOutput.vancouver.displayName">Estilo de citação Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Implementa o estilo de citação Vancouver.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/sr_SR/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationOutput.vancouver.displayName">Vancouver Citation Style</message>
 	<message key="plugins.citationOutput.vancouver.description">Uvodi Vancouver stil citiranja.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/tr_TR/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationOutput.vancouver.displayName">Vancouver Atıf Biçimi</message>
 	<message key="plugins.citationOutput.vancouver.description">Vancouver atıf biçimini uygular.</message>
 </locale>

--- a/plugins/citationOutput/vancouver/locale/uk_UA/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationOutput.vancouver.displayName">Формат цитат Vancouver</message>
 	<message key="plugins.citationOutput.vancouver.description">Дозволяє використання формату цитат Vancouver.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/id_ID/locale.xml
+++ b/plugins/citationParser/freecite/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.freecite.displayName">Ekstraksi Sitiran FreeCite Citation Extractor</message>
 	<message key="plugins.citationParser.freecite.description">Ekstrak field dari teks sitasi biasa melalui layanan FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/freecite/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.freecite.displayName">Extrator de citação FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Extrai campos de citações em texto puro por meio do serviço FreeCite.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/freecite/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.freecite.displayName">FreeCite Citation Extractor</message>
 	<message key="plugins.citationParser.freecite.description">Izdvaja polja iz teksta citata putem FreeCite servisa.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/freecite/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.freecite.displayName">FreeCite Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.freecite.description">FreeCite servisi üzerinden düz metin alıntıları alanlarını ayırır.</message>
 </locale>

--- a/plugins/citationParser/freecite/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/freecite/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.freecite.displayName">Синтаксичний аналізатор цитат FreeCite</message>
 	<message key="plugins.citationParser.freecite.description">Аналізує поля неструктурованих текстових цитат через службу FreeCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/id_ID/locale.xml
+++ b/plugins/citationParser/paracite/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.paracite.displayName">Ekstraksi Sitiran ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Ekstrak field dari teks sitasi biasa melalui layanan ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/paracite/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.paracite.displayName">Extrator de citação ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Extrai campos de citações em texto puro por meio do serviço ParaCite.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/paracite/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.paracite.displayName">ParaCite Citation Extractor</message>
 	<message key="plugins.citationParser.paracite.description">Izdvaja polja iz teksta citata putem ParaCite servisa.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/paracite/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.paracite.displayName">ParaCite Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.paracite.description">ParaCite servisi üzerinden düz metin atıf alanlarını ayıklar.</message>
 </locale>

--- a/plugins/citationParser/paracite/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/paracite/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.paracite.displayName">Синтаксичний аналізатор цитат ParaCite</message>
 	<message key="plugins.citationParser.paracite.description">Аналізує поля неструктурованих текстових цитат через службу ParaCite.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/id_ID/locale.xml
+++ b/plugins/citationParser/parscit/locale/id_ID/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.parscit.displayName">Ekstraksi Sitiran ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Ekstrak field dari teks sitasi biasa melalui layanan ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/parscit/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.parscit.displayName">Extrator de citação ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Extrai campos de citações de texto puro por meio do serviço ParsCit.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/parscit/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.parscit.displayName">ParsCit Citation Extractor</message>
 	<message key="plugins.citationParser.parscit.description">Izdvaja polja iz teksta citata putem ParsCit servisa.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/parscit/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.parscit.displayName">ParsCit Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.parscit.description">ParsCit servisi üzerinden düz metin atıf alanlarını ayırır.</message>
 </locale>

--- a/plugins/citationParser/parscit/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/parscit/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.parscit.displayName">Синтаксичний аналізатор цитат ParsCit</message>
 	<message key="plugins.citationParser.parscit.description">Аналізує поля неструктурованих текстових цитат через службу ParsCit.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/id_ID/locale.xml
+++ b/plugins/citationParser/regex/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.citationParser.regex.displayName">Ekstraksi Sitiran Regular Expressions</message>
 	<message key="plugins.citationParser.regex.description">Ekstrak field dari teks sitasi biasa melalui layanan regular expressions.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/pt_BR/locale.xml
+++ b/plugins/citationParser/regex/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.citationParser.regex.displayName">Extração de citações por Expressões Regulares</message>
 	<message key="plugins.citationParser.regex.description">Extrai campos de citações de texto puro por meio de expressões regulares.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/sr_SR/locale.xml
+++ b/plugins/citationParser/regex/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.citationParser.regex.displayName">Regular Expressions Citation Extractor</message>
 	<message key="plugins.citationParser.regex.description">Izdvaja polja iz teksta citata preko ustaljenih izraza.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/tr_TR/locale.xml
+++ b/plugins/citationParser/regex/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.citationParser.regex.displayName">Düzenli İfadeler Atıf Ayırıcı</message>
 	<message key="plugins.citationParser.regex.description">Düzenli ifadeler yoluyla düz metin alıntıları alanlanlarınıı ayıklar.</message>
 </locale>

--- a/plugins/citationParser/regex/locale/uk_UA/locale.xml
+++ b/plugins/citationParser/regex/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.citationParser.regex.displayName">Аналізатор регулярних виразів</message>
 	<message key="plugins.citationParser.regex.description">Аналізує поля неструктурованих текстових цитат за допомогою регулярних виразів.</message>
 </locale>

--- a/plugins/generic/acron/locale/cs_CZ/locale.xml
+++ b/plugins/generic/acron/locale/cs_CZ/locale.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   * Translated by Petr Petyovsky (petyovsky 'at' feec.vutbr.cz)
   *
   -->

--- a/plugins/generic/acron/locale/es_ES/locale.xml
+++ b/plugins/generic/acron/locale/es_ES/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the es_ES (Español) locale.
+  * Localization strings for the es_ES (Español (España)) locale.
   *
   -->
  
-<locale name="es_ES" full_name="España Castellano">
+<locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.generic.acron.name">Acron Plugin</message>
 	<message key="plugins.generic.acron.description"><![CDATA[Este plugin pretende reducir la dependencia de OCS de las tareas periódicas de programación tales como 'cron.']]></message>
 

--- a/plugins/generic/acron/locale/eu_ES/locale.xml
+++ b/plugins/generic/acron/locale/eu_ES/locale.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the eu_ES (Basque (Euskara)) locale.
+  * Localization strings for the eu_ES (Euskara) locale.
   *
   -->
  

--- a/plugins/generic/acron/locale/it_IT/locale.xml
+++ b/plugins/generic/acron/locale/it_IT/locale.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the it_IT (U.S. English) locale.
+  * Localization strings for the it_IT (Italiano) locale.
   *
   -->
  

--- a/plugins/generic/acron/locale/pt_PT/locale.xml
+++ b/plugins/generic/acron/locale/pt_PT/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.generic.acron.name">Plugin Acron</message>
 	<message key="plugins.generic.acron.description">Este plugin tem por objectivo reduzir a dependência do OCS em ferramentas de agendamento periódico, tais como a 'cron.'</message>
 

--- a/plugins/generic/acron/locale/ru_RU/locale.xml
+++ b/plugins/generic/acron/locale/ru_RU/locale.xml
@@ -8,12 +8,12 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   *
   -->
  
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.acron.name">Плагин «Acron»</message>
 	<message key="plugins.generic.acron.description"><![CDATA[Этот плагин пытается уменьшить зависимость OCS от инструментов периодического запуска по расписанию, таких как cron.]]></message>
 	<message key="plugins.generic.acron.enabled">Плагин «Acron» был включен.</message>

--- a/plugins/generic/acron/locale/zh_TW/locale.xml
+++ b/plugins/generic/acron/locale/zh_TW/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_TW (正體中文) locale.
+  * Localization strings for the zh_TW (繁體中文) locale.
   *正體中文由 陳文誌 (長庚大學工業設計系) 與 莊惠茹 共同翻譯 (V1 @ 20080515)
   -->
  
-<locale name="zh_TW" full_name="正體中文">
+<locale name="zh_TW" full_name="繁體中文">
 	<message key="plugins.generic.acron.name">Acron 外掛程式</message>
 	<message key="plugins.generic.acron.description">這個外掛程式可以用來降低 OCS 系統對於周期性行事曆工具 (例如 cron)的依賴性。</message>
 

--- a/plugins/generic/usageEvent/locale/es_ES/locale.xml
+++ b/plugins/generic/usageEvent/locale/es_ES/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.generic.usageEvent.displayName">Caso de uso</message>
 	<message key="plugins.generic.usageEvent.description">Crea un "hook" que proporciona el uso de eventos en un formato definido.</message>
 </locale>

--- a/plugins/generic/usageEvent/locale/ru_RU/locale.xml
+++ b/plugins/generic/usageEvent/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
  
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.usageEvent.displayName">Плагин «Событие использования»</message>
 	<message key="plugins.generic.usageEvent.description">Это плагин создает обработчик, который выдает событие использования сайта в определенном формате.</message>
 </locale>

--- a/plugins/generic/usageStats/locale/es_ES/locale.xml
+++ b/plugins/generic/usageStats/locale/es_ES/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings
   -->
 
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.generic.usageStats.settings.logging">Opciones de acceso al registro</message>
 	<message key="plugins.generic.usageStats.settings.createLogFiles">Crear archivos de registro</message>
 	<message key="plugins.generic.usageStats.settings.createLogFiles.description">La activación de esta opción hará que el plugin crear archivos de registro de acceso dentro del directorio de archivos. Estos archivos deben ser utilizados para extraer los datos de las estadísticas de uso. Si no desea crear más archivos de registro de acceso se puede dejar esta opción desactivada y utilizar sus propios archivos de registro del servidor de acceso.</message>

--- a/plugins/generic/usageStats/locale/ru_RU/locale.xml
+++ b/plugins/generic/usageStats/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
  
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.usageStats.settings.logging">Настройки журнала доступа</message>
 	<message key="plugins.generic.usageStats.settings.createLogFiles">Создавать файлы журнала</message>
 	<message key="plugins.generic.usageStats.settings.createLogFiles.description">Активация этой настройки приведет к созданию плагином файлов журнала доступа в каталоге files. Эти файлы должны быть использованы для извлечения данных по статистике использования. Если вы не хотите создавать дополнительные файлы журнала доступа, вы можете оставить эту настройку отключенной и использовать файлы журнала доступа вашего сервера.</message>

--- a/plugins/metadata/dc11/locale/es_ES/locale.xml
+++ b/plugins/metadata/dc11/locale/es_ES/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Metadatos Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Proporciona plantillas Dublin Core 1.1 y compatibilidad de aplicaciones.</message>

--- a/plugins/metadata/dc11/locale/id_ID/locale.xml
+++ b/plugins/metadata/dc11/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Metadata Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Berkontribusi terhadap skema dan adapter aplikasi Dublin Core versi 1.1.</message>

--- a/plugins/metadata/dc11/locale/pt_BR/locale.xml
+++ b/plugins/metadata/dc11/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Metadados Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Contribui com esquemas Dublin Core versão 1.1 e adaptadores de aplicação.</message>

--- a/plugins/metadata/dc11/locale/sr_SR/locale.xml
+++ b/plugins/metadata/dc11/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Dublin Core 1.1 meta-data</message>
 	<message key="plugins.metadata.dc11.description">Dodaje Dublin Core version 1.1 šeme i adaptere aplikacije</message>

--- a/plugins/metadata/dc11/locale/tr_TR/locale.xml
+++ b/plugins/metadata/dc11/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Dublin Core 1.1 Üst Veri</message>
 	<message key="plugins.metadata.dc11.description">Dublin Core 1.1 sürüm şemaları ve uygulama adaptörlerine katkıda bulun.</message>

--- a/plugins/metadata/dc11/locale/uk_UA/locale.xml
+++ b/plugins/metadata/dc11/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.metadata.dc11.displayName">Метадані Dublin Core 1.1</message>
 	<message key="plugins.metadata.dc11.description">Підтримка схем та шаблонів Dublin Core версії 1.1.</message>

--- a/plugins/metadata/mods34/locale/es_ES/locale.xml
+++ b/plugins/metadata/mods34/locale/es_ES/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Metadatos MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Proporciona plantillas MODS 3.4 y compatibilidad de aplicaciones.</message>

--- a/plugins/metadata/mods34/locale/id_ID/locale.xml
+++ b/plugins/metadata/mods34/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Metadata MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Berkontribusi terhadap skema dan adapter aplikasi MODS 3.4.</message>

--- a/plugins/metadata/mods34/locale/pt_BR/locale.xml
+++ b/plugins/metadata/mods34/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Metadados MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Contribui com esquemas MODS 3.4 e adaptadores de aplicação.</message>

--- a/plugins/metadata/mods34/locale/sr_SR/locale.xml
+++ b/plugins/metadata/mods34/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">MODS 3.4 meta-data</message>
 	<message key="plugins.metadata.mods34.description">Dodaje MODS 3.4 šeme i adaptere aplikacije.</message>

--- a/plugins/metadata/mods34/locale/uk_UA/locale.xml
+++ b/plugins/metadata/mods34/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.metadata.mods34.displayName">Метадані MODS 3.4</message>
 	<message key="plugins.metadata.mods34.description">Підтримка схем та шаблонів MODS 3.4.</message>

--- a/plugins/metadata/nlm30/locale/es_ES/locale.xml
+++ b/plugins/metadata/nlm30/locale/es_ES/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the es_ES (Español) locale.
+  * Localization strings for the es_ES (Español (España)) locale.
   -->
  
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">NLM 3.0 meta-data</message>
 	<message key="plugins.metadata.nlm30.description">Contributes NLM 3.0 schemas and application adapters.</message>

--- a/plugins/metadata/nlm30/locale/id_ID/locale.xml
+++ b/plugins/metadata/nlm30/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Metadata NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Berkontribusi terhadap dan adapter aplikasi NLM 3.0.</message>

--- a/plugins/metadata/nlm30/locale/pt_BR/locale.xml
+++ b/plugins/metadata/nlm30/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Metadados NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Contribui com esquemas NLM 3.0 e adaptadores de aplicação.</message>

--- a/plugins/metadata/nlm30/locale/sr_SR/locale.xml
+++ b/plugins/metadata/nlm30/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">NLM 3.0 meta-data</message>
 	<message key="plugins.metadata.nlm30.description">Dodaje NLM 3.0 šeme i adaptere aplikacije.</message>

--- a/plugins/metadata/nlm30/locale/tr_TR/locale.xml
+++ b/plugins/metadata/nlm30/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.metadata.nlm30.displayName">NLM 3.0 Üst Veri</message>
 	<message key="plugins.metadata.nlm30.citationAdapter.displayName">NLM 3.0 Atıf Adaptörü</message>
 </locale>

--- a/plugins/metadata/nlm30/locale/uk_UA/locale.xml
+++ b/plugins/metadata/nlm30/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings for the uk_UA locale.
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Метадані NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Підтримка схем та шаблонів NLM 3.0.</message>

--- a/plugins/metadata/openurl10/locale/es_ES/locale.xml
+++ b/plugins/metadata/openurl10/locale/es_ES/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the es_ES (Español) locale.
+  * Localization strings for the es_ES (Español (España)) locale.
   -->
 
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.metadata.openurl10.displayName">Metadatos OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Proporciona plantillas OpenURL 1.0. y compatibilidad de aplicaciones.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/id_ID/locale.xml
+++ b/plugins/metadata/openurl10/locale/id_ID/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   -->
 
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.metadata.openurl10.displayName">Metadata OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Berkontribusi terhadap skema dan adapter aplikasi OpenURL 1.0.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/pt_BR/locale.xml
+++ b/plugins/metadata/openurl10/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.metadata.openurl10.displayName">Metadados OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Contribui com esquemas OpenURL 1.0 e adaptadores de aplicação.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/sr_SR/locale.xml
+++ b/plugins/metadata/openurl10/locale/sr_SR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.metadata.openurl10.displayName">OpenURL 1.0 meta-data</message>
 	<message key="plugins.metadata.openurl10.description">Dodaje OpenURL 1.0 šeme i adaptere aplikacije.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/tr_TR/locale.xml
+++ b/plugins/metadata/openurl10/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.metadata.openurl10.displayName">OpenURL 1.0 Üst Veri</message>
 	<message key="plugins.metadata.openurl10.description">OpenURL 1.0 şemaları ve uygulama adaptörlerine katkıda bulunur.</message>
 </locale>

--- a/plugins/metadata/openurl10/locale/uk_UA/locale.xml
+++ b/plugins/metadata/openurl10/locale/uk_UA/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
 
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
 	<message key="plugins.metadata.openurl10.displayName">Метадані OpenURL 1.0</message>
 	<message key="plugins.metadata.openurl10.description">Підтримка схем та шаблонів OpenURL 1.0.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/el_GR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/el_GR/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the el_GR (Greek) locale.
+  * Localization strings for the el_GR (ελληνικά) locale.
   *
   -->
  
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Σχήμα Μεταδεδομένων</message>
 	<message key="plugins.oaiMetadata.dc.description">Μορφοποεί τα μεταδεδομένα ώστε να είναι συμβατά με την μορφή DC.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/es_ES/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/es_ES/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the es_ES (Español) locale.
+  * Localization strings for the es_ES (Español (España)) locale.
   *
   -->
  
-<locale name="es_ES" full_name="Español">
+<locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.oaiMetadata.dc.displayName">Formato de metadatos DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Estructura los metadatos con consistencia con el formato Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/fa_IR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/fa_IR/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   *
   -->
  
-<locale name="fa_IR" full_name="Persian">
+<locale name="fa_IR" full_name="فارسی">
 	<message key="plugins.oaiMetadata.dc.displayName">فرمت متاداده دی سی</message>
 	<message key="plugins.oaiMetadata.dc.description">ساختار متاداده باید با فرمت دوبلین کور سازگار باشد</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/id_ID/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/id_ID/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   *
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.oaiMetadata.dc.displayName">Format Metadata DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Struktur metadata yang konsisten dengan format Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/pt_PT/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/pt_PT/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
  
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.oaiMetadata.dc.displayName">Formato Meta-dados DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Estrutura os meta-dados de modo a serem consistentes com o formato Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/ro_RO/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/ro_RO/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   *
   -->
  
-<locale name="ro_RO" full_name="Română">
+<locale name="ro_RO" full_name="Limba Română">
 	<message key="plugins.oaiMetadata.dc.displayName">Formant de metadate DC</message>
 	<message key="plugins.oaiMetadata.dc.description">Structurează metadatele într-un mod conform cu formatul Dublin Core.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/sr_SR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/sr_SR/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="sr_SR" full_name="Srpski">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Metadata Format</message>
 	<message key="plugins.oaiMetadata.dc.description">Struktuira metapodatke tako da su u skladu sa Dublin Core formatom.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/tr_TR/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings.
   -->
  
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Üst Veri Biçimi</message>
 	<message key="plugins.oaiMetadata.dc.description">Üst veri yapısı bir bakıma Dublin Core biçimi ile tutarlı olmanın yoludur.</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/uk_UA/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/uk_UA/locale.xml
@@ -8,13 +8,13 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
        <message key="plugins.oaiMetadata.dc.displayName">Формат метаданих Дублинського ядра (DC)</message>
        <message key="plugins.oaiMetadata.dc.description">Модуль структурує метадані у формат метаданих Дублинського ядра (Dublin Core).</message>
 </locale>

--- a/plugins/oaiMetadataFormats/dc/locale/zh_CN/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/zh_CN/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   *
   -->
  
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.oaiMetadata.dc.displayName">DC Metadata Format</message>
 	<message key="plugins.oaiMetadata.dc.description">Structures metadata in a way that is consistent with the Dublin Core format.</message>
 </locale>


### PR DESCRIPTION
All locales (translations) are now named in their language. Following https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes.

This also addresses pkp/pkp-lib#765. 