### PR TITLE
Fix TinyMCE variable replacement regex

### DIFF
--- a/js/controllers/SiteHandler.js
+++ b/js/controllers/SiteHandler.js
@@ -195,7 +195,7 @@
 					'#' + tinyMCEObject.id);
 
 			e.content = e.content.replace(
-					/\{\$([a-zA-Z]+)\}/g, function(match, contents, offset, s) {
+					/\{\$([a-zA-Z]+)\}(?![^<]*>)/g, function(match, contents, offset, s) {
 						if (variablesParsed[contents] !== undefined) {
 							return $.pkp.classes.TinyMCEHelper.prototype.getVariableElement(
 									contents, variablesParsed[contents]).html();


### PR DESCRIPTION
Avoid matching variables in HTML tag attributes, such as `<a href="{$submissionReviewUrl}">{$submissionReviewUrl}</a>`