### PR TITLE
Fixed undefined variable $userGroupDao

### DIFF
--- a/classes/security/authorization/internal/UserAccessibleWorkflowStageRequiredPolicy.inc.php
+++ b/classes/security/authorization/internal/UserAccessibleWorkflowStageRequiredPolicy.inc.php
@@ -103,6 +103,7 @@ class UserAccessibleWorkflowStageRequiredPolicy extends AuthorizationPolicy {
 						// and the requested workflow stage must be assigned to
 						// them in the context settings.
 						import('lib.pkp.classes.security.authorization.internal.SectionAssignmentRule');
+						$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
 						if (SectionAssignmentRule::effect($contextId, $submission->getSectionId(), $userId) &&
 						$userGroupDao->userAssignmentExists($contextId, $userId, $stageId)) {
 							$accessibleStageRoles[] = $roleId;


### PR DESCRIPTION
I came across this undefined variable $userGroupDao when accessing a submission's workflow as a user with the Section Editor role.