### PR TITLE
proposed Bitcoin ISO 4217 code (XTC) added

### DIFF
--- a/locale/ar_IQ/currencies.xml
+++ b/locale/ar_IQ/currencies.xml
@@ -173,4 +173,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/ca_ES/currencies.xml
+++ b/locale/ca_ES/currencies.xml
@@ -173,4 +173,5 @@
 	<currency name="Rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha zambià" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Dòlar de Zimbabwe" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/cs_CZ/currencies.xml
+++ b/locale/cs_CZ/currencies.xml
@@ -174,4 +174,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/da_DK/currencies.xml
+++ b/locale/da_DK/currencies.xml
@@ -177,4 +177,5 @@
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
 
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/de_DE/currencies.xml
+++ b/locale/de_DE/currencies.xml
@@ -173,4 +173,5 @@
 	<currency name="Rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Sambischer Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Simbabwe-Dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/el_GR/currencies.xml
+++ b/locale/el_GR/currencies.xml
@@ -174,4 +174,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Δολλάριο Ζιμπάμπουε" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/en_US/currencies.xml
+++ b/locale/en_US/currencies.xml
@@ -173,4 +173,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/es_AR/currencies.xml
+++ b/locale/es_AR/currencies.xml
@@ -174,4 +174,5 @@
 	<currency name="Rand sudafricano" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha zambiano" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Dólar zimbabuense" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/es_ES/currencies.xml
+++ b/locale/es_ES/currencies.xml
@@ -181,4 +181,5 @@
 	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
 	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Dólar de Zimbabwe" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/eu_ES/currencies.xml
+++ b/locale/eu_ES/currencies.xml
@@ -174,5 +174,6 @@
 	<currency name="Rand hegoafrikarra" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha zambiarra" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Dolar zimbawetarra" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>
 

--- a/locale/fa_IR/currencies.xml
+++ b/locale/fa_IR/currencies.xml
@@ -182,4 +182,5 @@
 	<currency name="ین" code_numeric="392" code_alpha="JPY" />
 	<currency name="یوان رنمیمبی" code_numeric="156" code_alpha="CNY" />
 	<currency name="دلار زیمبابو" code_numeric="716" code_alpha="ZWD" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/fr_CA/currencies.xml
+++ b/locale/fr_CA/currencies.xml
@@ -181,4 +181,5 @@
 	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
 	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Dollar zimbabwéen" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/gl_ES/currencies.xml
+++ b/locale/gl_ES/currencies.xml
@@ -182,4 +182,5 @@
 	<currency name="Ien" code_alpha="JPY" code_numeric="392" />
 	<currency name="Iuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Dólar de Cimbabue" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/hr_HR/currencies.xml
+++ b/locale/hr_HR/currencies.xml
@@ -181,4 +181,5 @@
 	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
 	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/id_ID/currencies.xml
+++ b/locale/id_ID/currencies.xml
@@ -173,4 +173,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/it_IT/currencies.xml
+++ b/locale/it_IT/currencies.xml
@@ -180,4 +180,5 @@
 	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
 	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Dollaro dello Zimbabwe" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/ja_JP/currencies.xml
+++ b/locale/ja_JP/currencies.xml
@@ -181,4 +181,5 @@
 	<currency name="円" code_alpha="円" code_numeric="392" />
 	<currency name="人民元" code_alpha="CNY" code_numeric="156" />
 	<currency name="ジンバブエ・ドル" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/ml_IN/currencies.xml
+++ b/locale/ml_IN/currencies.xml
@@ -174,4 +174,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/nb_NO/currencies.xml
+++ b/locale/nb_NO/currencies.xml
@@ -174,4 +174,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/nl_NL/currencies.xml
+++ b/locale/nl_NL/currencies.xml
@@ -184,4 +184,5 @@
 	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
 	<currency name="Renminbi Yuan" code_alpha="CNY" code_numeric="156" />
 	<currency name="Zimbabwaanse Dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/pt_BR/currencies.xml
+++ b/locale/pt_BR/currencies.xml
@@ -187,4 +187,5 @@
 	<currency name="Rial Iêmenita " code_alpha="YER" code_numeric="886" />
 	<currency name="Rand Sul-Africano" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Dolar do Zimbabwe" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/pt_PT/currencies.xml
+++ b/locale/pt_PT/currencies.xml
@@ -188,4 +188,5 @@
 	<currency name="Rial Iêmenita " code_alpha="YER" code_numeric="886" />
 	<currency name="Rand Sul-Africano" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Dólar do Zimbabwe" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/ro_RO/currencies.xml
+++ b/locale/ro_RO/currencies.xml
@@ -175,4 +175,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha zambian" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Dolar zimbabwean" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/ru_RU/currencies.xml
+++ b/locale/ru_RU/currencies.xml
@@ -181,4 +181,5 @@
 	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
 	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Доллар Зимбабве" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/sr_SR/currencies.xml
+++ b/locale/sr_SR/currencies.xml
@@ -178,4 +178,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/sv_SE/currencies.xml
+++ b/locale/sv_SE/currencies.xml
@@ -174,4 +174,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/tr_TR/currencies.xml
+++ b/locale/tr_TR/currencies.xml
@@ -182,4 +182,5 @@
 	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Zimbabve Doları" code_alpha="ZWD" code_numeric="716" />
 	<currency name="Cezayir Dinarı" code_alpha="DZD" code_numeric="12" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/uk_UA/currencies.xml
+++ b/locale/uk_UA/currencies.xml
@@ -176,4 +176,5 @@
 	<currency name="Ренд" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Замбійська квача" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Долар Зімбабве" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/vi_VN/currencies.xml
+++ b/locale/vi_VN/currencies.xml
@@ -181,4 +181,5 @@
 	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
 	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Đô-la Xim-ba-bui" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/zh_CN/currencies.xml
+++ b/locale/zh_CN/currencies.xml
@@ -175,4 +175,5 @@
 	<currency name="南非兰特" code_alpha="ZAR" code_numeric="710" />
 	<currency name="克瓦查" code_alpha="ZMK" code_numeric="894" />
 	<currency name="津巴布韦元" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>

--- a/locale/zh_TW/currencies.xml
+++ b/locale/zh_TW/currencies.xml
@@ -174,4 +174,5 @@
 	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
 	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
 	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Bitcoin" code_alpha="XTC" code_numeric="000" />
 </currencies>


### PR DESCRIPTION
cf. [https://en.bitcoin.it/wiki/Bitcoin_symbol#Currency_code](https://en.bitcoin.it/wiki/Bitcoin_symbol#Currency_code)