### PR TITLE
define column metric as integer instead of small integer

### DIFF
--- a/xml/schema/metrics.xml
+++ b/xml/schema/metrics.xml
@@ -44,7 +44,7 @@
 		<field name="metric_type" type="C2" size="255">
 			<NOTNULL />
 		</field>
-		<field name="metric" type="I2">
+		<field name="metric" type="I4">
 			<NOTNULL />
 		</field>
 


### PR DESCRIPTION
S. http://forum.pkp.sfu.ca/t/ojs-upgrade-failed-2-4-8-1-to-3-0-0/20226/7
the PR for ojs-stable-3_0_0 is coming too.
I am not sure if the cherry-picking to omp-stable-1_2 and omp-dev-1_2 is also necessary? :-)
