### PR TITLE
fix test for null reply-to address

### DIFF
--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -353,7 +353,7 @@ class Mail extends DataObject {
 	 */
 	function getReplyToString($send = false) {
 		$replyTo = $this->getReplyTo();
-		if ($replyTo == null) {
+		if (!array_key_exists('email', $replyTo) || $replyTo['email'] == null) {
 			return null;
 		} else {
 			return (Mail::encodeDisplayName($replyTo['name'], $send) . ' <'.$replyTo['email'].'>');


### PR DESCRIPTION
Test the array element for null instead of the array itself.  This will keep the reply-to header out of the Mail envelope entirely.