### PR TITLE
Fix FBV textarea "required" attribute

### DIFF
--- a/classes/form/FormBuilderVocabulary.inc.php
+++ b/classes/form/FormBuilderVocabulary.inc.php
@@ -493,6 +493,7 @@ class FormBuilderVocabulary {
 					}
 					break;
 				case 'id': break; // if we don't do this, the textarea ends up with two id attributes because FBV_id is also set.
+				case 'required': if ($value) $textAreaParams .= $key . ' '; break;
 				default: $textAreaParams .= htmlspecialchars($key, ENT_QUOTES, LOCALE_ENCODING) . '="' . htmlspecialchars($value, ENT_QUOTES, LOCALE_ENCODING) . '" ';
 			}
 		}


### PR DESCRIPTION
The `required` attribute is a `boolean attribute`. Even when the `default` switch case renders it as `required="0"`, the text area is still marked as required. So I add a case to add it only when it is `true`.