### PR TITLE
pkp/pkp-lib#1092: Add HTML entity decode to stripAssocArray() for conversion of HTML to plaintext.

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -322,13 +322,19 @@ function arrayClean(&$array) {
 
 /**
  * Recursively strip HTML from a (multidimensional) array.
+ * Assumes entity decoding to UTF-8 (primarily for OAI-PMH)
  * @param $values array
  * @return array the cleansed array
  */
-function stripAssocArray($values) {
+function stripAssocArray($values, $useClientCharset = false) {
 	foreach ($values as $key => $value) {
 		if (is_scalar($value)) {
 			$values[$key] = strip_tags($values[$key]);
+			if ($useClientCharset && strtolower(Config::getVar('i18n', 'client_charset')) !== 'utf-8') {
+				$values[$key] = html_entity_decode($values[$key], ENT_QUOTES, Config::getVar('i18n', 'client_charset'));
+			} else {
+				$values[$key] = String::html2utf($values[$key]);
+			}
 		} else {
 			$values[$key] = stripAssocArray($values[$key]);
 		}


### PR DESCRIPTION
Resolves https://github.com/pkp/pkp-lib/issues/1092, at least to the degree that PHP is natively able, by decoding known entities into the specified client character set.