### PR TITLE
pkp/pkp-lib#1728 fail import if revison uploader or user group is not…

### DIFF
--- a/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
@@ -154,10 +154,16 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 		// Determine the user group based on the user_group_ref element.
 		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
 		$userGroups = $userGroupDao->getByContextId($context->getId());
+		$unknownUserGroup = true;
 		while ($userGroup = $userGroups->next()) {
 			if (in_array($uploaderUserGroup, $userGroup->getName(null))) {
 				$submissionFile->setUserGroupId($userGroup->getId());
+				$unknownUserGroup = false;
+				break;
 			}
+		}
+		if ($unknownUserGroup) {
+			fatalError('Unknown user group "' . $uploaderUserGroup . '"!');
 		}
 
 		// Do the same for the user.
@@ -165,6 +171,8 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 		$user = $userDao->getByUsername($uploaderUsername);
 		if ($user) {
 			$submissionFile->setUploaderUserId($user->getId());
+		} else {
+			fatalError('Unknown uploader "' . $uploaderUsername . '"!');
 		}
 
 		$fileSize = $node->getAttribute('filesize');


### PR DESCRIPTION
… in the system

s. https://github.com/pkp/pkp-lib/issues/1728
This just calls `fatalError` like currently everywhere else in this plugin -- a better error handling will come with this issue https://github.com/pkp/pkp-lib/issues/1709