### PR TITLE
Only allow to have recaptcha only on HTTPS

### DIFF
--- a/lib/recaptcha/recaptchalib.inc.php
+++ b/lib/recaptcha/recaptchalib.inc.php
@@ -35,7 +35,6 @@
 /**
  * The reCAPTCHA server URL's
  */
-define("RECAPTCHA_API_SERVER", "http://www.google.com/recaptcha/api");
 define("RECAPTCHA_API_SECURE_SERVER", "https://www.google.com/recaptcha/api");
 define("RECAPTCHA_VERIFY_SERVER", "www.google.com");
 
@@ -109,11 +108,7 @@ function recaptcha_get_html ($pubkey, $error = null, $use_ssl = false)
 		die ("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
 	}
 	
-	if ($use_ssl) {
-                $server = RECAPTCHA_API_SECURE_SERVER;
-        } else {
-                $server = RECAPTCHA_API_SERVER;
-        }
+        $server = RECAPTCHA_API_SECURE_SERVER;
 
         $errorpart = "";
         if ($error) {


### PR DESCRIPTION
To prevent the problem of using a force_ssl off and ssl on sign in on.
When this occurs, the sign on over ssl, the user will have a ssl session and the recaptcha will be requested using http protocol instead of https. If the recaptcha is always required in https, then the issue disapears.