### PR TITLE
pkp/pkp-lib#1155 Prevent stub queries from being seen by others before completion

### DIFF
--- a/classes/query/QueryDAO.inc.php
+++ b/classes/query/QueryDAO.inc.php
@@ -65,18 +65,23 @@ class QueryDAO extends DAO {
 	 */
 	function getByAssoc($assocType, $assocId, $stageId = null, $userId = null) {
 		$params = array();
+		$params[] = (int) ASSOC_TYPE_QUERY;
 		if ($userId) $params[] = (int) $userId;
 		$params[] = (int) $assocType;
 		$params[] = (int) $assocId;
 		if ($stageId) $params[] = (int) $stageId;
+		if ($userId) $params[] = (int) $userId;
 
 		return new DAOResultFactory(
 			$this->retrieve(
-				'SELECT	q.*
+				'SELECT	DISTINCT q.*
 				FROM	queries q
+				LEFT JOIN notes n ON n.assoc_type = ? AND n.assoc_id = q.query_id
 				' . ($userId?'INNER JOIN query_participants qp ON (q.query_id = qp.query_id AND qp.user_id = ?)':'') . '
 				WHERE	q.assoc_type = ? AND q.assoc_id = ?
 				' . ($stageId?' AND q.stage_id = ?':'') . '
+				AND (' . ($userId?'n.user_id = ? OR ':'') .
+				'n.title IS NOT NULL OR n.contents IS NOT NULL)
 				ORDER BY q.seq',
 				$params
 			),

--- a/classes/query/QueryDAO.inc.php
+++ b/classes/query/QueryDAO.inc.php
@@ -79,9 +79,10 @@ class QueryDAO extends DAO {
 				LEFT JOIN notes n ON n.assoc_type = ? AND n.assoc_id = q.query_id
 				' . ($userId?'INNER JOIN query_participants qp ON (q.query_id = qp.query_id AND qp.user_id = ?)':'') . '
 				WHERE	q.assoc_type = ? AND q.assoc_id = ?
-				' . ($stageId?' AND q.stage_id = ?':'') . '
-				AND (' . ($userId?'n.user_id = ? OR ':'') .
-				'n.title IS NOT NULL OR n.contents IS NOT NULL)
+				' . ($stageId?' AND q.stage_id = ?':'') .
+				($userId?'
+				AND (n.user_id = ? OR n.title IS NOT NULL
+				OR n.contents IS NOT NULL)':'') . '
 				ORDER BY q.seq',
 				$params
 			),


### PR DESCRIPTION
Addresses pkp/pkp-lib#1155. Discussions can only be seen if:
 * there is at least one message with non-null title, OR
 * there is at least one message with non-null body, OR
 * the null message was created by the current user, OR
 * the current user is a manager or editor.