### PR TITLE
pkp/pkp-lib#1310: Set "from" display in mail template to "reply-to" address (due to SPF)

### DIFF
--- a/classes/mail/PKPMailTemplate.inc.php
+++ b/classes/mail/PKPMailTemplate.inc.php
@@ -180,7 +180,7 @@ class PKPMailTemplate extends Mail {
 		$form->setData('blankTo', Request::getUserVar('blankTo'));
 		$form->setData('blankCc', Request::getUserVar('blankCc'));
 		$form->setData('blankBcc', Request::getUserVar('blankBcc'));
-		$form->setData('from', $this->getFromString(false));
+		$form->setData('from', $this->getReplyToString()? $this->getReplyToString() : $this->getFromString(false));
 
 		$form->setData('addressFieldsEnabled', $this->getAddressFieldsEnabled());
 


### PR DESCRIPTION
Resolves https://github.com/pkp/pkp-lib/issues/1310