### PR TITLE
Locale Standardization

### DIFF
--- a/locale/en_US/admin.xml
+++ b/locale/en_US/admin.xml
@@ -35,7 +35,6 @@
 	<message key="admin.languages.download.cannotOpen">Cannot open language descriptor from PKP web site.</message>
 	<message key="admin.languages.download.cannotModifyRegistry">Cannot add the new locale to the locale registry file, typically "registry/locales.xml".</message>
 	<message key="admin.languages.cantDisable">This locale is the primary language of the site. You can't disable it until you choose another primary locale.</message>
-
 	<message key="admin.languages.confirmReload">Are you sure you want to reload this locale? This will erase any existing locale-specific data such as customized email templates.</message>
 	<message key="admin.languages.installedLocales">Installed Locales</message>
 	<message key="admin.languages.installLanguages">Manage Locales</message>
@@ -106,13 +105,11 @@
 	<message key="admin.version.updateAvailable">An updated version is available</message>
 	<message key="admin.version.upToDate">Your system is up-to-date</message>
 	<message key="admin.version">Version</message>
-
 	<message key="admin.fileLoader.wrongBasePathLocation">Base path {$path} must be inside the public files directory.</message>
 	<message key="admin.fileLoader.pathNotAccessible">Folder {$path} is not a directory or is not readable.</message>
 	<message key="admin.fileLoader.moveFileFailed">File {$filename} could not be moved from {$currentFilePath} to {$destinationPath}</message>
 	<message key="admin.fileLoader.fileProcessed">File {$filename} was processed and archived.</message>
 	<message key="admin.fileLoader.emailSubject">File loader</message>
-
 	<message key="admin.copyAccessLogFileTool.usage">Copy the passed apache access log file(s), filtering the entries related with this installation,
 to the current files directory, inside the UsageStatsPlugin stage directory. Must run under user with enough privilegies to read access apache log files.
 

--- a/locale/en_US/bic21qualifiers.xml
+++ b/locale/en_US/bic21qualifiers.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE qualifiers SYSTEM "../../dtd/bic21qualifiers.dtd">
+
 <!--
   * locale/en_US/bic21qualifiers.xml
   *
@@ -8,6 +9,7 @@
   * localized list of BIC 2.1 Subject Qualifiers
   * Reference:  http://www.bic.org.uk/7/BIC-Standard-Subject-Categories
   -->
+
 <qualifiers>
 	<qualifier code="1D" text="Europe" />
 	<qualifier code="1DB" text="British Isles" />

--- a/locale/en_US/bic21subjects.xml
+++ b/locale/en_US/bic21subjects.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE subjects SYSTEM "../../dtd/bic21subjects.dtd">
+
 <!--
   * locale/en_US/bic21subjects.xml
   *
@@ -8,6 +9,7 @@
   * localized list of BIC 2.1 Subjects
   * Reference:  http://www.bic.org.uk/7/BIC-Standard-Subject-Categories
   -->
+
 <subjects>
 	<subject code="A" text="The arts" />
 	<subject code="AB" text="The arts: general issues" />

--- a/locale/en_US/common.xml
+++ b/locale/en_US/common.xml
@@ -361,7 +361,6 @@
 	<message key="stageParticipants.notify.chooseMessage">Choose a predefined message to use, or fill out the form below.</message>
 	<message key="stageParticipants.notify.message">Message</message>
 	<message key="stageParticipants.notify.warning">Please ensure that you have filled out the message field and selected at least one recipient.</message>
-
 	<message key="locale.primary">Primary locale</message>
 	<message key="locale.supported">Supported locales</message>
 	<message key="navigation.access"><![CDATA[Users &amp; Roles]]></message>
@@ -485,7 +484,6 @@
 	<!-- Common -->
 	<message key="grid.action.toggleHelp">Toggle the display of inline help</message>
 	<message key="grid.action.downloadFile">Download this file</message>
-
 	<message key="context.path">Path</message>
 	<message key="review.ensuringBlindReview">Ensuring a Blind Review</message>
 	<message key="grid.action.showReviewPolicy">Read the current review policy</message>
@@ -493,10 +491,8 @@
 	<message key="grid.action.markNew">Mark New</message>
 	<message key="grid.action.markRead">Mark Read</message>
 	<message key="common.tasks.titleAndTask">{$acronym}: "{$title}": {$task}</message>
-
 	<message key="dashboard.tasks">Tasks</message>
 	<message key="dashboard.submissions">Submissions</message>
-
 	<message key="review.blindPeerReview">
 		<![CDATA[<p>To ensure the integrity of the blind peer-review for submission to this press, every effort should be made to prevent the identities of the authors and reviewers from being known to each other. This involves the authors, editors, and reviewers (who upload documents as part of their review) checking to see if the following steps have been taken with regard to the text and the file properties:</p>
 			<ul><li>The authors of the document have deleted their names from the text, with "Author" and year used in the references and footnotes, instead of the authors' name, article title, etc.</li>
@@ -510,7 +506,6 @@
 	<message key="reviewer.submission.reviewDueDate">Review Due Date</message>
 	<message key="submission.task.responseDueDate">Response Due Date</message>
 	<message key="navigation.goBack">Go Back</message>
-
 	<message key="notification.addedReviewer">Reviewer added.</message>
 	<message key="notification.removedReviewer">Reviewer removed.</message>
 	<message key="notification.addedStageParticipant">User added as a stage participant.</message>

--- a/locale/en_US/countries.xml
+++ b/locale/en_US/countries.xml
@@ -10,6 +10,7 @@
   *
   * Localized list of countries. Based on ISO 3166-1.
   -->
+
 <countries>
 	<country name="Afghanistan" code="AF"/>
 	<country name="Åland Islands" code="AX"/>

--- a/locale/en_US/grid.xml
+++ b/locale/en_US/grid.xml
@@ -16,7 +16,6 @@
 	<message key="grid.noItems">No Items</message>
 	<message key="grid.settings">Settings</message>
 	<message key="grid.noAuditors">No Auditors</message>
-
 	<message key="grid.action.manageAccess">Manage Access</message>
 	<message key="grid.action.sort">Sort</message>
 	<message key="grid.action.addItem">Add Item</message>

--- a/locale/en_US/languages.xml
+++ b/locale/en_US/languages.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE languages SYSTEM "../../dtd/languages.dtd">
+
 <!--
   * locale/en_US/languages.xml
   *
@@ -10,6 +11,7 @@
   * Localized list of common languages. Based on ISO 639-1.
   *
   -->
+  
 <languages>
 	<language code="ab" name="Abkhazian"/>
 	<language code="aa" name="Afar"/>

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -16,7 +16,6 @@
 	<message key="manager.website.information">Information</message>
 	<message key="manager.website.appearance">Appearance</message>
 	<message key="manager.website.imageFileRequired">An image file is required. Please ensure that you have chosen and uploaded a file.</message>
-
 	<message key="manager.announcements">Announcements</message>
 	<message key="manager.announcements.confirmDelete">Are you sure you want to permanently delete this announcement?</message>
 	<message key="manager.announcements.create">Create New Announcement</message>
@@ -375,7 +374,6 @@
 	<message key="manager.plugins.uploadPluginDir">Select plugin file</message>
 	<message key="manager.plugins.versionFileInvalid">version.xml in plugin directory contains invalid data.</message>
 	<message key="manager.plugins.versionFileNotFound">version.xml not found in plugin directory</message>
-
 	<message key="notification.localeEnabled">Locale enabled.</message>
 	<message key="notification.localeDisabled">Locale disabled.</message>
 	<message key="notification.primaryLocaleDefined">{$locale} defined as primary locale.</message>
@@ -441,7 +439,6 @@
 	<message key="grid.content.navigation.socialMedia.includeInCatalog">Use this for each published item in the catalog?</message>
 	<message key="grid.content.navigation.socialMedia.inCatalog">Used In Catalog</message>
 	<message key="grid.action.addMedia">Add a new Social Media type</message>
-
 	<message key="notification.addedFooterCategory">Category added.</message>
 	<message key="notification.editedFooterCategory">Category edited.</message>
 	<message key="notification.removedFooterCategory">Category removed.</message>
@@ -521,7 +518,6 @@
 	<message key="grid.action.createReviewForm">Create a new Review Form</message>
 	<message key="manager.setup.reviewerCompetingInterestsRequired.description">Reviewer Competing Interest statement</message>
 	<message key="manager.setup.competingInterests.required">Accept a Competing Interest statement</message>
-
 	<message key="manager.setup.includeCopyrightStatement">Display the copyright statement with content (advisable for asserting an author-held copyright).</message>
 	<message key="manager.setup.includeLicense">Display the license with published work.</message>
 	<message key="manager.setup.licenseURLDescription">Provide URL for license webpage, if available.</message>

--- a/locale/en_US/reader.xml
+++ b/locale/en_US/reader.xml
@@ -46,11 +46,9 @@
 	<message key="rt.admin.contexts.options.geoTerms">Use geographical indexing data as default search terms.</message>
 	<message key="rt.admin.contexts.options">Options</message>
 	<message key="rt.admin.management">Management</message>
-
 	<message key="rt.admin.sharing">Sharing</message>
 	<message key="rt.admin.sharing.enabled">Sharing Enabled</message>
 	<message key="rt.admin.sharing.description"><![CDATA[To enable your readers to share content, sign up for an account with <a href="http://www.addthis.com">addthis.com</a>, and copy/paste the Sharing button code below.]]></message>
-
 	<message key="rt.admin.sharing.basic">Basic Settings</message>
 	<message key="rt.admin.sharing.userNameLabel">AddThis.com user name</message>
 	<message key="rt.admin.sharing.buttonStyleLabel">Button style</message>
@@ -63,7 +61,6 @@
 	<message key="rt.admin.sharing.logolabel">Logo</message>
 	<message key="rt.admin.sharing.logoBackgroundLabel">Logo background</message>
 	<message key="rt.admin.sharing.logoColorLabel">Logo color</message>
-
 	<message key="rt.admin.readingToolsEnabled">Reading tools</message>
 	<message key="rt.admin.searches.confirmDelete">Are you sure you wish to delete this Search?</message>
 	<message key="rt.admin.searches.createSearch">Create Search</message>
@@ -100,7 +97,7 @@
 	<message key="rt.captureCite.format">Citation Format</message>
 	<message key="rt.captureCite">How to cite item</message>
 	<message key="rt.captureCite.online">Online</message>
-	<message key="rt.captureCite.web">Web</message>	
+	<message key="rt.captureCite.web">Web</message>
 	<message key="rt.colleague">Notify colleague</message>
 	<message key="rt.context.abbrev">Abbrev</message>
 	<message key="rt.context.and">AND</message>

--- a/locale/en_US/reviewer.xml
+++ b/locale/en_US/reviewer.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings
+  * Localization strings.
   -->
 
 <locale name="en_US" full_name="U.S. English">
@@ -41,5 +41,4 @@
 	<message key="reviewer.complete.whatNext">Thank you for completing the review of this submission. Your review has been submitted successfully. We appreciate your contribution to the quality of the work that we publish; the editor may contact you again for more information if need be.</message>
 	<message key="reviewer.aboutDueDates">About Due Dates</message>
 	<message key="reviewer.aboutDueDates.text">The editor asks that you either accept or decline the review before the Response Due Date and complete the review by the Review Due Date.</message>
-
 </locale>

--- a/locale/en_US/submission.xml
+++ b/locale/en_US/submission.xml
@@ -335,7 +335,6 @@
 
 	<!-- Stage Participants -->
 	<message key="submission.stageParticipants.notify">Notify</message>
-
 	<message key="submission.lastModified">Last modified</message>
 	<message key="submission.layout.addGalley">Add a Layout Galley</message>
 	<message key="submission.layout.confirmDeleteGalley">Are you sure you want to permanently delete this galley?</message>
@@ -476,7 +475,6 @@
 	<message key="workflow.stage.any">Any Stage</message>
 	<message key="workflow.stage">Stage</message>
 
-
 	<!-- Submission status -->
 	<message key="submission.status.editorial">In Copyediting</message>
 	<message key="submission.status.production">In Proofreading</message>
@@ -485,7 +483,6 @@
 	<message key="submission.status.unassigned">Unassigned</message>
 	<message key="submission.status.declined">Declined</message>
 	<message key="submission.status.published">Published</message>
-
 	<message key="submission.submit.uploadStep">1. Upload Submission</message>
 	<message key="submission.submit.uploadSubmissionFile">Upload Submission File</message>
 	<message key="submission.submit.metadataStep">2. Metadata</message>
@@ -559,7 +556,6 @@
 	<message key="submission.currentStage">Current stage</message>
 	<message key="submission.noActionRequired">No action required</message>
 	<message key="submission.actionNeeded">Needs action</message>
-
 	<message key="reviewer.submission.reviewFiles">Review Files</message>
 	<message key="submission.submit.currentFile">Current file</message>
 	<message key="submission.finalDraft">Draft Files</message>

--- a/locale/en_US/user.xml
+++ b/locale/en_US/user.xml
@@ -103,7 +103,6 @@
 	<message key="user.login.registerNewAccount">Register</message>
 	<message key="user.login.resetPasswordInstructions"><![CDATA[For security reasons, this system emails a reset password to registered users, rather than recalling the
 current password.<br /><br />Enter your email address below to reset your password. A confirmation will be sent to this email address.]]></message>
-
 	<message key="user.register.form.emailExists">The selected email address is already in use by another user.</message>
 	<message key="user.register.form.passwordsDoNotMatch">The passwords do not match.</message>
 	<message key="user.register.form.emailsDoNotMatch">The email address fields do not match.</message>


### PR DESCRIPTION
Removes unnecessary empty lines and standarizes the comment section with a break line before and after it.
I'm currently updating some of the pt_br locales and found some unnecessary empty lines, so i've also standarized a empy line before and after the comment header of the files.

Not really *usefull*, but anyway here it go.