### PR TITLE
Check is_array again

### DIFF
--- a/classes/core/DataObject.inc.php
+++ b/classes/core/DataObject.inc.php
@@ -130,7 +130,8 @@ class DataObject {
 					if (empty($this->_data[$key])) unset($this->_data[$key]);
 				}
 			} else {
-				$this->_data[$key][$locale] = $value;
+				if (is_array($this->_data[$key])
+					$this->_data[$key][$locale] = $value;
 			}
 		}
 	}


### PR DESCRIPTION
If $this->_data[$key] isn't an array, then you might get something like:

`stderr: PHP Warning:  Cannot use a scalar value as an array in ojs3/lib/pkp/classes/core/DataObject.inc.php on line 134, referer: http://ojs3.localhost//admin/settings
`

This causes the settings page, in the first tab (settings), to be blank (and the "loading" icon to stay forever loading). This is related with custom locales (we are using es_AR, which seems to be very incomplete at the time).
I am not entirely sure what to do if is_array returns false. Maybe create it?