### PR TITLE
pkp/pkp-lib#1303: remove duplicated code doc for PKPEmailTemplateDAO::installEmailTemplates()

### DIFF
--- a/classes/mail/PKPEmailTemplateDAO.inc.php
+++ b/classes/mail/PKPEmailTemplateDAO.inc.php
@@ -668,8 +668,6 @@ class PKPEmailTemplateDAO extends DAO {
 	 * skipping others
 	 * @param $skipExisting boolean If true, do not install email templates
 	 * that already exist in the database
-	 * @param $emailKey string If specified, the key of the single template
-	 * to install (otherwise all are installed)
 	 * @return array
 	 */
 	function installEmailTemplates($templatesFile, $returnSql = false, $emailKey = null, $skipExisting = false) {


### PR DESCRIPTION
Found this duplicated param documentation while looking at https://github.com/pkp/pkp-lib/issues/1303
