### PR TITLE
New frontend design

### DIFF
--- a/templates/frontend/components/footer.tpl
+++ b/templates/frontend/components/footer.tpl
@@ -29,47 +29,23 @@
 
 	<div class="pkp_structure_footer">
 
-		<div class="pkp_site_name_wrapper">
-			{* Logo or site title. *}
-			<div class="pkp_site_name">
-				{if $currentJournal && $multipleContexts}
-					{url|assign:"homeUrl" journal="index" router=$smarty.const.ROUTE_PAGE}
-				{else}
-					{url|assign:"homeUrl" page="index" router=$smarty.const.ROUTE_PAGE}
-				{/if}
-				{if $displayPageHeaderLogo && is_array($displayPageHeaderLogo)}
-					<a href="{$homeUrl}" class="is_img" rel="home">
-						<img src="{$publicFilesDir}/{$displayPageHeaderLogo.uploadName|escape:"url"}" width="{$displayPageHeaderLogo.width|escape}" height="{$displayPageHeaderLogo.height|escape}" {if $displayPageHeaderLogo.altText != ''}alt="{$displayPageHeaderLogo.altText|escape}"{else}alt="{translate key="common.pageHeaderLogo.altText"}"{/if} />
-					</a>
-				{elseif $displayPageHeaderTitle && !$displayPageHeaderLogo && is_string($displayPageHeaderTitle)}
-					<a href="{$homeUrl}" class="is_text" rel="home">{$displayPageHeaderTitle}</a>
-				{elseif $displayPageHeaderTitle && !$displayPageHeaderLogo && is_array($displayPageHeaderTitle)}
-					<a href="{$homeUrl}" class="is_img">
-						<img src="{$publicFilesDir}/{$displayPageHeaderTitle.uploadName|escape:"url"}" alt="{$displayPageHeaderTitle.altText|escape}" width="{$displayPageHeaderTitle.width|escape}" height="{$displayPageHeaderTitle.height|escape}" />
-					</a>
-				{else}
-					<a href="{$homeUrl}" class="is_img" rel="home">
-						<img src="{$baseUrl}/templates/images/structure/logo.png" alt="{$applicationName|escape}" title="{$applicationName|escape}" width="180" height="90" />
-					</a>
-				{/if}
+		{if $pageFooter}
+			<div class="pkp_footer_content">
+				{$pageFooter}
 			</div>
-		</div>
+		{/if}
 
-		<div class="page_footer">
-			{$pageFooter}
+		<div class="pkp_brand_footer" role="complementary" aria-label="{translate|escape key="about.aboutThisPublishingSystem"}">
+			<a href="{url page="about" op="aboutThisPublishingSystem"}">
+				<img alt="{translate key=$packageKey}" src="{$baseUrl}/{$brandImage}">
+			</a>
+			<a href="{$pkpLink}">
+				<img alt="{translate key="common.publicKnowledgeProject"}" src="{$baseUrl}/lib/pkp/templates/images/pkp_brand.png">
+			</a>
 		</div>
-	</div><!-- pkp_structure_footer -->
+	</div>
 
 </div><!-- pkp_structure_footer_wrapper -->
-
-<div class="pkp_brand_footer" role="complementary" aria-label="{translate|escape key="about.aboutThisPublishingSystem"}">
-	<a href="{url page="about" op="aboutThisPublishingSystem"}">
-		<img alt="{translate key=$packageKey}" src="{$baseUrl}/{$brandImage}">
-	</a>
-	<a href="{$pkpLink}">
-		<img alt="{translate key="common.publicKnowledgeProject"}" src="{$baseUrl}/lib/pkp/templates/images/pkp_brand.png">
-	</a>
-</div>
 
 </div><!-- pkp_structure_page -->
 

--- a/templates/frontend/components/header.tpl
+++ b/templates/frontend/components/header.tpl
@@ -11,11 +11,18 @@
  *       represents a page-level override, and doesn't indicate whether or not
  *       sidebars have been configured for thesite.
  *}
+
+{* Determine whether a logo or title string is being displayed *}
+{assign var="showingLogo" value=true}
+{if $displayPageHeaderTitle && !$displayPageHeaderLogo && is_string($displayPageHeaderTitle)}
+	{assign var="showingLogo" value=false}
+{/if}
+
 <!DOCTYPE html>
 <html lang="{$currentLocale|replace:"_":"-"}" xml:lang="{$currentLocale|replace:"_":"-"}">
 {if !$pageTitleTranslated}{translate|assign:"pageTitleTranslated" key=$pageTitle}{/if}
 {include file="core:frontend/components/headerHead.tpl"}
-<body class="pkp_page_{$requestedPage|escape|default:"index"} pkp_op_{$requestedOp|escape|default:"index"}">
+<body class="pkp_page_{$requestedPage|escape|default:"index"} pkp_op_{$requestedOp|escape|default:"index"}{if $showingLogo} has_site_logo{/if}">
 	<script type="text/javascript">
 		// Initialise JS handler.
 		$(function() {ldelim}


### PR DESCRIPTION
This and companion PRs for OJS/OMP implements the new high-contrast look we discussed over email.

![omp-book](https://cloud.githubusercontent.com/assets/2306629/12822520/55197fc2-cb60-11e5-8716-44943b1fe620.png)

I think this will be easier to customize for various needs and the color selection is more straightforward. Here are [examples of a wide range of color choices](http://imgur.com/a/txUz5) that work well for different tastes/branding.

In particular, the look is much better for journals/presses with no logo (text only).