### PR TITLE
pkp/pkp-lib#1959 Disable PubMed web API tests for TLS auth problem

### DIFF
--- a/tests/plugins/citationLookup/pubmed/filter/PubmedNlm30CitationSchemaFilterTest.php
+++ b/tests/plugins/citationLookup/pubmed/filter/PubmedNlm30CitationSchemaFilterTest.php
@@ -28,6 +28,8 @@ class PubmedNlm30CitationSchemaFilterTest extends Nlm30CitationSchemaFilterTestC
 	 * @covers PubmedNlm30CitationSchemaFilter
 	 */
 	public function testExecuteWithPmid() {
+		$this->markTestSkipped('Web API authentication problem with older CURL/OpenSSL');
+
 		// Test article Pubmed lookup
 		$citationFilterTests = array(
 			array(
@@ -50,6 +52,8 @@ class PubmedNlm30CitationSchemaFilterTest extends Nlm30CitationSchemaFilterTestC
 	 * @covers PubmedNlm30CitationSchemaFilter
 	 */
 	public function testExecuteWithSearch() {
+		$this->markTestSkipped('Web API authentication problem with older CURL/OpenSSL');
+
 		// Build the test citations array
 		$citationFilterTests = array(
 			// strict search


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/1959