### PR TITLE
Propose a new Review Form element type Instruction Text

### DIFF
--- a/classes/reviewForm/ReviewFormElement.inc.php
+++ b/classes/reviewForm/ReviewFormElement.inc.php
@@ -21,6 +21,7 @@ define('REVIEW_FORM_ELEMENT_TYPE_TEXTAREA',		0x000003);
 define('REVIEW_FORM_ELEMENT_TYPE_CHECKBOXES',		0x000004);
 define('REVIEW_FORM_ELEMENT_TYPE_RADIO_BUTTONS',	0x000005);
 define('REVIEW_FORM_ELEMENT_TYPE_DROP_DOWN_BOX',	0x000006);
+define('REVIEW_FORM_ELEMENT_TYPE_INSTRUCTION_TEXT',	0x000007);
 
 class ReviewFormElement extends DataObject {
 	/**
@@ -179,7 +180,8 @@ class ReviewFormElement extends DataObject {
 			REVIEW_FORM_ELEMENT_TYPE_TEXTAREA => 'manager.reviewFormElements.textarea',
 			REVIEW_FORM_ELEMENT_TYPE_CHECKBOXES => 'manager.reviewFormElements.checkboxes',
 			REVIEW_FORM_ELEMENT_TYPE_RADIO_BUTTONS => 'manager.reviewFormElements.radiobuttons',
-			REVIEW_FORM_ELEMENT_TYPE_DROP_DOWN_BOX => 'manager.reviewFormElements.dropdownbox'
+			REVIEW_FORM_ELEMENT_TYPE_DROP_DOWN_BOX => 'manager.reviewFormElements.dropdownbox',
+			REVIEW_FORM_ELEMENT_TYPE_INSTRUCTION_TEXT => 'manager.reviewFormElements.instructiontext'
 		);
 		return $reviewFormElementTypeOptions;
 	}

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -483,6 +483,7 @@
 	<message key="manager.reviewFormElements.radiobuttons">Radio buttons (you can only choose one)</message>
 	<message key="manager.reviewFormElements.required">Reviewers required to complete item</message>
 	<message key="manager.reviewFormElements.included">Included in message to author</message>
+	<message key="manager.reviewFormElements.instructiontext">Instruction text</message>
 	<message key="manager.reviewFormElements.smalltextfield">Single word text box</message>
 	<message key="manager.reviewFormElements.textarea">Extended text box</message>
 	<message key="manager.reviewFormElements.textfield">Single line text box</message>


### PR DESCRIPTION
Sometimes we may want to add instructions midway in a review form to introduce different sections.

For example:

> **Section A: Please rate the following qualities of the manuscript (5 - excellent ... 1 - poor).**
> 
> 1. Methodology (radio buttons)
> 2. Originality (radio buttons)
> 3. Clarity (radio buttons)
> 
> **Section B: Please give you comments and suggestions.**
> 
> 1. Comments (textarea)
> 2. Suggestions (textarea)

Although the instructions can be put in the question texts of the first questions, it is semantically better to allow a separate element type for pure texts.