### PR TITLE
pkp/pkp-lib#1555: Ensure LOCALE_COMPONENT_PKP_ADMIN is loaded before the use of $this->getName() by ScheduledTask.

### DIFF
--- a/classes/scheduledTask/ScheduledTask.inc.php
+++ b/classes/scheduledTask/ScheduledTask.inc.php
@@ -39,6 +39,9 @@ class ScheduledTask {
 	function ScheduledTask($args = array()) {
 		$this->_args = $args;
 		$this->_processId = uniqid();
+
+		// Ensure common locale keys are available
+		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_ADMIN, LOCALE_COMPONENT_PKP_COMMON);
 		
 		// Check the scheduled task execution log folder.
 		import('lib.pkp.classes.file.PrivateFileManager');
@@ -55,8 +58,6 @@ class ScheduledTask {
 				$this->_executionLogFile = null;
 			}
 		}
-
-		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_ADMIN, LOCALE_COMPONENT_PKP_COMMON);
 	}
 
 


### PR DESCRIPTION
Resolves https://github.com/pkp/pkp-lib/issues/1555.