### PR TITLE
Fix review form item reorder

### DIFF
--- a/controllers/grid/settings/reviewForms/ReviewFormElementsGridHandler.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormElementsGridHandler.inc.php
@@ -157,7 +157,7 @@ class ReviewFormElementsGridHandler extends GridHandler {
 	/**
 	 * @see lib/pkp/classes/controllers/grid/GridHandler::setDataElementSequence()
 	 */
-	function setDataElementSequence($request, $rowId, &$reviewForm, $newSequence) {
+	function setDataElementSequence($request, $rowId, &$reviewFormElement, $newSequence) {
 		$reviewFormElementDao = DAORegistry::getDAO('ReviewFormElementDAO'); /* @var $reviewFormElementDao ReviewFormElementDAO */
 		$reviewFormElement->setSequence($newSequence);
 		$reviewFormElementDao->updateObject($reviewFormElement);


### PR DESCRIPTION
It wasn't working due to a mismatched argument name.