### PR TITLE
pkp/pkp-lib#1381 Prevent mkdirtree infinite recursion

### DIFF
--- a/classes/file/FileManager.inc.php
+++ b/classes/file/FileManager.inc.php
@@ -348,7 +348,11 @@ class FileManager {
 	 */
 	function mkdirtree($dirPath, $perms = null) {
 		if (!file_exists($dirPath)) {
-			if ($this->mkdirtree(dirname($dirPath), $perms)) {
+			//Avoid infinite recursion when file_exists reports false for root directory
+			if ($dirPath == dirname ( $dirPath )) {
+				trigger_error ( 'There are no readable files in this directory tree. Is safe mode or open_basedir active?', E_USER_ERROR );
+				return false;
+			} else if ($this->mkdirtree(dirname($dirPath), $perms)) {
 				return $this->mkdir($dirPath, $perms);
 			} else {
 				return false;

--- a/classes/file/FileManager.inc.php
+++ b/classes/file/FileManager.inc.php
@@ -349,8 +349,8 @@ class FileManager {
 	function mkdirtree($dirPath, $perms = null) {
 		if (!file_exists($dirPath)) {
 			//Avoid infinite recursion when file_exists reports false for root directory
-			if ($dirPath == dirname ( $dirPath )) {
-				trigger_error ( 'There are no readable files in this directory tree. Is safe mode or open_basedir active?', E_USER_ERROR );
+			if ($dirPath == dirname($dirPath)) {
+				fatalError('There are no readable files in this directory tree. Are safe mode or open_basedir active?');
 				return false;
 			} else if ($this->mkdirtree(dirname($dirPath), $perms)) {
 				return $this->mkdir($dirPath, $perms);


### PR DESCRIPTION
Prevent infinite recursion when mkdirtree is called with a path where its first existing directory is outside those allowed by the open_basedir directive.

This is done by detecting when mkdirtree is about to make a recursive call to itself with the same parameters. That is, when the current given path is its own parent, which happens with the root directory ('/').