### PR TITLE
default to sending mail from User in MailTemplate

### DIFF
--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -93,9 +93,8 @@ class MailTemplate extends Mail {
 
 		// Default "From" to user if available, otherwise site/context principal contact
 		if ($user) {
-			$this->setReplyTo($user->getEmail(), $user->getFullName());
-		}
-		if (!$context) {
+			$this->setFrom($user->getEmail(), $user->getFullName());
+		} elseif (is_null($context) || is_null($context->getSetting('contactEmail'))) {
 			$site = $request->getSite();
 			$this->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
 		} else {

--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -46,6 +46,9 @@ class MailTemplate extends Mail {
 	/** @var array The list of parameters to be assigned to the template. */
 	var $params;
 
+	/** @var string the email header to prepend */
+	var $emailHeader;
+
 	/**
 	 * Constructor.
 	 * @param $emailKey string unique identifier for the template
@@ -92,6 +95,7 @@ class MailTemplate extends Mail {
 		}
 
 		// Default "From" to user if available, otherwise site/context principal contact
+		$this->emailHeader = '';
 		if ($user) {
 			$this->setFrom($user->getEmail(), $user->getFullName());
 		} elseif (is_null($context) || is_null($context->getSetting('contactEmail'))) {
@@ -99,6 +103,7 @@ class MailTemplate extends Mail {
 			$this->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
 		} else {
 			$this->setFrom($context->getSetting('contactEmail'), $context->getSetting('contactName'));
+			$this->emailHeader = $context->getSetting('emailHeader');
 		}
 
 		if ($context) {
@@ -220,7 +225,7 @@ class MailTemplate extends Mail {
 			// them. This is here to accomodate MIME-encoded
 			// messages or other cases where the signature cannot
 			// just be appended.
-			$header = $this->context->getSetting('emailHeader');
+			$header = $this->emailHeader;
 			if (strstr($this->getBody(), '{$templateHeader}') === false) {
 				$this->setBody($header . "<br/>" . $this->getBody());
 			} else {

--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -219,19 +219,6 @@ class MailTemplate extends Mail {
 	 */
 	function send() {
 		if (isset($this->context)) {
-			//If {$templateSignature} and/or {$templateHeader}
-			// exist in the body of the message, replace them with
-			// the signature; otherwise just pre/append
-			// them. This is here to accomodate MIME-encoded
-			// messages or other cases where the signature cannot
-			// just be appended.
-			$header = $this->emailHeader;
-			if (strstr($this->getBody(), '{$templateHeader}') === false) {
-				$this->setBody($header . "<br/>" . $this->getBody());
-			} else {
-				$this->setBody(str_replace('{$templateHeader}', $header, $this->getBody()));
-			}
-
 			$signature = $this->context->getSetting('emailSignature');
 			if (strstr($this->getBody(), '{$templateSignature}') === false) {
 				$this->setBody($this->getBody() . "<br/>" . $signature);

--- a/controllers/tab/settings/emailTemplates/form/EmailTemplatesForm.inc.php
+++ b/controllers/tab/settings/emailTemplates/form/EmailTemplatesForm.inc.php
@@ -22,7 +22,6 @@ class EmailTemplatesForm extends ContextSettingsForm {
 	 */
 	function EmailTemplatesForm($wizardMode = false) {
 		$settings = array(
-			'emailHeader' => 'string',
 			'emailSignature' => 'string',
 			'envelopeSender' => 'string'
 		);

--- a/templates/controllers/tab/settings/emailTemplates/form/emailTemplatesForm.tpl
+++ b/templates/controllers/tab/settings/emailTemplates/form/emailTemplatesForm.tpl
@@ -22,9 +22,6 @@
 <form class="pkp_form" id="emailTemplatesForm" method="post" action="{url router=$smarty.const.ROUTE_COMPONENT component="tab.settings.PublicationSettingsTabHandler" op="saveFormData" tab="emailTemplates"}">
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="emailTemplatesFormNotification"}
 
-	{fbvFormSection label="manager.setup.emailHeader" for="emailHeader" description="manager.setup.emailHeaderDescription"}
-		{fbvElement type="textarea" id="emailHeader" value=$emailHeader size=$fbvStyles.size.LARGE rich=true variables=$emailVariables}
-	{/fbvFormSection}
 	{fbvFormSection label="manager.setup.emailSignature" for="emailSignature" description="manager.setup.emailSignatureDescription"}
 		{fbvElement type="textarea" id="emailSignature" value=$emailSignature size=$fbvStyles.size.LARGE rich=true variables=$emailVariables}
 	{/fbvFormSection}


### PR DESCRIPTION
This fixes up the default From header in the MailTemplate class in pkp-lib, so mail appears is sent from the logged in user first, before defaulting to site and then context.

the send() method already included a test that called getEnvelopeSender, which tests to see if envelope forcing is turned on before setting the Sender property of the mailer, so there was no need to adjust that.  OMP and OJS master both include force_default_envelope_sender options already.