### PR TITLE
pkp/pkp-lib#1426: use only HTTP_ prefixed variables for server hostname detection.

### DIFF
--- a/classes/core/PKPRequest.inc.php
+++ b/classes/core/PKPRequest.inc.php
@@ -335,7 +335,7 @@ class PKPRequest {
 		if (!isset($_this->_serverHost)) {
 			$_this->_serverHost = isset($_SERVER['HTTP_X_FORWARDED_HOST']) ? $_SERVER['HTTP_X_FORWARDED_HOST']
 				: (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST']
-				: (isset($_SERVER['HOSTNAME']) ? $_SERVER['HOSTNAME']
+				: (isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME']
 				: null));
 
 			HookRegistry::call('Request::getServerHost', array(&$_this->_serverHost, &$default, &$includePort));

--- a/tests/classes/core/PKPRequestTest.php
+++ b/tests/classes/core/PKPRequestTest.php
@@ -254,6 +254,18 @@ class PKPRequestTest extends PKPTestCase {
 		$_SERVER = array(
 			'HOSTNAME' => 'hostname'
 		);
+		self::assertEquals('localhost', $this->request->getServerHost());
+	}
+
+	/**
+	 * @covers PKPRequest::getServerHost
+	 * @depends testGetServerHostLocalhost
+	 */
+	public function testGetServerHostWithServerName() {
+		// if HOSTNAME is set then return it
+		$_SERVER = array(
+			'SERVER_NAME' => 'hostname'
+		);
 		self::assertEquals('hostname', $this->request->getServerHost());
 	}
 


### PR DESCRIPTION
`$_SERVER['HOSTNAME']` is unlikely to return expected results in modern architectures.

This resolves https://github.com/pkp/pkp-lib/issues/1426 and helps to resolve https://github.com/pkp/pkp-lib/issues/1423, at the expense of anyone who is really still running an install on a dedicated physical server with a physical hostname matching the OJS install's DNS name, but not matching the config.inc.php base_url.
