### PR TITLE
pkp/pkp-lib#1507: Use SSL for RECAPTCHA if protocol is HTTPS or if config requires SSL

### DIFF
--- a/classes/notification/form/NotificationMailingListForm.inc.php
+++ b/classes/notification/form/NotificationMailingListForm.inc.php
@@ -73,7 +73,7 @@ class NotificationMailingListForm extends Form {
 		if ($this->captchaEnabled && $this->recaptchaEnabled) {
 			import('lib.pkp.lib.recaptcha.recaptchalib');
 			$publicKey = Config::getVar('captcha', 'recaptcha_public_key');
-			$useSSL = Config::getVar('security', 'force_ssl')?true:false;
+			$useSSL = Config::getVar('security', 'force_ssl')||Request::getProtocol()=='https'?true:false;
 			$reCaptchaHtml = recaptcha_get_html($publicKey, null, $useSSL);
 			$templateMgr->assign('reCaptchaHtml', $reCaptchaHtml);
 			$templateMgr->assign('captchaEnabled', true);


### PR DESCRIPTION
Partially resolves https://github.com/pkp/pkp-lib/issues/1507

Allows backwards compatibility in the unlikely case of SSL being forced, but the request coming in over HTTP (a proxy perhaps?) but primarily ensures if the Request is HTTPS, then SSL should be used.