### PR TITLE
pkp/pkp-lib#2129: Leverage FileWrapper class to provide proxy support for fetching plugin gallery xml.

### DIFF
--- a/classes/plugins/PluginGalleryDAO.inc.php
+++ b/classes/plugins/PluginGalleryDAO.inc.php
@@ -15,6 +15,7 @@
  */
 
 import('lib.pkp.classes.plugins.GalleryPlugin');
+import('lib.pkp.classes.file.FileWrapper');
 
 define('PLUGIN_GALLERY_XML_URL', 'http://pkp.sfu.ca/ojs/xml/plugins.xml');
 
@@ -58,7 +59,8 @@ class PluginGalleryDAO extends DAO {
 	 */
 	private function _getDocument() {
 		$doc = new DOMDocument('1.0');
-		$doc->load(PLUGIN_GALLERY_XML_URL);
+		$gallery = FileWrapper::wrapper(PLUGIN_GALLERY_XML_URL);
+		$doc->loadXML($gallery->contents());
 		return $doc;
 	}
 


### PR DESCRIPTION
Resolves pkp/pkp-lib#2129; reported [successfully tested](http://forum.pkp.sfu.ca/t/allow-url-fopen-issue/27144/4?u=ctgraham).