### PR TITLE
pkp/pkp-lib#1347 common import export validation key

### DIFF
--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -517,4 +517,6 @@
 	<message key="manager.setup.licenseURLDescription">URL to a webpage describing the license, if available.</message>
 
 	<message key="manager.setup.metadata.submission">Submission Form</message>
+	<!--  common importexport keys -->
+	<message key="plugins.importexport.common.validationErrors">Validation errors:</message>
 </locale>


### PR DESCRIPTION
I've put this key in the pkp-lib, because it is used by ojs and omp, ok so?