### PR TITLE
pkp/pkp-lib#1905: Move updateLastRunTime() call for CLI-based scheduled tasks before the execution

### DIFF
--- a/classes/cliTool/ScheduledTaskTool.inc.php
+++ b/classes/cliTool/ScheduledTaskTool.inc.php
@@ -109,8 +109,8 @@ class ScheduledTaskTool extends CommandLineTool {
 		if (!is_object($task =& instantiate($className, null, null, 'execute', $args))) {
 			fatalError('Cannot instantiate task class.');
 		}
-		$task->execute();
 		$this->taskDao->updateLastRunTime($className);
+		$task->execute();
 	}
 }
 


### PR DESCRIPTION
This helps resolve pkp/pkp-lib#1905 by aligning the two methods of running scheduled tasks to one another.  Calling the update before the execution enables the use of the last runtime as a more reliable semaphore.
