### PR TITLE
pkp/pkp-lib#2074: Update use of createElement and createElementNS escaping

### DIFF
--- a/plugins/importexport/native/filter/NativeExportFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeExportFilter.inc.php
@@ -41,7 +41,7 @@ class NativeExportFilter extends NativeImportExportFilter {
 		if (is_array($values)) {
 			foreach ($values as $locale => $value) {
 				if ($value === '') continue; // Skip empty values
-				$parentNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), $name, $value));
+				$parentNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), $name, htmlspecialchars($value, ENT_COMPAT, 'UTF-8')));
 				$node->setAttribute('locale', $locale);
 			}
 		}
@@ -59,7 +59,7 @@ class NativeExportFilter extends NativeImportExportFilter {
 		if ($value === '' || $value === null) return null;
 
 		$deployment = $this->getDeployment();
-		$parentNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), $name, $value));
+		$parentNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), $name, htmlspecialchars($value, ENT_COMPAT, 'UTF-8')));
 		return $node;
 	}
 }

--- a/plugins/importexport/native/filter/PKPAuthorNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/PKPAuthorNativeXmlFilter.inc.php
@@ -86,9 +86,9 @@ class PKPAuthorNativeXmlFilter extends NativeExportFilter {
 		$authorNode->setAttribute('user_group_ref', $userGroup->getName($context->getPrimaryLocale()));
 
 		// Add metadata
-		$authorNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'firstname', $author->getFirstName()));
+		$authorNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'firstname', htmlspecialchars($author->getFirstName(), ENT_COMPAT, 'UTF-8')));
 		$this->createOptionalNode($doc, $authorNode, 'middlename', $author->getMiddleName());
-		$authorNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'lastname', $author->getLastName()));
+		$authorNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'lastname', htmlspecialchars($author->getLastName(), ENT_COMPAT, 'UTF-8')));
 
 		$this->createLocalizedNodes($doc, $authorNode, 'affiliation', $author->getAffiliation(null));
 

--- a/plugins/importexport/native/filter/RepresentationNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/RepresentationNativeXmlFilter.inc.php
@@ -108,13 +108,13 @@ class RepresentationNativeXmlFilter extends NativeExportFilter {
 		$deployment = $this->getDeployment();
 
 		// Add internal ID
-		$representationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $representation->getId()));
+		$representationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($representation->getId(), ENT_COMPAT, 'UTF-8')));
 		$node->setAttribute('type', 'internal');
 		$node->setAttribute('advice', 'ignore');
 
 		// Add public ID
 		if ($pubId = $representation->getStoredPubId('publisher-id')) {
-			$representationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$representationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', 'public');
 			$node->setAttribute('advice', 'update');
 		}
@@ -138,7 +138,7 @@ class RepresentationNativeXmlFilter extends NativeExportFilter {
 		$pubId = $representation->getStoredPubId($pubIdPlugin->getPubIdType());
 		if ($pubId) {
 			$deployment = $this->getDeployment();
-			$representationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$representationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', $pubIdPlugin->getPubIdType());
 			$node->setAttribute('advice', 'update');
 			return $node;

--- a/plugins/importexport/native/filter/SubmissionFileNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/SubmissionFileNativeXmlFilter.inc.php
@@ -135,7 +135,7 @@ class SubmissionFileNativeXmlFilter extends NativeExportFilter {
 
 		// Add public ID
 		if ($pubId = $submissionFile->getStoredPubId('publisher-id')) {
-			$revisionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$revisionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', 'public');
 			$node->setAttribute('advice', 'update');
 		}
@@ -159,7 +159,7 @@ class SubmissionFileNativeXmlFilter extends NativeExportFilter {
 		$pubId = $submissionFile->getStoredPubId($pubIdPlugin->getPubIdType());
 		if ($pubId) {
 			$deployment = $this->getDeployment();
-			$revisionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$revisionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', $pubIdPlugin->getPubIdType());
 			$node->setAttribute('advice', 'update');
 			return $node;

--- a/plugins/importexport/native/filter/SubmissionNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/SubmissionNativeXmlFilter.inc.php
@@ -124,7 +124,7 @@ class SubmissionNativeXmlFilter extends NativeExportFilter {
 
 		// Add public ID
 		if ($pubId = $submission->getStoredPubId('publisher-id')) {
-			$submissionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$submissionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', 'public');
 			$node->setAttribute('advice', 'update');
 		}
@@ -148,7 +148,7 @@ class SubmissionNativeXmlFilter extends NativeExportFilter {
 		$pubId = $submission->getStoredPubId($pubIdPlugin->getPubIdType());
 		if ($pubId) {
 			$deployment = $this->getDeployment();
-			$submissionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$submissionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', $pubIdPlugin->getPubIdType());
 			$node->setAttribute('advice', 'update');
 			return $node;
@@ -203,7 +203,7 @@ class SubmissionNativeXmlFilter extends NativeExportFilter {
 				$controlledVocabulariesNode = $doc->createElementNS($deployment->getNamespace(), $controlledVocabulariesNodeName);
 				$controlledVocabulariesNode->setAttribute('locale', $locale);
 				foreach ($controlledVocabulary[$locale] as $controlledVocabularyItem) {
-					$controlledVocabulariesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), $controlledVocabularyNodeName, $controlledVocabularyItem));
+					$controlledVocabulariesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), $controlledVocabularyNodeName, htmlspecialchars($controlledVocabularyItem, ENT_COMPAT, 'UTF-8')));
 				}
 				$submissionNode->appendChild($controlledVocabulariesNode);
 			}

--- a/plugins/importexport/users/filter/PKPUserUserXmlFilter.inc.php
+++ b/plugins/importexport/users/filter/PKPUserUserXmlFilter.inc.php
@@ -83,22 +83,22 @@ class PKPUserUserXmlFilter extends NativeExportFilter {
 		$userNode = $doc->createElementNS($deployment->getNamespace(), 'user');
 
 		// Add metadata
-		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'firstname', $user->getFirstName()));
+		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'firstname', htmlspecialchars($user->getFirstName(), ENT_COMPAT, 'UTF-8')));
 		$this->createOptionalNode($doc, $userNode, 'middlename', $user->getMiddleName());
-		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'lastname', $user->getLastName()));
+		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'lastname', htmlspecialchars($user->getLastName(), ENT_COMPAT, 'UTF-8')));
 
 		if (is_array($user->getAffiliation(null))) {
 			$this->createLocalizedNodes($doc, $userNode, 'affiliation', $user->getAffiliation(null));
 		}
 
 		$this->createOptionalNode($doc, $userNode, 'country', $user->getCountry());
-		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'email', $user->getEmail()));
+		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'email', htmlspecialchars($user->getEmail(), ENT_COMPAT, 'UTF-8')));
 		$this->createOptionalNode($doc, $userNode, 'url', $user->getUrl());
 		if (is_array($user->getBiography(null))) {
 			$this->createLocalizedNodes($doc, $userNode, 'biography', $user->getBiography(null));
 		}
 
-		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'username', $user->getUsername()));
+		$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'username', htmlspecialchars($user->getUsername(), ENT_COMPAT, 'UTF-8')));
 
 		if (is_array($user->getGossip(null))) {
 			$this->createLocalizedNodes($doc, $userNode, 'gossip', $user->getGossip(null));
@@ -111,7 +111,7 @@ class PKPUserUserXmlFilter extends NativeExportFilter {
 		$passwordNode->setAttribute('is_disabled', $user->getDisabled() ? 'true' : 'false');
 		$passwordNode->setAttribute('must_change', $user->getMustChangePassword() ? 'true' : 'false');
 		$passwordNode->setAttribute('encryption', Config::getVar('security', 'encryption'));
-		$passwordNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'value', $user->getPassword()));
+		$passwordNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'value', htmlspecialchars($user->getPassword(), ENT_COMPAT, 'UTF-8')));
 
 		$userNode->appendChild($passwordNode);
 
@@ -140,7 +140,7 @@ class PKPUserUserXmlFilter extends NativeExportFilter {
 		while ($assignedGroup = $assignedGroups->next()) {
 			$userGroup = $userGroupDao->getById($assignedGroup->getUserGroupId());
 			if ($userGroup) {
-				$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'user_group_ref', $userGroup->getName($context->getPrimaryLocale())));
+				$userNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'user_group_ref', htmlspecialchars($userGroup->getName($context->getPrimaryLocale()), ENT_COMPAT, 'UTF-8')));
 			}
 		}
 

--- a/plugins/importexport/users/filter/UserGroupNativeXmlFilter.inc.php
+++ b/plugins/importexport/users/filter/UserGroupNativeXmlFilter.inc.php
@@ -90,7 +90,7 @@ class UserGroupNativeXmlFilter extends NativeExportFilter {
 
 		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
 		$assignedStages = $userGroupDao->getAssignedStagesByUserGroupId($context->getId(), $userGroup->getId());
-		$userGroupNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'stage_assignments', join(':', array_keys($assignedStages))));
+		$userGroupNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'stage_assignments', htmlspecialchars(join(':', array_keys($assignedStages)), ENT_COMPAT, 'UTF-8')));
 		return $userGroupNode;
 	}
 }


### PR DESCRIPTION
Specifically, in XML output contexts with user-sourced data.  Part of resolving pkp/pkp-lib#2074.

Our XML output is UTF-8 regardless of any user-selected locale, right?
