### PR TITLE
Add missing Review Reminder email variables

### DIFF
--- a/controllers/grid/users/reviewer/form/ReviewReminderForm.inc.php
+++ b/controllers/grid/users/reviewer/form/ReviewReminderForm.inc.php
@@ -92,6 +92,26 @@ class ReviewReminderForm extends Form {
 	}
 
 	/**
+	 * @copydoc Form::fetch()
+	 */
+	function fetch($request) {
+		$context = $request->getContext();
+		$user = $request->getUser();
+
+		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr->assign('emailVariables', array(
+			'reviewerName' => __('user.name'),
+			'reviewDueDate' => __('reviewer.submission.reviewDueDate'),
+			'submissionReviewUrl' => __('common.url'),
+			'submissionTitle' => __('submission.title'),
+			'passwordResetUrl' => __('common.url'),
+			'contextName' => $context->getLocalizedName(),
+			'editorialContactSignature' => $user->getContactSignature(),
+		));
+		return parent::fetch($request);
+	}
+
+	/**
 	 * Assign form data to user-submitted data.
 	 * @see Form::readInputData()
 	 */

--- a/templates/controllers/grid/users/reviewer/form/reviewReminderForm.tpl
+++ b/templates/controllers/grid/users/reviewer/form/reviewReminderForm.tpl
@@ -26,14 +26,14 @@
 		{/fbvFormSection}
 
 		{fbvFormSection title="editor.review.personalMessageToReviewer" for="message"}
-			{fbvElement type="textarea" id="message" value=$message rich=true}
+			{fbvElement type="textarea" id="message" value=$message variables=$emailVariables rich=true}
 		{/fbvFormSection}
 		{fbvFormSection title="reviewer.submission.reviewSchedule"}
-			{fbvElement type="text" id="dateNotified" label="reviewer.submission.reviewRequestDate" value=$reviewAssignment->getDateNotified()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
+			{fbvElement type="text" id="dateNotified" label="reviewer.submission.reviewRequestDate" value=$reviewAssignment->getDateNotified()|date_format:$dateFormatShort readonly=true inline=true size=$fbvStyles.size.SMALL}
 			{if $reviewAssignment->getDateConfirmed()}
-				{fbvElement type="text" id="dateConfirmed" label="editor.review.dateAccepted" value=$reviewAssignment->getDateConfirmed()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
+				{fbvElement type="text" id="dateConfirmed" label="editor.review.dateAccepted" value=$reviewAssignment->getDateConfirmed()|date_format:$dateFormatShort readonly=true inline=true size=$fbvStyles.size.SMALL}
 			{else}
-				{fbvElement type="text" id="responseDue" label="reviewer.submission.responseDueDate" value=$reviewAssignment->getDateResponseDue()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
+				{fbvElement type="text" id="responseDue" label="reviewer.submission.responseDueDate" value=$reviewAssignment->getDateResponseDue()|date_format:$dateFormatShort readonly=true inline=true size=$fbvStyles.size.SMALL}
 			{/if}
 			{fbvElement type="text" id="reviewDueDate" label="reviewer.submission.reviewDueDate" value=$reviewDueDate readonly=true inline=true size=$fbvStyles.size.SMALL}
 		{/fbvFormSection}

--- a/templates/controllers/grid/users/reviewer/form/reviewReminderForm.tpl
+++ b/templates/controllers/grid/users/reviewer/form/reviewReminderForm.tpl
@@ -35,7 +35,7 @@
 			{else}
 				{fbvElement type="text" id="responseDue" label="reviewer.submission.responseDueDate" value=$reviewAssignment->getDateResponseDue()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
 			{/if}
-			{fbvElement type="text" id="dateDue" label="reviewer.submission.reviewDueDate" value=$reviewAssignment->getDateDue()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
+			{fbvElement type="text" id="reviewDueDate" label="reviewer.submission.reviewDueDate" value=$reviewDueDate readonly=true inline=true size=$fbvStyles.size.SMALL}
 		{/fbvFormSection}
 		{fbvFormButtons submitText="editor.review.sendReminder"}
 	{/fbvFormArea}


### PR DESCRIPTION
- remove extra `emailSignature`
- pass missing `reviewDueDate` to the form in `initData()`
- add missing email variables

Corresponding changes to `dateDue` in Review Reminder form template:
- rename to `reviewDueDate` for consistency with other email templates
- change `disabled` attribute to `readonly`, since disabled inputs are not posted in the request
- remove `datepicker` class for consistency with `readonly` attribute

These changes are kept minimal to make the Review Reminder functional.
- Should I also change the other dates (`dateNotified`, `dateConfirmed` and `responseDue`) to `readonly` and remove their `datepicker` class?
- Should these dates be also passed to the form in `initData()`?
- I'm not sure the proper way to pass those email variables to TinyMCE, as there is no `fetch()` implemented here.