### PR TITLE
pkp/pkp-lib#1740 Prevent file browser from opening twice in Windows b…

### DIFF
--- a/js/controllers/UploaderHandler.js
+++ b/js/controllers/UploaderHandler.js
@@ -88,15 +88,26 @@
 		this.pluploader.bind('QueueChanged',
 				this.callbackWrapper(this.refreshUploader));
 
-		// Pass clicks from the visual button to plupload's file input
-		pluploaderId = this.pluploader.id;
-		this.getHtmlElement().find('#' + uploaderOptions.browse_button)
-				.click(function(e) {
-					e.preventDefault();
-					$(this).siblings('.moxie-shim').find('input').click();
-				});
+		// Ensure clicks on the visual button don't attempt to submit the form
+		var $browseButton = $('#' + uploaderOptions.browse_button, this.getHtmlElement());
+		$browseButton.click(function(e) {
+			return false;
+		});
 
 		this.pluploader.refresh();
+
+		// Fake a focus effect on the visual button when plupload's hidden
+		// button is focused
+		var self = this;
+		setTimeout( function() {
+			self.getHtmlElement().find('.moxie-shim input')
+			.focus(function(e) {
+				$browseButton.addClass('in_focus');
+			})
+			.blur(function(e) {
+				$browseButton.removeClass('in_focus');
+			});
+		}, 100);
 	};
 	$.pkp.classes.Helper.inherits(
 			$.pkp.controllers.UploaderHandler, $.pkp.classes.Handler);

--- a/js/controllers/UploaderHandler.js
+++ b/js/controllers/UploaderHandler.js
@@ -35,7 +35,10 @@
 				' to a div!'].join(''));
 		}
 
-		var uploaderOptions, pluploaderId;
+		var uploaderOptions,
+			pluploaderId,
+			$browseButton,
+			self;
 
 		// Set up options to pass to plupload
 		uploaderOptions = {
@@ -89,7 +92,7 @@
 				this.callbackWrapper(this.refreshUploader));
 
 		// Ensure clicks on the visual button don't attempt to submit the form
-		var $browseButton = $('#' + uploaderOptions.browse_button, this.getHtmlElement());
+		$browseButton = $('#' + uploaderOptions.browse_button, this.getHtmlElement());
 		$browseButton.click(function(e) {
 			return false;
 		});
@@ -98,7 +101,7 @@
 
 		// Fake a focus effect on the visual button when plupload's hidden
 		// button is focused
-		var self = this;
+		self = this;
 		setTimeout( function() {
 			self.getHtmlElement().find('.moxie-shim input')
 			.focus(function(e) {

--- a/styles/controllers/plupload.less
+++ b/styles/controllers/plupload.less
@@ -71,6 +71,10 @@
 
 .pkp_uploader_button {
 	float: right;
+
+	&.in_focus {
+		&:extend(.pkp_button:hover all);
+	}
 }
 
 .pkpUploaderProgress {

--- a/templates/controllers/fileUploadContainer.tpl
+++ b/templates/controllers/fileUploadContainer.tpl
@@ -70,7 +70,7 @@
 		<div class="pkpUploaderError"></div>
 
 		{* Button to add/change file *}
-		<button id="{$browseButton|escape}" class="pkp_uploader_button pkp_button">
+		<button id="{$browseButton|escape}" class="pkp_uploader_button pkp_button" tabindex="-1">
 			<span class="pkp_uploader_button_add">
 				{translate key=$stringAddFile}
 			</span>


### PR DESCRIPTION
…rowsers.

This commit removes code which passes clicks on the file upload
button to the plupload control. This code was added to improve
keyboard accessibility, but in Windows browsers it caused the
file browser to be opened twice.

Removing this code presents accessibility challenges, which were
addressed by providing visual feedback which mocked a focus
effect on the browse button when focus is placed on plupload's
control. This does not address the accessibility issue whereby
the plupload control has no meaningful text label. Screen readers
may suffer.

In addition, disabling clicks on the visual button could cause
some compatibility runtimes to break. plupload includes several
different compatibility runtimes to ensure as wide a browser
support as possible. But we're not able to test all of these
comprehensively. We may find the downside to this change is
bigger than the upside.