### PR TITLE
Fix upgrading of plugins

### DIFF
--- a/classes/controllers/grid/plugins/PluginGridHandler.inc.php
+++ b/classes/controllers/grid/plugins/PluginGridHandler.inc.php
@@ -318,7 +318,9 @@ abstract class PluginGridHandler extends CategoryGridHandler {
 	 */
 	function saveUploadPlugin($args, $request) {
 		$function = $request->getUserVar('function');
-		$uploadPluginForm = new UploadPluginForm($function);
+		$plugin = $request->getUserVar('plugin');
+		$category = $request->getUserVar('category');
+		$uploadPluginForm = new UploadPluginForm($function, $plugin, $category);
 		$uploadPluginForm->readInputData();
 
 		if($uploadPluginForm->validate()) {
@@ -382,7 +384,9 @@ abstract class PluginGridHandler extends CategoryGridHandler {
 	 */
 	function _showUploadPluginForm($function, $request) {
 		import('lib.pkp.controllers.grid.plugins.form.UploadPluginForm');
-		$uploadPluginForm = new UploadPluginForm($function);
+		$plugin = $request->getUserVar('plugin');
+		$category = $request->getUserVar('category');
+		$uploadPluginForm = new UploadPluginForm($function, $plugin, $category);
 		$uploadPluginForm->initData();
 
 		return new JSONMessage(true, $uploadPluginForm->fetch($request));

--- a/controllers/grid/plugins/form/UploadPluginForm.inc.php
+++ b/controllers/grid/plugins/form/UploadPluginForm.inc.php
@@ -23,15 +23,18 @@ class UploadPluginForm extends Form {
 
 	/** @var String PLUGIN_ACTION_... */
 	var $_function;
+	var $_plugin;
+	var $_category;
 
 
 	/**
 	 * Constructor.
 	 * @param $function string PLUGIN_ACTION_...
 	 */
-	function UploadPluginForm($function) {
+	function UploadPluginForm($function, $plugin, $category) {
 		parent::Form('controllers/grid/plugins/form/uploadPluginForm.tpl');
-
+		$this->_plugin = $plugin;
+		$this->_category = $category;
 		$this->_function = $function;
 
 		$this->addCheck(new FormValidator($this, 'temporaryFileId', 'required', 'manager.plugins.uploadFailed'));
@@ -53,7 +56,8 @@ class UploadPluginForm extends Form {
 	function fetch($request) {
 		$templateMgr = TemplateManager::getManager($request);
 		$templateMgr->assign('function', $this->_function);
-
+		$templateMgr->assign('plugin', $this->_plugin);
+		$templateMgr->assign('category', $this->_category);
 		return parent::fetch($request);
 	}
 

--- a/templates/controllers/grid/plugins/form/uploadPluginForm.tpl
+++ b/templates/controllers/grid/plugins/form/uploadPluginForm.tpl
@@ -22,7 +22,7 @@
 	{rdelim});
 </script>
 
-<form class="pkp_form" id="uploadPluginForm" action="{url router=$smarty.const.ROUTE_COMPONENT op="saveUploadPlugin" function=$function}" method="post">
+<form class="pkp_form" id="uploadPluginForm" action="{url router=$smarty.const.ROUTE_COMPONENT op="saveUploadPlugin" function=$function category=$category plugin=$plugin}" method="post">
 	{csrf}
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="uploadPluginNotification"}
 	


### PR DESCRIPTION
As I noticed in #1523 upgrading plugins is currently broken.  
The plugin and it's category isn't currently propagated to the point of upgrade and this pr fixes that.  
This doesn't fix the upgrading completely however: If I try to upgrade plugin after these changes it says:

> The current role does not have access to this operation.

even though it's the admin account.
