### PR TITLE
pkp/pkp-lib#1810: quote undefined constants, which ought to be strings

### DIFF
--- a/classes/admin/form/PKPSiteSettingsForm.inc.php
+++ b/classes/admin/form/PKPSiteSettingsForm.inc.php
@@ -131,9 +131,9 @@ class PKPSiteSettingsForm extends Form {
 			$site->updateSetting('pageHeaderTitleImage', $setting, 'object', true);
 		}
 
-		$site->updateSetting('showThumbnail', $this->getData('showThumbnail'), bool);
-		$site->updateSetting('showTitle', $this->getData('showTitle'), bool);
-		$site->updateSetting('showDescription', $this->getData('showDescription'), bool);
+		$site->updateSetting('showThumbnail', $this->getData('showThumbnail'), 'bool');
+		$site->updateSetting('showTitle', $this->getData('showTitle'), 'bool');
+		$site->updateSetting('showDescription', $this->getData('showDescription'), 'bool');
 
 		$siteDao->updateObject($site);
 		return true;


### PR DESCRIPTION
Fixes #1810.