### PR TITLE
fix warning if there are no optional columns in the usage stats form

### DIFF
--- a/plugins/generic/usageStats/UsageStatsSettingsForm.inc.php
+++ b/plugins/generic/usageStats/UsageStatsSettingsForm.inc.php
@@ -86,7 +86,7 @@ class UsageStatsSettingsForm extends Form {
 
 		$optionalColumns = $this->getData('optionalColumns');
 		// Make sure optional columns data makes sense.
-		if (in_array(STATISTICS_DIMENSION_CITY, $optionalColumns) && !in_array(STATISTICS_DIMENSION_REGION, $optionalColumns)) {
+		if ($optionalColumns && in_array(STATISTICS_DIMENSION_CITY, $optionalColumns) && !in_array(STATISTICS_DIMENSION_REGION, $optionalColumns)) {
 			$user = Request::getUser();
 			import('classes.notification.NotificationManager');
 			$notificationManager = new NotificationManager();


### PR DESCRIPTION
PHP Warning:  in_array() expects parameter 2 to be array, null given