### PR TITLE
#836 Move some frontend components to pkp-lib

### DIFF
--- a/locale/en_US/common.xml
+++ b/locale/en_US/common.xml
@@ -370,6 +370,8 @@
 	<message key="navigation.access"><![CDATA[Users &amp; Roles]]></message>
 	<message key="navigation.about">About</message>
 	<message key="navigation.admin">Administration</message>
+	<message key="navigation.breadcrumbLabel">You are here:</message>
+	<message key="navigation.breadcrumbSeparator">/</message>
 	<message key="navigation.tools">Tools</message>
 	<message key="navigation.tools.importExport">Import/Export</message>
 	<message key="navigation.tools.statistics">Statistics</message>

--- a/templates/common/frontend/headerHead.tpl
+++ b/templates/common/frontend/headerHead.tpl
@@ -12,9 +12,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>
 		{$pageTitleTranslated|strip_tags}
-		{if $pageNumber}
-			{translate key="common.pageNumber"}
-		{/if}
 	</title>
 	<meta name="description" content="{$metaSearchDescription|escape}" />
 	<meta name="keywords" content="{$metaSearchKeywords|escape}" />

--- a/templates/information/information.tpl
+++ b/templates/information/information.tpl
@@ -13,10 +13,10 @@
 {/if}
 
 <div class="page page_information">
-	<h1 class="page_title">
-		{translate key=$pageTitle}
-	</h1>
-	{$content|nl2br}
+	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey=$pageTitle}
+	<div class="description">
+		{$content}
+	</div>
 </div>
 
 {if !$contentOnly}


### PR DESCRIPTION
A few small changes made while bringing the `ojs` frontend up-to-speed with the `omp` one. Matching PRs coming for `ojs` and `omp`.