### PR TITLE
pkp/pkp-lib#831: Validate password reset hash via new Validation method

### DIFF
--- a/pages/login/PKPLoginHandler.inc.php
+++ b/pages/login/PKPLoginHandler.inc.php
@@ -237,8 +237,7 @@ class PKPLoginHandler extends Handler {
 
 		$templateMgr =& TemplateManager::getManager();
 
-		$hash = Validation::generatePasswordResetHash($user->getId());
-		if ($hash == false || $confirmHash != $hash) {
+		if (!Validation::verifyPasswordResetHash($user->getId(), $confirmHash)) {
 			$templateMgr->assign('errorMsg', 'user.login.lostPassword.invalidHash');
 			$templateMgr->assign('backLink', $request->url(null, null, 'lostPassword'));
 			$templateMgr->assign('backLinkLabel',  'user.login.resetPassword');


### PR DESCRIPTION
Tested this on my VM to confirm success with a correct hash/expiry and failure with an incorrect hash/expiry, but then the VM decided not to talk to Github.  So, copy-pasted one line change to a repo that would talk, but doesn't actually have a web front end.

Resolves https://github.com/pkp/pkp-lib/issues/831 (I hope).
