### PR TITLE
Improve grid styles

### DIFF
--- a/classes/controllers/grid/GridHandler.inc.php
+++ b/classes/controllers/grid/GridHandler.inc.php
@@ -593,7 +593,7 @@ class GridHandler extends PKPHandler {
 				new LinkAction(
 					'search',
 					new NullAction(),
-					'',
+					__('common.search'),
 					'search_extras_expand'
 				)
 			);

--- a/styles/controllers/grid/grid.less
+++ b/styles/controllers/grid/grid.less
@@ -101,6 +101,10 @@
 
 		.section {
 			margin-bottom: @half;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
 		}
 
 		.pkp_spinner {

--- a/styles/controllers/grid/grid.less
+++ b/styles/controllers/grid/grid.less
@@ -72,12 +72,12 @@
 		transition: all 0.3s ease;
 
 		&:before {
-			margin-right: 0.25em;
+			margin-right: 0.5em;
 		}
 	}
 
 	.pkp_linkaction_search:before {
-		content: @fa-var-search-plus;
+		content: @fa-var-search;
 	}
 
 	.pkp_linkaction_search.is_open {
@@ -85,10 +85,6 @@
 		background: @bg-light;
 		border: @bg-border-light;
 		border-bottom: none;
-	}
-
-	.pkp_linkaction_search.is_open:before {
-		content: @fa-var-search-minus;
 	}
 
 	// Search filter

--- a/styles/controllers/grid/grid.less
+++ b/styles/controllers/grid/grid.less
@@ -55,6 +55,8 @@
 		}
 
 		a {
+			position: relative;
+			top: 1px; // alignment to account for filter toggle offset
 			display: inline-block;
 			line-height: @double;
 			font-size: @font-sml;
@@ -79,8 +81,10 @@
 	}
 
 	.pkp_linkaction_search.is_open {
-		padding: 0 1em;
-		background: @bg;
+		padding: 0 @base;
+		background: @bg-light;
+		border: @bg-border-light;
+		border-bottom: none;
 	}
 
 	.pkp_linkaction_search.is_open:before {
@@ -90,8 +94,10 @@
 	// Search filter
 	.filter {
 		padding: @base;
-		background: @bg;
 		font-size: @font-sml;
+		background: @bg-light;
+		border: @bg-border-light;
+		border-bottom: none;
 
 		label {
 			font-size: @font-sml;
@@ -119,37 +125,42 @@
 
 	tr {
 		position: static;
+		border: @bg-border-light;
+		border-top: none;
+
 	}
 
 	// Content rows only
 	.gridRow {
-		border-top: 1px solid @bg;
+		border-top: @bg-border-light;
 	}
 
 	th,
 	td {
-		padding: 0;
-		padding-left: 1em;
+		padding-left: @base;
+		padding-right: @base;
 		vertical-align: top;
 	}
 
 	thead {
-		background: @bg;
-		font-size: @font-sml;
-		line-height: @double;
+		font-size: @font-tiny;
+		line-height: 16px;
 		color: @text-light;
 		color: @text-light-rgba;
-		border-top: 1px solid #fff; // divider between form when form opened
+		border: @bg-border-light;
 
 		th {
+			padding-top: @half;
+			padding-bottom: @half;
 			font-weight: @normal;
+			border-left: @bg-border-light;
 		}
 	}
 
 	td {
 		position: relative;
 		padding-top: @half;
-		padding-bottom: @half;
+		padding-bottom: @half - 1;
 		line-height: @line-base;
 	}
 
@@ -157,6 +168,7 @@
 	.empty td {
 		padding: 8px 0;
 		font-size: @font-sml;
+		font-style: italic;
 		line-height: @line-base;
 		color: @text-light;
 		color: @text-light-rgba;
@@ -280,9 +292,12 @@
 	// Secondary row of actions
 	.row_controls {
 		display: none;
+		background: @bg-light;
 
 		td {
 			line-height: @line-base;
+			padding-top: 3px;
+			padding-bottom: 3px;
 		}
 
 		a {
@@ -370,7 +385,7 @@
 	// Items shown for infinite scrolling
 	.gridPagingScrolling {
 		position: relative;
-		border-top: @bg-border;
+		border-top: @bg-border-light;
 		font-size: @font-sml;
 		color: @text-light;
 		color: @text-light-rgba;
@@ -423,18 +438,12 @@
 // Categorized grids
 .pkp_grid_category {
 
-	thead {
-		background: @shade;
-		color: #fff;
-	}
-
 	.gridRow.category,
 	.category_controls {
 		background: @bg;
 		font-size: @font-sml;
 		color: @text-light;
 		color: @text-light-rgba;
-		border-bottom: 1px solid @lift;
 	}
 }
 

--- a/styles/fontawesome/icons.less
+++ b/styles/fontawesome/icons.less
@@ -18,8 +18,8 @@
 //.@{fa-css-prefix}-remove:before,
 //.@{fa-css-prefix}-close:before,
 .@{fa-css-prefix}-times:before { content: @fa-var-times; }
-.@{fa-css-prefix}-search-plus:before { content: @fa-var-search-plus; }
-.@{fa-css-prefix}-search-minus:before { content: @fa-var-search-minus; }
+// .@{fa-css-prefix}-search-plus:before { content: @fa-var-search-plus; }
+// .@{fa-css-prefix}-search-minus:before { content: @fa-var-search-minus; }
 //.@{fa-css-prefix}-power-off:before { content: @fa-var-power-off; }
 //.@{fa-css-prefix}-signal:before { content: @fa-var-signal; }
 //.@{fa-css-prefix}-gear:before,

--- a/styles/pages/settings.less
+++ b/styles/pages/settings.less
@@ -69,7 +69,8 @@
 
 // Makes height similar to footer grid category rows which sit next to it
 #socialMediaGridContainer th {
-	line-height: 40px; // long story...
+	padding-top: 12px;
+	padding-bottom: 12px;
 }
 
 #announcementTypeGridContainer {

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -13,6 +13,7 @@
 
 // Background
 @bg:			#ddd;
+@bg-light:		#eee;
 @shade:			#888;
 @lift:			#fff;
 
@@ -38,7 +39,8 @@
 @text-light-rgba:	rgba(0, 0, 0, 0.54);
 
 // Border colors
-@bg-border-color:	#bbb;
+@bg-border-color:		#bbb;
+@bg-border-color-light:	#ddd;
 
 //
 // Spacing
@@ -75,5 +77,6 @@
 //
 // Borders
 //
-@bg-border:		1px solid @bg-border-color;
-@radius:		5px;
+@bg-border:			1px solid @bg-border-color;
+@bg-border-light:	1px solid @bg-border-color-light;
+@radius:			5px;

--- a/templates/controllers/grid/grid.tpl
+++ b/templates/controllers/grid/grid.tpl
@@ -74,8 +74,6 @@
 		{/if}
 		{foreach from=$gridBodyParts item=bodyPart}
 			{$bodyPart}
-		{foreachelse}
-			<tbody><tr></tr></tbody>
 		{/foreach}
 		<tbody class="empty"{if count($gridBodyParts) > 0} style="display: none;"{/if}>
 			{**
@@ -83,7 +81,7 @@
 				so that we can restore it if the user deletes all rows.
 			**}
 			<tr>
-				<td colspan="{$grid->getColumnsCount('indent')|@count}">{translate key=$grid->getEmptyRowText()}</td>
+				<td colspan="{$grid->getColumnsCount('indent')}">{translate key=$grid->getEmptyRowText()}</td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
This PR:

- Switches to the lighter grid header styles I passed around the UI/UX group.
- Adds text label to the grid filter search toggle
- Removes extra space below grid filter submission button
- Fixes alignment issues experienced in __some__ grids when no items exist.

@beghelli This last change required removing an empty `<tbody>` in `grid.tpl`. I suspect it was there for a reason (perhaps some kind of JS-only insertion?). But I wasn't able to see any problems introduced with this change. Take a look and let me know what you think.