### PR TITLE
pkp/pkp-lib#794: Enable XMLCustomWriter support for XML comment nodes

### DIFF
--- a/classes/xml/XMLComment.inc.php
+++ b/classes/xml/XMLComment.inc.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @file classes/xml/XMLComment.inc.php
+ *
+ * Copyright (c) 2013-2015 Simon Fraser University Library
+ * Copyright (c) 2000-2015 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class XMLComment
+ * @ingroup xml
+ *
+ * @brief Extension of XMLNode for a simple DOM-style comment.
+ */
+
+import ('lib.pkp.classes.xml.XMLNode');
+
+class XMLComment extends XMLNode {
+
+	/**
+	 * Constructor.
+	 * @param $name element/tag name
+	 */
+	function XMLComment() {
+		$this->name = '!--';
+		$this->parent = null;
+		$this->attributes = array();
+		$this->value = null;
+		$this->children = array();
+	}
+
+	/**
+	 * @param $includeNamespace boolean
+	 * @return string
+	 */
+	function getName($includeNamespace = true) {
+		return false;
+	}
+
+	/**
+	 * @param $name string
+	 */
+	function setName($name) {
+		assert(false);
+	}
+
+	/**
+	 * @return array all attributes
+	 */
+	function getAttributes() {
+		return array();
+	}
+
+	/**
+	 * @param $name string attribute name
+	 * @return string attribute value
+	 */
+	function getAttribute($name) {
+		return null;
+	}
+
+	/**
+	 * @param $name string attribute name
+	 * @param value string attribute value
+	 */
+	function setAttribute($name, $value) {
+		assert(false);
+	}
+
+	/**
+	 * @param $attributes array
+	 */
+	function setAttributes($attributes) {
+		assert(false);
+	}
+
+	/**
+	 * @return array this node's children (XMLNode objects)
+	 */
+	function &getChildren() {
+		return array();
+	}
+
+	/**
+	 * @param $name
+	 * @param $index
+	 * @return XMLNode the ($index+1)th child matching the specified name
+	 */
+	function &getChildByName($name, $index = 0) {
+		$child = null;
+		return $child;
+	}
+
+	/**
+	 * Get the value of a child node.
+	 * @param $name String name of node
+	 * @param $index Optional integer index of child node to find
+	 * @return string
+	 */
+	function &getChildValue($name, $index = 0) {
+		$returner = null;
+		return $returner;
+	}
+
+	/**
+	 * @param $node XMLNode the child node to add
+	 */
+	function addChild(&$node) {
+		assert(false);
+	}
+}
+?>

--- a/classes/xml/XMLCustomWriter.inc.php
+++ b/classes/xml/XMLCustomWriter.inc.php
@@ -15,6 +15,7 @@
 
 
 import ('lib.pkp.classes.xml.XMLNode');
+import ('lib.pkp.classes.xml.XMLComment');
 
 class XMLCustomWriter {
 	/**
@@ -51,6 +52,17 @@ class XMLCustomWriter {
 	function &createElement(&$doc, $name) {
 		if (is_callable(array($doc, 'createElement'))) $element =& $doc->createElement($name);
 		else $element = new XMLNode($name);
+
+		return $element;
+	}
+
+	function &createComment(&$doc, $content) {
+		if (is_callable(array($doc, 'createComment'))) {
+			$element =& $doc->createComment($content);
+		} else {
+			$element = new XMLComment();
+			$element->setValue($content);
+		}
 
 		return $element;
 	}

--- a/classes/xml/XMLNode.inc.php
+++ b/classes/xml/XMLNode.inc.php
@@ -198,7 +198,9 @@ class XMLNode {
 				$value = XMLNode::xmlentities($value);
 				$out .= " $name=\"$value\"";
 			}
-			$out .= '>';
+			if ($this->name !== '!--') {
+				$out .= '>';
+			}
 		}
 		$out .= XMLNode::xmlentities($this->value, ENT_NOQUOTES);
 		foreach ($this->children as $child) {
@@ -209,7 +211,11 @@ class XMLNode {
 			}
 			$out .= $child->toXml($output);
 		}
-		if ($this->name !== null) $out .= '</' . $this->name . '>';
+		if ($this->name === '!--') {
+			$out .= '-->';
+		} else if ($this->name !== null) {
+			$out .= '</' . $this->name . '>';
+		}
 		if ($output !== null) {
 			if ($output === true) echo $out;
 			else fwrite ($output, $out);


### PR DESCRIPTION
Pretty lightweight change to allow XMLCustomWriter support for comment nodes, I think.