### PR TITLE
Fix missing locale component at about site

### DIFF
--- a/pages/about/AboutSiteHandler.inc.php
+++ b/pages/about/AboutSiteHandler.inc.php
@@ -22,6 +22,7 @@ class AboutSiteHandler extends Handler {
 	function __construct() {
 		parent::__construct();
 		AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON);
+		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_USER);
 	}
 
 	/**

--- a/pages/about/AboutSiteHandler.inc.php
+++ b/pages/about/AboutSiteHandler.inc.php
@@ -21,8 +21,7 @@ class AboutSiteHandler extends Handler {
 	 */
 	function __construct() {
 		parent::__construct();
-		AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON);
-		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_USER);
+		AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON, LOCALE_COMPONENT_PKP_USER);
 	}
 
 	/**


### PR DESCRIPTION
When logged in `templates/frontend/components/header.tpl` tries to get the translation for "user.logOut" (line 122). But the locale component is actually never loaded. So `##user.logOut##` is returned and shown in the popup instead of "Logout" (assuming the locale en_US).