### PR TITLE
pkp/pkp-lib#1925: PKPString::mime_content_type() falls back on mime_content_type() if finfo_open() is not available.

### DIFF
--- a/classes/core/PKPString.inc.php
+++ b/classes/core/PKPString.inc.php
@@ -424,6 +424,15 @@ class PKPString {
 			}
 		}
 
+		if (!$result && function_exists('mime_content_type')) {
+			$result = mime_content_type($filename);
+			// mime_content_type appears to return a charset
+			// (erroneously?) in recent versions of PHP5
+			if (($i = strpos($result, ';')) !== false) {
+				$result = trim(substr($result, 0, $i));
+			}
+		}
+
 		if (!$result) {
 			// Fall back on an external "file" tool
 			$f = escapeshellarg($filename);


### PR DESCRIPTION
Resolves pkp/pkp-lib#1925.