### PR TITLE
Add missing Review Reminder email variables to both the email templat…

### DIFF
--- a/controllers/grid/users/reviewer/form/ReviewReminderForm.inc.php
+++ b/controllers/grid/users/reviewer/form/ReviewReminderForm.inc.php
@@ -19,6 +19,9 @@ class ReviewReminderForm extends Form {
 	/** The review assignment associated with the reviewer **/
 	var $_reviewAssignment;
 
+	/** The submission associated with the review assignment **/
+	var $_submission;
+
 	/**
 	 * Constructor.
 	 */
@@ -41,6 +44,22 @@ class ReviewReminderForm extends Form {
 		return $this->_reviewAssignment;
 	}
 
+	/**
+	 * Get the submission
+	 * @return Submission
+	 */
+	function getSubmission() {
+		return $this->_submission;
+	}
+
+	/**
+	 * Set the submission
+	 * @param $submission Submission
+	 */
+	function setSubmission($submission) {
+		$this->_submission = $submission;
+	}
+
 
 	//
 	// Overridden template methods
@@ -61,6 +80,7 @@ class ReviewReminderForm extends Form {
 
 		$submissionDao = Application::getSubmissionDAO();
 		$submission = $submissionDao->getById($reviewAssignment->getSubmissionId());
+		$this->setSubmission($submission);
 
 		import('lib.pkp.classes.mail.SubmissionMailTemplate');
 		$email = new SubmissionMailTemplate($submission, 'REVIEW_REMIND');
@@ -88,6 +108,50 @@ class ReviewReminderForm extends Form {
 		$this->setData('reviewAssignment', $reviewAssignment);
 		$this->setData('reviewerName', $reviewer->getFullName() . ' <' . $reviewer->getEmail() . '>');
 		$this->setData('message', $email->getBody());
+	}
+
+	/**
+	 * @copydoc Form::fetch()
+	 */
+	function fetch($request) {
+		$context = $request->getContext();
+		$user = $request->getUser();
+
+		// Get the review method options.
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$reviewMethods = $reviewAssignmentDao->getReviewMethodsTranslationKeys();
+		$submission = $this->getSubmission();
+
+		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr->assign('reviewMethods', $reviewMethods);
+		$reviewFormDao = DAORegistry::getDAO('ReviewFormDAO');
+		$reviewForms = array(0 => __('editor.article.selectReviewForm'));
+		$reviewFormsIterator = $reviewFormDao->getActiveByAssocId(Application::getContextAssocType(), $context->getId());
+		while ($reviewForm = $reviewFormsIterator->next()) {
+			$reviewForms[$reviewForm->getId()] = $reviewForm->getLocalizedTitle();
+		}
+		$templateMgr->assign('reviewForms', $reviewForms);
+		$templateMgr->assign('emailVariables', array(
+			'reviewerName' => __('user.name'),
+			'reviewDueDate' => __('reviewer.submission.reviewDueDate'),
+			'submissionReviewUrl' => __('common.url'),
+			'submissionTitle' => __('submission.title'),
+			'passwordResetUrl' => __('common.url'),
+			'contextName' => $context->getLocalizedName(),
+			'editorialContactSignature' => $user->getContactSignature(),
+		));
+		// Allow the default template
+		$templateKeys[] = $this->_getMailTemplateKey($request->getContext());
+
+		foreach ($templateKeys as $templateKey) {
+			$template = new SubmissionMailTemplate($submission, $templateKey, null, null, null, false);
+			$template->assignParams(array());
+			$templates[$templateKey] = $template->getSubject();
+		}
+
+		$templateMgr->assign('templates', $templates);
+
+		return parent::fetch($request);
 	}
 
 	/**
@@ -124,6 +188,22 @@ class ReviewReminderForm extends Form {
 		$reviewAssignment->stampModified();
 		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
 		$reviewAssignmentDao->updateObject($reviewAssignment);
+	}
+
+	/**
+	 * Get the email template key depending on if reviewer one click access is
+	 * enabled or not.
+	 *
+	 * @param mixed $context Context
+	 * @return int Email template key
+	 */
+	function _getMailTemplateKey($context) {
+		$templateKey = 'REVIEW_REMIND';
+		if ($context->getSetting('reviewerAccessKeysEnabled')) {
+			$templateKey = 'REVIEW_REMIND_ONECLICK';
+		}
+
+		return $templateKey;
 	}
 }
 

--- a/templates/controllers/grid/users/reviewer/form/reviewReminderForm.tpl
+++ b/templates/controllers/grid/users/reviewer/form/reviewReminderForm.tpl
@@ -26,14 +26,14 @@
 		{/fbvFormSection}
 
 		{fbvFormSection title="editor.review.personalMessageToReviewer" for="message"}
-			{fbvElement type="textarea" id="message" value=$message rich=true}
+			{fbvElement type="textarea" id="message" value=$message variables=$emailVariables rich=true}
 		{/fbvFormSection}
 		{fbvFormSection title="reviewer.submission.reviewSchedule"}
-			{fbvElement type="text" id="dateNotified" label="reviewer.submission.reviewRequestDate" value=$reviewAssignment->getDateNotified()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
+			{fbvElement type="text" id="dateNotified" label="reviewer.submission.reviewRequestDate" value=$reviewAssignment->getDateNotified()|date_format:$dateFormatShort readonly=true inline=true size=$fbvStyles.size.SMALL}
 			{if $reviewAssignment->getDateConfirmed()}
-				{fbvElement type="text" id="dateConfirmed" label="editor.review.dateAccepted" value=$reviewAssignment->getDateConfirmed()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
+				{fbvElement type="text" id="dateConfirmed" label="editor.review.dateAccepted" value=$reviewAssignment->getDateConfirmed()|date_format:$dateFormatShort readonly=true inline=true size=$fbvStyles.size.SMALL}
 			{else}
-				{fbvElement type="text" id="responseDue" label="reviewer.submission.responseDueDate" value=$reviewAssignment->getDateResponseDue()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
+				{fbvElement type="text" id="responseDue" label="reviewer.submission.responseDueDate" value=$reviewAssignment->getDateResponseDue()|date_format:$dateFormatShort readonly=true inline=true size=$fbvStyles.size.SMALL}
 			{/if}
 			{fbvElement type="text" id="dateDue" label="reviewer.submission.reviewDueDate" value=$reviewAssignment->getDateDue()|date_format:$dateFormatShort disabled=true inline=true size=$fbvStyles.size.SMALL class="datepicker"}
 		{/fbvFormSection}


### PR DESCRIPTION
…e and TinyMCE

Rebased from PR #1133.

I tried to follow @asmecher and @bozana's suggestions to implement `fetch()` here, following how it is done in `Reviewer Form`, to supply the email variables to TinyMCE, and to modify the few dates in the same way.

I guess I might have copied more than necessary from `Reviewer Form` to here. Please advise. 