### PR TITLE
Make datepicker respect date formats #1868 fix

### DIFF
--- a/classes/core/PKPString.inc.php
+++ b/classes/core/PKPString.inc.php
@@ -347,7 +347,7 @@ class PKPString {
 	 * @param $pattern string Regular expression
 	 * @param $subject string String to apply regular expression to
 	 * @param $matches array Reference to receive matches
-	 * @return int|boolean Returns 1 if the pattern matches given subject, 0 if it does not, or FALSE if an error occurred. 
+	 * @return int|boolean Returns 1 if the pattern matches given subject, 0 if it does not, or FALSE if an error occurred.
 	 */
 	static function regexp_match_get($pattern, $subject, &$matches) {
 		// NOTE: This function was created since PHP < 5.x does not support optional reference parameters
@@ -360,7 +360,7 @@ class PKPString {
 	 * @param $pattern string Regular expression
 	 * @param $subject string String to apply regular expression to
 	 * @param $matches array Reference to receive matches
-	 * @return int|boolean Returns number of full matches of given subject, or FALSE if an error occurred. 
+	 * @return int|boolean Returns number of full matches of given subject, or FALSE if an error occurred.
 	 */
 	static function regexp_match_all($pattern, $subject, &$matches) {
 		if (PCRE_UTF8 && !self::utf8_compliant($subject)) $subject = self::utf8_bad_strip($subject);
@@ -1005,6 +1005,73 @@ class PKPString {
 				.strtoupper(dechex(hexdec(ord(substr($charid,16,1))) % 4 + 8)).substr($charid,17, 3).$hyphen
 				.substr($charid,20,12);
 		return $uuid;
+	}
+
+	/**
+	 * Matches each symbol of PHP date format string
+	 * to jQuery Datepicker widget date format.
+	 * @param $phpFormat string
+	 * @return string
+	 */
+	function dateformatPHP2JQueryDatepicker($phpFormat) {
+		$SYMBOLS = array(
+			// Day
+			'd' => 'dd',
+			'D' => 'D',
+			'j' => 'd',
+			'l' => 'DD',
+			'N' => '',
+			'S' => '',
+			'w' => '',
+			'z' => 'o',
+			// Week
+			'W' => '',
+			// Month
+			'F' => 'MM',
+			'm' => 'mm',
+			'M' => 'M',
+			'n' => 'm',
+			't' => '',
+			// Year
+			'L' => '',
+			'o' => '',
+			'Y' => 'yy',
+			'y' => 'y',
+			// Time
+			'a' => '',
+			'A' => '',
+			'B' => '',
+			'g' => '',
+			'G' => '',
+			'h' => '',
+			'H' => '',
+			'i' => '',
+			's' => '',
+			'u' => '',
+			// Other
+			'%' => ''
+		);
+
+		$datepickerFormat = "";
+		$escaping = false;
+
+		for ($i = 0; $i < strlen($phpFormat); $i++) {
+			$char = $phpFormat[$i];
+			if($char === '\\') {
+				$i++;
+				if($escaping) $datepickerFormat .= $phpFormat[$i];
+				else $datepickerFormat .= '\'' . $phpFormat[$i];
+				$escaping = true;
+			} else {
+				if($escaping) { $datepickerFormat .= "'"; $escaping = false; }
+				if(isset($SYMBOLS[$char])) 
+					$datepickerFormat .= $SYMBOLS[$char];
+				else
+					$datepickerFormat .= $char;
+			}
+		}
+
+		return $datepickerFormat;
 	}
 }
 

--- a/classes/core/PKPString.inc.php
+++ b/classes/core/PKPString.inc.php
@@ -1008,46 +1008,64 @@ class PKPString {
 	}
 
 	/**
-	 * Matches each symbol of PHP date format string
-	 * to jQuery Datepicker widget date format.
+	 * Matches each symbol of PHP strftime format string
+	 * to jQuery Datepicker widget date format. 
 	 * @param $phpFormat string
 	 * @return string
 	 */
 	function dateformatPHP2JQueryDatepicker($phpFormat) {
 		$symbols = array(
 			// Day
-			'd' => 'dd',
-			'D' => 'D',
-			'j' => 'd',
-			'l' => 'DD',
-			'N' => '',
-			'S' => '',
-			'w' => '',
-			'z' => 'o',
+			'a' => 'D',	// date() format 'D'
+			'A' => 'DD',	// date() format 'DD'
+			'd' => 'dd',	// date() format 'd'
+			'e' => 'd',	// date() format 'j'
+			'j' => 'oo',	// date() format none
+			'u' => '',		// date() format 'N'
+			'w' => '',		// date() format 'w'
+
 			// Week
-			'W' => '',
+			'U' => '',		// date() format none
+			'V' => '',		// date() format none
+			'W' => '',		// date() format 'W'
+
 			// Month
-			'F' => 'MM',
-			'm' => 'mm',
-			'M' => 'M',
-			'n' => 'm',
-			't' => '',
+			'b' => 'M',	// date() format 'M'
+			'h' => 'M',	// date() format 'M'
+			'B' => 'MM',	// date() format 'F'
+			'm' => 'mm',	// date() format 'm'
+
 			// Year
-			'L' => '',
-			'o' => '',
-			'Y' => 'yy',
-			'y' => 'y',
+			'C' => '',		// date() format none
+			'g' => 'y',	// date() format none
+			'G' => 'yy',	// date() format 'o'
+			'y' => 'y',	// date() format 'y'
+			'Y' => 'yy',	// date() format 'Y'
+
 			// Time
-			'a' => '',
-			'A' => '',
-			'B' => '',
-			'g' => '',
-			'G' => '',
-			'h' => '',
-			'H' => '',
-			'i' => '',
-			's' => '',
-			'u' => '',
+			'H' => '',		// date() format 'H'
+			'k' => '',		// date() format none
+			'I' => '',		// date() format 'h'
+			'l' => '',		// date() format 'g'
+			'P' => '',		// date() format 'a'
+			'p' => '',		// date() format 'A'
+			'M' => '',		// date() format 'i'
+			'S' => '',		// date() format 's'
+			's' => '',		// date() format 'u'
+
+			// Timezone
+			'z' => '',		// date() format 'O'
+			'Z' => '',		// date() format 'T'
+
+			// Full Date/Time
+			'r' => '',		// date() format none
+			'R' => '',		// date() format none
+			'X' => '',		// date() format none
+			'D' => '',		// date() format none
+			'F' => '',		// date() format none
+			'x' => '',		// date() format none
+			'c' => '',		// date() format none
+
 			// Other
 			'%' => ''
 		);
@@ -1069,7 +1087,7 @@ class PKPString {
 				}
 
 				$datepickerFormat .= isset($symbols[$char]) ? $symbols[$char] : $char;
-				
+
 			}
 		}
 

--- a/classes/core/PKPString.inc.php
+++ b/classes/core/PKPString.inc.php
@@ -1014,7 +1014,7 @@ class PKPString {
 	 * @return string
 	 */
 	function dateformatPHP2JQueryDatepicker($phpFormat) {
-		$SYMBOLS = array(
+		$symbols = array(
 			// Day
 			'd' => 'dd',
 			'D' => 'D',
@@ -1059,15 +1059,17 @@ class PKPString {
 			$char = $phpFormat[$i];
 			if($char === '\\') {
 				$i++;
-				if($escaping) $datepickerFormat .= $phpFormat[$i];
-				else $datepickerFormat .= '\'' . $phpFormat[$i];
+				$datepickerFormat .= $escaping ? $phpFormat[$i] : '\'' . $phpFormat[$i];
+
 				$escaping = true;
 			} else {
-				if($escaping) { $datepickerFormat .= "'"; $escaping = false; }
-				if(isset($SYMBOLS[$char])) 
-					$datepickerFormat .= $SYMBOLS[$char];
-				else
-					$datepickerFormat .= $char;
+				if($escaping) {
+					$datepickerFormat .= "'";
+					$escaping = false;
+				}
+
+				$datepickerFormat .= isset($symbols[$char]) ? $symbols[$char] : $char;
+				
 			}
 		}
 

--- a/classes/file/FileManager.inc.php
+++ b/classes/file/FileManager.inc.php
@@ -36,7 +36,7 @@ class FileManager {
 	/**
 	 * Constructor
 	 */
-	function __construct() {
+	function FileManager() {
 	}
 
 	/**
@@ -92,10 +92,10 @@ class FileManager {
 	 */
 	function getUploadedFileType($fileName) {
 		if (isset($_FILES[$fileName])) {
-			$type = PKPString::mime_content_type(
-				$_FILES[$fileName]['tmp_name'], // Location on server
-				array_pop(explode('.',$_FILES[$fileName]['name'])) // Extension on client machine
-			);
+			$type = PKPString::mime_content_type($_FILES[$fileName]['tmp_name']);
+
+			// pkp/pkp-lib#1893 Force text/css for .css files
+			if (in_array($type, array('text/plain', 'text/x-c')) && preg_match('/\.css$/i', $_FILES[$fileName]['name'])) return 'text/css';
 
 			if (!empty($type)) return $type;
 			return $_FILES[$fileName]['type'];

--- a/classes/form/FormBuilderVocabulary.inc.php
+++ b/classes/form/FormBuilderVocabulary.inc.php
@@ -434,7 +434,6 @@ class FormBuilderVocabulary {
 				case 'value':
 				case 'uniqId':
 					$smarty->assign('FBV_' . $key, $value); break;
-					break;
 				case 'required': if ($value != 'true') $textInputParams .= 'required="' + htmlspecialchars($value, ENT_QUOTES, LOCALE_ENCODING) +'"'; break;
 				default: $textInputParams .= htmlspecialchars($key, ENT_QUOTES, LOCALE_ENCODING) . '="' . htmlspecialchars($value, ENT_QUOTES, LOCALE_ENCODING). '" ';
 			}

--- a/classes/plugins/ImportExportPlugin.inc.php
+++ b/classes/plugins/ImportExportPlugin.inc.php
@@ -127,45 +127,22 @@ abstract class ImportExportPlugin extends Plugin {
 
 	/**
 	 * Return the plugin export directory.
-	 *
-	 * This will create the directory if it doesn't exist yet.
-	 *
-	 * @return string|array The export directory name or an array with
-	 *  errors if something went wrong.
+	 * @return string The export directory path.
 	 */
 	function getExportPath() {
-		$exportPath = Config::getVar('files', 'files_dir') . '/' . $this->getPluginSettingsPrefix();
-		if (!file_exists($exportPath)) {
-			$fileManager = new FileManager();
-			$fileManager->mkdir($exportPath);
-		}
-		if (!is_writable($exportPath)) {
-			$errors = array(
-					array('plugins.importexport.common.export.error.outputFileNotWritable', $exportPath)
-			);
-			return $errors;
-		}
-		return realpath($exportPath) . '/';
+		return Config::getVar('files', 'files_dir') . '/temp/';
 	}
 
 	/**
 	 * Return the whole export file name.
+	 * @param $basePath string Base path for temporary file storage
 	 * @param $objectsFileNamePart string Part different for each object type.
 	 * @param $context Context
+	 * @param $extension string
 	 * @return string
 	 */
-	function getExportFileName($objectsFileNamePart, $context) {
-		return $this->getExportPath() . date('Ymd-His') .'-' . $objectsFileNamePart .'-' . $context->getId() . '.xml';
-	}
-
-	/**
-	 * Remove the given temporary file.
-	 * @param $tempfile string
-	 */
-	function cleanTmpfile($tempfile) {
-		if (file_exists($tempfile)) {
-			unlink($tempfile);
-		}
+	function getExportFileName($basePath, $objectsFileNamePart, $context, $extension = '.xml') {
+		return $basePath . $this->getPluginSettingsPrefix() . '-' . date('Ymd-His') .'-' . $objectsFileNamePart .'-' . $context->getId() . $extension;
 	}
 
 }

--- a/classes/plugins/ImportExportPlugin.inc.php
+++ b/classes/plugins/ImportExportPlugin.inc.php
@@ -22,8 +22,8 @@ abstract class ImportExportPlugin extends Plugin {
 	/**
 	 * Constructor
 	 */
-	function __construct() {
-		parent::__construct();
+	function ImportExportPlugin() {
+		parent::Plugin();
 	}
 
 	/**
@@ -127,22 +127,45 @@ abstract class ImportExportPlugin extends Plugin {
 
 	/**
 	 * Return the plugin export directory.
-	 * @return string The export directory path.
+	 *
+	 * This will create the directory if it doesn't exist yet.
+	 *
+	 * @return string|array The export directory name or an array with
+	 *  errors if something went wrong.
 	 */
 	function getExportPath() {
-		return Config::getVar('files', 'files_dir') . '/temp/';
+		$exportPath = Config::getVar('files', 'files_dir') . '/' . $this->getPluginSettingsPrefix();
+		if (!file_exists($exportPath)) {
+			$fileManager = new FileManager();
+			$fileManager->mkdir($exportPath);
+		}
+		if (!is_writable($exportPath)) {
+			$errors = array(
+					array('plugins.importexport.common.export.error.outputFileNotWritable', $exportPath)
+			);
+			return $errors;
+		}
+		return realpath($exportPath) . '/';
 	}
 
 	/**
 	 * Return the whole export file name.
-	 * @param $basePath string Base path for temporary file storage
 	 * @param $objectsFileNamePart string Part different for each object type.
 	 * @param $context Context
-	 * @param $extension string
 	 * @return string
 	 */
-	function getExportFileName($basePath, $objectsFileNamePart, $context, $extension = '.xml') {
-		return $basePath . $this->getPluginSettingsPrefix() . '-' . date('Ymd-His') .'-' . $objectsFileNamePart .'-' . $context->getId() . $extension;
+	function getExportFileName($objectsFileNamePart, $context) {
+		return $this->getExportPath() . date('Ymd-His') .'-' . $objectsFileNamePart .'-' . $context->getId() . '.xml';
+	}
+
+	/**
+	 * Remove the given temporary file.
+	 * @param $tempfile string
+	 */
+	function cleanTmpfile($tempfile) {
+		if (file_exists($tempfile)) {
+			unlink($tempfile);
+		}
 	}
 
 }

--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -256,6 +256,7 @@ class PKPTemplateManager extends Smarty {
 		$this->register_modifier('translate', array('AppLocale', 'translate'));
 		$this->register_modifier('strip_unsafe_html', array('PKPString', 'stripUnsafeHtml'));
 		$this->register_modifier('String_substr', array('PKPString', 'substr'));
+		$this->register_modifier('dateformatPHP2JQueryDatepicker', array('PKPString', 'dateformatPHP2JQueryDatepicker'));
 		$this->register_modifier('to_array', array($this, 'smartyToArray'));
 		$this->register_modifier('compare', array($this, 'smartyCompare'));
 		$this->register_modifier('concat', array($this, 'smartyConcat'));

--- a/js/controllers/form/FormHandler.js
+++ b/js/controllers/form/FormHandler.js
@@ -51,7 +51,26 @@
 			this.callerSubmitHandler_ = options.submitHandler;
 		}
 
-		$('.datepicker').datepicker({dateFormat: 'yy-mm-dd'});
+		// Handle datepicker
+		// If we find a .datepicker in tpl the code adds (form/textInput.tpl) a new hidden field with the 
+		// id = <original-element-id>-altField
+		// attr: data-date-format = date format from config.inc.php translated into JQuery Datepicker date format
+		// The <original-element-name> if changed to <original-element-name>-removed in order for the hidden field value to send to post request
+		// altField and altFormat are used in order for the user to have its config.inc.php dateFormatShort parameter displayed 
+		// but 'yy-mm-dd' to be send to post request. [http://api.jqueryui.com/datepicker/#option-altField]
+		$('.datepicker').each(function () {
+			$(this).datepicker({
+				altField: '#' + $(this).prop('id') + '-altField',
+				altFormat: 'yy-mm-dd',
+				dateFormat: $('#' + $(this).prop('id') + '-altField').attr('data-date-format')
+			});
+
+			if (!$(this).hasClass('hasDatepicker')) {
+				$(this).prop('name', $(this).prop('name') + "-removed");
+			}
+		});
+
+		
 
 		// Set the redirect-to URL for the cancel button (if there is one).
 		if (options.cancelRedirectUrl) {
@@ -632,9 +651,10 @@
 	 */
 	$.pkp.controllers.form.FormHandler.prototype.showSpinner_ =
 			function() {
-		this.getHtmlElement()
-				.find('.formButtons .pkp_spinner').addClass('is_visible');
-	};
+				this.getHtmlElement()
+						.find('.formButtons .pkp_spinner').addClass('is_visible');
+			};
+
 
 /** @param {jQuery} $ jQuery closure. */
 }(jQuery));

--- a/js/controllers/form/FormHandler.js
+++ b/js/controllers/form/FormHandler.js
@@ -651,9 +651,9 @@
 	 */
 	$.pkp.controllers.form.FormHandler.prototype.showSpinner_ =
 			function() {
-				this.getHtmlElement()
-						.find('.formButtons .pkp_spinner').addClass('is_visible');
-			};
+		this.getHtmlElement()
+				.find('.formButtons .pkp_spinner').addClass('is_visible');
+	};
 
 
 /** @param {jQuery} $ jQuery closure. */

--- a/plugins/importexport/users/PKPUserImportExportPlugin.inc.php
+++ b/plugins/importexport/users/PKPUserImportExportPlugin.inc.php
@@ -19,8 +19,8 @@ abstract class PKPUserImportExportPlugin extends ImportExportPlugin {
 	/**
 	 * Constructor
 	 */
-	function __construct() {
-		parent::__construct();
+	function PKPUserImportExportPlugin() {
+		parent::ImportExportPlugin();
 	}
 
 	/**
@@ -140,24 +140,26 @@ abstract class PKPUserImportExportPlugin extends ImportExportPlugin {
 					$request->getContext(),
 					$request->getUser()
 				);
-				import('lib.pkp.classes.file.FileManager');
-				$fileManager = new FileManager();
-				$exportFileName = $this->getExportFileName($this->getExportPath(), 'users', $context, '.xml');
-				$fileManager->writeFile($exportFileName, $exportXml);
-				$fileManager->downloadFile($exportFileName);
-				$fileManager->deleteFile($exportFileName);
+				$exportFileName = $this->getExportFileName('users', $context);
+				file_put_contents($exportFileName, $exportXml);
+				header('Content-Type: application/xml');
+				header('Cache-Control: private');
+				header('Content-Disposition: attachment; filename="' . basename($exportFileName) . '"');
+				readfile($exportFileName);
+				$this->cleanTmpfile($exportFileName);
 				break;
 			case 'exportAllUsers':
 				$exportXml = $this->exportAllUsers(
 					$request->getContext(),
 					$request->getUser()
 				);
-				import('lib.pkp.classes.file.TemporaryFileManager');
-				$fileManager = new TemporaryFileManager();
-				$exportFileName = $this->getExportFileName($this->getExportPath(), 'users', $context, '.xml');
-				$fileManager->writeFile($exportFileName, $exportXml);
-				$fileManager->downloadFile($exportFileName);
-				$fileManager->deleteFile($exportFileName);
+				$exportFileName = $this->getExportFileName('users', $context);
+				file_put_contents($exportFileName, $exportXml);
+				header('Content-Type: application/xml');
+				header('Cache-Control: private');
+				header('Content-Disposition: attachment; filename="' . basename($exportFileName) . '"');
+				readfile($exportFileName);
+				$this->cleanTmpfile($exportFileName);
 				break;
 			default:
 				$dispatcher = $request->getDispatcher();

--- a/plugins/importexport/users/PKPUserImportExportPlugin.inc.php
+++ b/plugins/importexport/users/PKPUserImportExportPlugin.inc.php
@@ -140,26 +140,24 @@ abstract class PKPUserImportExportPlugin extends ImportExportPlugin {
 					$request->getContext(),
 					$request->getUser()
 				);
-				$exportFileName = $this->getExportFileName('users', $context);
-				file_put_contents($exportFileName, $exportXml);
-				header('Content-Type: application/xml');
-				header('Cache-Control: private');
-				header('Content-Disposition: attachment; filename="' . basename($exportFileName) . '"');
-				readfile($exportFileName);
-				$this->cleanTmpfile($exportFileName);
+				import('lib.pkp.classes.file.FileManager');
+				$fileManager = new FileManager();
+				$exportFileName = $this->getExportFileName($this->getExportPath(), 'users', $context, '.xml');
+				$fileManager->writeFile($exportFileName, $exportXml);
+				$fileManager->downloadFile($exportFileName);
+				$fileManager->deleteFile($exportFileName);
 				break;
 			case 'exportAllUsers':
 				$exportXml = $this->exportAllUsers(
 					$request->getContext(),
 					$request->getUser()
 				);
-				$exportFileName = $this->getExportFileName('users', $context);
-				file_put_contents($exportFileName, $exportXml);
-				header('Content-Type: application/xml');
-				header('Cache-Control: private');
-				header('Content-Disposition: attachment; filename="' . basename($exportFileName) . '"');
-				readfile($exportFileName);
-				$this->cleanTmpfile($exportFileName);
+				import('lib.pkp.classes.file.TemporaryFileManager');
+				$fileManager = new TemporaryFileManager();
+				$exportFileName = $this->getExportFileName($this->getExportPath(), 'users', $context, '.xml');
+				$fileManager->writeFile($exportFileName, $exportXml);
+				$fileManager->downloadFile($exportFileName);
+				$fileManager->deleteFile($exportFileName);
 				break;
 			default:
 				$dispatcher = $request->getDispatcher();

--- a/templates/controllers/grid/announcements/form/announcementForm.tpl
+++ b/templates/controllers/grid/announcements/form/announcementForm.tpl
@@ -52,7 +52,7 @@
 				{fbvElement type="textarea" multilingual="true" id="description" value=$description label="manager.announcements.form.descriptionInstructions" rich=true}
 			{/fbvFormSection}
 			{fbvFormSection title="manager.announcements.form.dateExpire" for="dataExpire"}
-				{fbvElement type="text" id="dateExpire" value=$dateExpire|date_format:"%y-%m-%d" label="manager.announcements.form.dateExpireInstructions" class="datepicker"}
+				{fbvElement type="text" id="dateExpire" value=$dateExpire|date_format:$dateFormatShort label="manager.announcements.form.dateExpireInstructions" class="datepicker"}
 			{/fbvFormSection}
 		{/fbvFormArea}
 		<p><span class="formRequired">{translate key="common.requiredField"}</span></p>

--- a/templates/form/textInput.tpl
+++ b/templates/form/textInput.tpl
@@ -62,6 +62,13 @@
 		{if $FBV_tabIndex} tabindex="{$FBV_tabIndex|escape}"{/if}
 	/>
 
+	{if $FBV_class|strstr:"datepicker"} 
+		<input data-date-format="{$dateFormatShort|dateformatPHP2JQueryDatepicker}" type="hidden" 
+		name="{$FBV_name|escape}{if $FBV_multilingual}[{$formLocale|escape}]{/if}"
+		value="{if $FBV_multilingual}{$FBV_value[$formLocale]|escape}{else}{$FBV_value|escape}{/if}"
+		id="{$FBV_id|escape}{$uniqId}-altField" />
+	{/if}
+
 	<span>{$FBV_label_content}</span>
 {/if}
 </div>

--- a/templates/frontend/objects/announcement_full.tpl
+++ b/templates/frontend/objects/announcement_full.tpl
@@ -16,7 +16,7 @@
 		{$announcement->getLocalizedTitle()}
 	</h1>
 	<div class="date">
-		{$announcement->getDatePosted()}
+		{$announcement->getDatePosted()|date_format:$dateFormatShort}
 	</div>
 	<div class="description">
 		{if $announcement->getLocalizedDescription()}

--- a/templates/frontend/objects/announcement_summary.tpl
+++ b/templates/frontend/objects/announcement_summary.tpl
@@ -21,7 +21,7 @@
 		</a>
 	</{$heading}>
 	<div class="date">
-		{$announcement->getDatePosted()}
+		{$announcement->getDatePosted()|date_format:$dateFormatShort}
 	</div>
 	<div class="summary">
 		{$announcement->getLocalizedDescriptionShort()|strip_unsafe_html}


### PR DESCRIPTION
@asmecher The past 2 days I was trying to find out if there was a case, or an already existing central mechanism that could port php variables in the FormHandler Javascript object, using its "options" parameter (like OJS does with grids and 'features' variable of the 'options' parameter). I couldn't find any.

So I decided to go with a general approach that includes some code changes in form/textInput.tpl and FormHandler.js.

Tried to add the altField and altFormat as well, as @NateWr suggested.

I have found some .datepicker initialization in other places to (other from FormHandler.js), not sure if I have to see those too. I will look at them. I added a function in PKPString that changes PHP date formats to JQuery Datepicker date formats, and registered it in PKPTemplateManager. Not sure if that is the right approach, or the right class to put that kind of a function.
