### PR TITLE
pkp/pkp-lib#1148 suppress redundant email notification to author from…

### DIFF
--- a/classes/notification/NotificationManagerDelegate.inc.php
+++ b/classes/notification/NotificationManagerDelegate.inc.php
@@ -58,9 +58,9 @@ abstract class NotificationManagerDelegate extends PKPNotificationOperationManag
 	 * creation of the passed notification type.
 	 * @copydoc PKPNotificationOperationManager::createNotification()
 	 */
-	function createNotification($request, $userId = null, $notificationType, $contextId = null, $assocType = null, $assocId = null, $level = NOTIFICATION_LEVEL_NORMAL, $params = null) {
+	function createNotification($request, $userId = null, $notificationType, $contextId = null, $assocType = null, $assocId = null, $level = NOTIFICATION_LEVEL_NORMAL, $params = null, $suppressEmail = false) {
 		assert($notificationType == $this->getNotificationType() || $this->multipleTypesUpdate());
-		return parent::createNotification($request, $userId, $notificationType, $contextId, $assocType, $assocId, $level, $params);
+		return parent::createNotification($request, $userId, $notificationType, $contextId, $assocType, $assocId, $level, $params, $suppressEmail);
 	}
 
 	/**

--- a/classes/notification/PKPNotificationOperationManager.inc.php
+++ b/classes/notification/PKPNotificationOperationManager.inc.php
@@ -440,7 +440,7 @@ abstract class PKPNotificationOperationManager implements INotificationInfoProvi
 
 			$context = $request->getContext();
 			$site = $request->getSite();
-			$mail = $this->getMailTemplate('NOTIFICATION', null, $context, false);
+			$mail = $this->getMailTemplate('NOTIFICATION');
 			$mail->setReplyTo($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
 			$mail->assignParams(array(
 				'notificationContents' => $this->getNotificationContents($request, $notification),

--- a/classes/notification/managerDelegate/EditorDecisionNotificationManager.inc.php
+++ b/classes/notification/managerDelegate/EditorDecisionNotificationManager.inc.php
@@ -91,7 +91,8 @@ class EditorDecisionNotificationManager extends NotificationManagerDelegate {
 			$notificationDao->deleteObject($notification);
 		}
 
-		// (Re)create notifications.
+		// (Re)create notifications, but don’t send email, since we
+		// got here from the editor decision which sends its own email.
 		foreach ((array) $userIds as $userId) $this->createNotification(
 			$request,
 			$userId,
@@ -99,7 +100,9 @@ class EditorDecisionNotificationManager extends NotificationManagerDelegate {
 			$context->getId(),
 			ASSOC_TYPE_SUBMISSION,
 			$assocId,
-			$this->_getNotificationTaskLevel($this->getNotificationType())
+			$this->_getNotificationTaskLevel($this->getNotificationType()),
+			null,
+			true // suppressEmail
 		);
 	}
 


### PR DESCRIPTION
```
… editor decision
also remove superfluous arguments in PKPNotificationOperationManager
```
Seems to successfully address pkp/pkp-lib#1148 in testing here.