### PR TITLE
Issue/1155

### DIFF
--- a/classes/note/NoteDAO.inc.php
+++ b/classes/note/NoteDAO.inc.php
@@ -76,7 +76,7 @@ class NoteDAO extends DAO {
 	 * @param $sortDirection int Optional sorting order constant: SORT_DIRECTION_...
 	 * @return object DAOResultFactory containing matching Note objects
 	 */
-	function getByAssoc($assocType, $assocId, $userId = null, $orderBy = NOTE_ORDER_DATE_CREATED, $sortDirection = SORT_DIRECTION_DESC) {
+	function getByAssoc($assocType, $assocId, $userId = null, $orderBy = NOTE_ORDER_DATE_CREATED, $sortDirection = SORT_DIRECTION_DESC, $isAdmin = false) {
 		$params = array((int) $assocId, (int) $assocType);
 		if ($userId) $params[] = (int) $userId;
 
@@ -103,8 +103,9 @@ class NoteDAO extends DAO {
 			FROM	notes
 			WHERE	assoc_id = ?
 				AND assoc_type = ?
-				' . ($userId?' AND user_id = ?':'') . '
-				AND (title IS NOT NULL OR contents IS NOT NULL)
+				' . ($userId?' AND user_id = ?':'') .
+				($isAdmin?'':'
+				AND (title IS NOT NULL OR contents IS NOT NULL)') . '
 			ORDER BY ' . $orderSanitized . ' ' . $directionSanitized,
 			$params
 		);

--- a/classes/note/NoteDAO.inc.php
+++ b/classes/note/NoteDAO.inc.php
@@ -104,6 +104,7 @@ class NoteDAO extends DAO {
 			WHERE	assoc_id = ?
 				AND assoc_type = ?
 				' . ($userId?' AND user_id = ?':'') . '
+				AND (title IS NOT NULL OR contents IS NOT NULL)
 			ORDER BY ' . $orderSanitized . ' ' . $directionSanitized,
 			$params
 		);

--- a/classes/query/Query.inc.php
+++ b/classes/query/Query.inc.php
@@ -120,11 +120,12 @@ class Query extends DataObject {
 	 * @param $userId int Optional user ID
 	 * @param $sortBy int Optional NOTE_ORDER_...
 	 * @param $sortOrder int Optional SORT_DIRECTION_...
+	 * @param $isAdmin bool Optional user sees all
 	 * @return DAOResultFactory
 	 */
-	function getReplies($userId = null, $sortBy = NOTE_ORDER_ID, $sortOrder = SORT_DIRECTION_ASC) {
+	function getReplies($userId = null, $sortBy = NOTE_ORDER_ID, $sortOrder = SORT_DIRECTION_ASC, $isAdmin = false) {
 		$noteDao = DAORegistry::getDAO('NoteDAO');
-		return $noteDao->getByAssoc(ASSOC_TYPE_QUERY, $this->getId(), null, $sortBy, $sortOrder);
+		return $noteDao->getByAssoc(ASSOC_TYPE_QUERY, $this->getId(), null, $sortBy, $sortOrder, $isAdmin);
 	}
 }
 

--- a/controllers/grid/queries/QueryNotesGridHandler.inc.php
+++ b/controllers/grid/queries/QueryNotesGridHandler.inc.php
@@ -151,7 +151,7 @@ class QueryNotesGridHandler extends GridHandler {
 	 * @copydoc GridHandler::loadData()
 	 */
 	function loadData($request, $filter = null) {
-		return $this->getQuery()->getReplies(null, NOTE_ORDER_DATE_CREATED, SORT_DIRECTION_ASC);
+		return $this->getQuery()->getReplies(null, NOTE_ORDER_DATE_CREATED, SORT_DIRECTION_ASC, $this->getCanManage(null));
 	}
 
 	//
@@ -188,14 +188,20 @@ class QueryNotesGridHandler extends GridHandler {
 
 	/**
 	 * Determine whether the current user can manage (delete) a note.
-	 * @param $note Note
+	 * @param $note Note optional
 	 * @return boolean
 	 */
 	function getCanManage($note) {
-		return ($note->getUserId() == $this->_user->getId() || 0 != count(array_intersect(
+		$isAdmin = (0 != count(array_intersect(
 			$this->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES),
 			array(ROLE_ID_MANAGER, ROLE_ID_ASSISTANT, ROLE_ID_SUB_EDITOR)
 		)));
+
+		if ($note === null) {
+			return $isAdmin;
+		} else {
+			return ($note->getUserId() == $this->_user->getId() || $isAdmin);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The first commit (e151f10) should be uncontroversial; it hides stub messages from conversations (pkp/pkp-lib#1155). It hides them from _all_ users, even if the user who created the stub. This potentially clutters the database if it happens a lot.

The second commit (8f63b58) allows admin users to see the stubs (the better to delete them with). It involves changes to more classes and methods, and might be objectionable…