### PR TITLE
Update ISO lists according to the current ISO standards

### DIFF
--- a/locale/en_US/countries.xml
+++ b/locale/en_US/countries.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2000-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localized list of countries. Based on ISO 3166-1.
+  * Localized list of countries. Based on ISO 3166-1:2006.
   -->
 <countries>
 	<country name="Afghanistan" code="AF"/>
@@ -37,7 +37,7 @@
 	<country name="Benin" code="BJ"/>
 	<country name="Bermuda" code="BM"/>
 	<country name="Bhutan" code="BT"/>
-	<country name="Bolivia, Plurinational State of" code="BO"/>
+	<country name="Bolivia (Plurinational State of)" code="BO"/>
 	<country name="Bonaire, Sint Eustatius and Saba" code="BQ"/>
 	<country name="Bosnia and Herzegovina" code="BA"/>
 	<country name="Botswana" code="BW"/>
@@ -48,10 +48,10 @@
 	<country name="Bulgaria" code="BG"/>
 	<country name="Burkina Faso" code="BF"/>
 	<country name="Burundi" code="BI"/>
+	<country name="Cabo Verde" code="CV"/>
 	<country name="Cambodia" code="KH"/>
 	<country name="Cameroon" code="CM"/>
 	<country name="Canada" code="CA"/>
-	<country name="Cape Verde" code="CV"/>
 	<country name="Cayman Islands" code="KY"/>
 	<country name="Central African Republic" code="CF"/>
 	<country name="Chad" code="TD"/>
@@ -62,7 +62,7 @@
 	<country name="Colombia" code="CO"/>
 	<country name="Comoros" code="KM"/>
 	<country name="Congo" code="CG"/>
-	<country name="Congo, The Democratic Republic of the" code="CD"/>
+	<country name="Congo (the Democratic Republic of the)" code="CD"/>
 	<country name="Cook Islands" code="CK"/>
 	<country name="Costa Rica" code="CR"/>
 	<country name="Côte d'Ivoire" code="CI"/>
@@ -70,7 +70,7 @@
 	<country name="Cuba" code="CU"/>
 	<country name="Curaçao" code="CW"/>
 	<country name="Cyprus" code="CY"/>
-	<country name="Czech Republic" code="CZ"/>
+	<country name="Czechia" code="CZ"/>
 	<country name="Denmark" code="DK"/>
 	<country name="Djibouti" code="DJ"/>
 	<country name="Dominica" code="DM"/>
@@ -82,7 +82,7 @@
 	<country name="Eritrea" code="ER"/>
 	<country name="Estonia" code="EE"/>
 	<country name="Ethiopia" code="ET"/>
-	<country name="Falkland Islands (Malvinas)" code="FK"/>
+	<country name="Falkland Islands [Malvinas]" code="FK"/>
 	<country name="Faroe Islands" code="FO"/>
 	<country name="Fiji" code="FJ"/>
 	<country name="Finland" code="FI"/>
@@ -108,14 +108,14 @@
 	<country name="Guyana" code="GY"/>
 	<country name="Haiti" code="HT"/>
 	<country name="Heard Island and McDonald Islands" code="HM"/>
-	<country name="Holy See (Vatican City State)" code="VA"/>
+	<country name="Holy See" code="VA"/>
 	<country name="Honduras" code="HN"/>
 	<country name="Hong Kong" code="HK"/>
 	<country name="Hungary" code="HU"/>
 	<country name="Iceland" code="IS"/>
 	<country name="India" code="IN"/>
 	<country name="Indonesia" code="ID"/>
-	<country name="Iran, Islamic Republic of" code="IR"/>
+	<country name="Iran (Islamic Republic of)" code="IR"/>
 	<country name="Iraq" code="IQ"/>
 	<country name="Ireland" code="IE"/>
 	<country name="Isle of Man" code="IM"/>
@@ -128,8 +128,8 @@
 	<country name="Kazakhstan" code="KZ"/>
 	<country name="Kenya" code="KE"/>
 	<country name="Kiribati" code="KI"/>
-	<country name="Korea, Democratic People's Republic of" code="KP"/>
-	<country name="Korea, Republic of" code="KR"/>
+	<country name="Korea (the Democratic People's Republic of)" code="KP"/>
+	<country name="Korea (the Republic of)" code="KR"/>
 	<country name="Kuwait" code="KW"/>
 	<country name="Kyrgyzstan" code="KG"/>
 	<country name="Lao People's Democratic Republic" code="LA"/>
@@ -142,7 +142,7 @@
 	<country name="Lithuania" code="LT"/>
 	<country name="Luxembourg" code="LU"/>
 	<country name="Macao" code="MO"/>
-	<country name="Macedonia, Republic of" code="MK"/>
+	<country name="Macedonia (the former Yugoslav Republic of)" code="MK"/>
 	<country name="Madagascar" code="MG"/>
 	<country name="Malawi" code="MW"/>
 	<country name="Malaysia" code="MY"/>
@@ -155,8 +155,8 @@
 	<country name="Mauritius" code="MU"/>
 	<country name="Mayotte" code="YT"/>
 	<country name="Mexico" code="MX"/>
-	<country name="Micronesia, Federated States of" code="FM"/>
-	<country name="Moldova, Republic of" code="MD"/>
+	<country name="Micronesia (Federated States of)" code="FM"/>
+	<country name="Moldova (the Republic of)" code="MD"/>
 	<country name="Monaco" code="MC"/>
 	<country name="Mongolia" code="MN"/>
 	<country name="Montenegro" code="ME"/>
@@ -218,17 +218,17 @@
 	<country name="Somalia" code="SO"/>
 	<country name="South Africa" code="ZA"/>
 	<country name="South Georgia and the South Sandwich Islands" code="GS"/>
+	<country name="South Sudan" code="SS"/>
 	<country name="Spain" code="ES"/>
 	<country name="Sri Lanka" code="LK"/>
 	<country name="Sudan" code="SD"/>
 	<country name="Suriname" code="SR"/>
-	<country name="South Sudan" code="SS"/>
 	<country name="Svalbard and Jan Mayen" code="SJ"/>
 	<country name="Swaziland" code="SZ"/>
 	<country name="Sweden" code="SE"/>
 	<country name="Switzerland" code="CH"/>
 	<country name="Syrian Arab Republic" code="SY"/>
-	<country name="Taiwan, Province of China" code="TW"/>
+	<country name="Taiwan (Province of China)" code="TW"/>
 	<country name="Tajikistan" code="TJ"/>
 	<country name="Tanzania, United Republic of" code="TZ"/>
 	<country name="Thailand" code="TH"/>
@@ -245,16 +245,16 @@
 	<country name="Uganda" code="UG"/>
 	<country name="Ukraine" code="UA"/>
 	<country name="United Arab Emirates" code="AE"/>
-	<country name="United Kingdom" code="GB"/>
-	<country name="United States" code="US"/>
+	<country name="United Kingdom of Great Britain and Nothern Ireland" code="GB"/>
 	<country name="United States Minor Outlying Islands" code="UM"/>
+	<country name="United States of America" code="US"/>
 	<country name="Uruguay" code="UY"/>
 	<country name="Uzbekistan" code="UZ"/>
 	<country name="Vanuatu" code="VU"/>
-	<country name="Venezuela, Bolivarian Republic of" code="VE"/>
+	<country name="Venezuela (Bolivarian Republic of)" code="VE"/>
 	<country name="Viet Nam" code="VN"/>
-	<country name="Virgin Islands, British" code="VG"/>
-	<country name="Virgin Islands, U.S." code="VI"/>
+	<country name="Virgin Islands (British)" code="VG"/>
+	<country name="Virgin Islands (U.S.)" code="VI"/>
 	<country name="Wallis and Futuna" code="WF"/>
 	<country name="Western Sahara" code="EH"/>
 	<country name="Yemen" code="YE"/>

--- a/locale/en_US/currencies.xml
+++ b/locale/en_US/currencies.xml
@@ -8,169 +8,165 @@
   * Copyright (c) 2000-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Currencies data XML file. Based on ISO 4217.
+  * Currencies data XML file. Based on ISO 4217:2015.
   -->
 
 <currencies locale="en_US">
 	<currency name="US dollar" code_alpha="USD" code_numeric="840" />
 	<currency name="Euro" code_alpha="EUR" code_numeric="978" />
-	<currency name="Canadian dollar" code_alpha="CAD" code_numeric="124" />
-	<currency name="United Arab Emirates dirham" code_alpha="AED" code_numeric="784" />
+	<currency name="Canadian Dollar" code_alpha="CAD" code_numeric="124" />
+	<currency name="UAE Dirham" code_alpha="AED" code_numeric="784" />
 	<currency name="Afghani" code_alpha="AFN" code_numeric="971" />
 	<currency name="Lek" code_alpha="ALL" code_numeric="008" />
-	<currency name="Armenian dram" code_alpha="AMD" code_numeric="051" />
-	<currency name="Netherlands Antillean guilder" code_alpha="ANG" code_numeric="532" />
+	<currency name="Armenian Dram" code_alpha="AMD" code_numeric="051" />
+	<currency name="Netherlands Antillean Guilder" code_alpha="ANG" code_numeric="532" />
 	<currency name="Kwanza" code_alpha="AOA" code_numeric="973" />
-	<currency name="Argentine peso" code_alpha="ARS" code_numeric="032" />
-	<currency name="Australian dollar" code_alpha="AUD" code_numeric="036" />
-	<currency name="Aruban guilder" code_alpha="AWG" code_numeric="533" />
-	<currency name="Azerbaijanian manat" code_alpha="AZN" code_numeric="944" />
-	<currency name="Convertible marks" code_alpha="BAM" code_numeric="977" />
-	<currency name="Barbados dollar" code_alpha="BBD" code_numeric="052" />
-	<currency name="Bangladeshi taka" code_alpha="BDT" code_numeric="050" />
-	<currency name="Bulgarian lev" code_alpha="BGN" code_numeric="975" />
-	<currency name="Bahraini dinar" code_alpha="BHD" code_numeric="048" />
-	<currency name="Burundian franc" code_alpha="BIF" code_numeric="108" />
-	<currency name="Bermudian dollar (customarily known as Bermuda dollar)" code_alpha="BMD" code_numeric="060" />
-	<currency name="Brunei dollar" code_alpha="BND" code_numeric="096" />
+	<currency name="Argentine Peso" code_alpha="ARS" code_numeric="032" />
+	<currency name="Australian Dollar" code_alpha="AUD" code_numeric="036" />
+	<currency name="Aruban Florin" code_alpha="AWG" code_numeric="533" />
+	<currency name="Azerbaijanian Manat" code_alpha="AZN" code_numeric="944" />
+	<currency name="Convertible Mark" code_alpha="BAM" code_numeric="977" />
+	<currency name="Barbados Dollar" code_alpha="BBD" code_numeric="052" />
+	<currency name="Taka" code_alpha="BDT" code_numeric="050" />
+	<currency name="Bulgarian Lev" code_alpha="BGN" code_numeric="975" />
+	<currency name="Bahraini Dinar" code_alpha="BHD" code_numeric="048" />
+	<currency name="Burundi Franc" code_alpha="BIF" code_numeric="108" />
+	<currency name="Bermudian Dollar" code_alpha="BMD" code_numeric="060" />
+	<currency name="Brunei Dollar" code_alpha="BND" code_numeric="096" />
 	<currency name="Boliviano" code_alpha="BOB" code_numeric="068" />
-	<currency name="Bolivian Mvdol (funds code)" code_alpha="BOV" code_numeric="984" />
-	<currency name="Brazilian real" code_alpha="BRL" code_numeric="986" />
-	<currency name="Bahamian dollar" code_alpha="BSD" code_numeric="044" />
+	<currency name="Brazilian Real" code_alpha="BRL" code_numeric="986" />
+	<currency name="Bahamian Dollar" code_alpha="BSD" code_numeric="044" />
 	<currency name="Ngultrum" code_alpha="BTN" code_numeric="064" />
 	<currency name="Pula" code_alpha="BWP" code_numeric="072" />
-	<currency name="Belarussian ruble" code_alpha="BYR" code_numeric="974" />
-	<currency name="Belize dollar" code_alpha="BZD" code_numeric="084" />
-	<currency name="Franc Congolais" code_alpha="CDF" code_numeric="976" />
-	<currency name="Swiss franc" code_alpha="CHF" code_numeric="756" />
-	<currency name="Chilean peso" code_alpha="CLP" code_numeric="152" />
-	<currency name="Renminbi" code_alpha="CNY" code_numeric="156" />
+	<currency name="Belarusian Ruble" code_alpha="BYN" code_numeric="933" />
+	<currency name="Belize Dollar" code_alpha="BZD" code_numeric="084" />
+	<currency name="Congolese Franc" code_alpha="CDF" code_numeric="976" />
+	<currency name="Swiss Franc" code_alpha="CHF" code_numeric="756" />
+	<currency name="Chilean Peso" code_alpha="CLP" code_numeric="152" />
+	<currency name="Yuan Renminbi" code_alpha="CNY" code_numeric="156" />
 	<currency name="Colombian peso" code_alpha="COP" code_numeric="170" />
-	<currency name="Unidad de Valor Real" code_alpha="COU" code_numeric="970" />
-	<currency name="Costa Rican colon" code_alpha="CRC" code_numeric="188" />
-	<currency name="Cuban peso" code_alpha="CUP" code_numeric="192" />
-	<currency name="Cape Verde escudo" code_alpha="CVE" code_numeric="132" />
-	<currency name="Czech koruna" code_alpha="CZK" code_numeric="203" />
-	<currency name="Djibouti franc" code_alpha="DJF" code_numeric="262" />
-	<currency name="Danish krone" code_alpha="DKK" code_numeric="208" />
-	<currency name="Dominican peso" code_alpha="DOP" code_numeric="214" />
-	<currency name="Algerian dinar" code_alpha="DZD" code_numeric="012" />
-	<currency name="Kroon" code_alpha="EEK" code_numeric="233" />
-	<currency name="Egyptian pound" code_alpha="EGP" code_numeric="818" />
+	<currency name="Costa Rican Colon" code_alpha="CRC" code_numeric="188" />
+	<currency name="Cuban Peso" code_alpha="CUP" code_numeric="192" />
+	<currency name="Peso Convertible" code_alpha="CUC" code_numeric="931" />
+	<currency name="Cabo Verde Escudo" code_alpha="CVE" code_numeric="132" />
+	<currency name="Czech Koruna" code_alpha="CZK" code_numeric="203" />
+	<currency name="Djibouti Franc" code_alpha="DJF" code_numeric="262" />
+	<currency name="Danish Krone" code_alpha="DKK" code_numeric="208" />
+	<currency name="Dominican Peso" code_alpha="DOP" code_numeric="214" />
+	<currency name="Algerian Dinar" code_alpha="DZD" code_numeric="012" />
+	<currency name="Egyptian Pound" code_alpha="EGP" code_numeric="818" />
 	<currency name="Nakfa" code_alpha="ERN" code_numeric="232" />
-	<currency name="Ethiopian birr" code_alpha="ETB" code_numeric="230" />
-	<currency name="Fiji dollar" code_alpha="FJD" code_numeric="242" />
-	<currency name="Falkland Islands pound" code_alpha="FKP" code_numeric="238" />
-	<currency name="Pound sterling" code_alpha="GBP" code_numeric="826" />
+	<currency name="Ethiopian Birr" code_alpha="ETB" code_numeric="230" />
+	<currency name="Fiji Dollar" code_alpha="FJD" code_numeric="242" />
+	<currency name="Falkland Islands Pound" code_alpha="FKP" code_numeric="238" />
+	<currency name="Pound Sterling" code_alpha="GBP" code_numeric="826" />
 	<currency name="Lari" code_alpha="GEL" code_numeric="981" />
-	<currency name="Cedi" code_alpha="GHS" code_numeric="936" />
-	<currency name="Gibraltar pound" code_alpha="GIP" code_numeric="292" />
+	<currency name="Ghana Cedi" code_alpha="GHS" code_numeric="936" />
+	<currency name="Gibraltar Pound" code_alpha="GIP" code_numeric="292" />
 	<currency name="Dalasi" code_alpha="GMD" code_numeric="270" />
-	<currency name="Guinea franc" code_alpha="GNF" code_numeric="324" />
+	<currency name="Guinea Franc" code_alpha="GNF" code_numeric="324" />
 	<currency name="Quetzal" code_alpha="GTQ" code_numeric="320" />
-	<currency name="Guyana dollar" code_alpha="GYD" code_numeric="328" />
-	<currency name="Hong Kong dollar" code_alpha="HKD" code_numeric="344" />
+	<currency name="Guyana Dollar" code_alpha="GYD" code_numeric="328" />
+	<currency name="Hong Kong Dollar" code_alpha="HKD" code_numeric="344" />
 	<currency name="Lempira" code_alpha="HNL" code_numeric="340" />
-	<currency name="Croatian kuna" code_alpha="HRK" code_numeric="191" />
-	<currency name="Haiti gourde" code_alpha="HTG" code_numeric="332" />
+	<currency name="Kuna" code_alpha="HRK" code_numeric="191" />
+	<currency name="Gourde" code_alpha="HTG" code_numeric="332" />
 	<currency name="Forint" code_alpha="HUF" code_numeric="348" />
 	<currency name="Rupiah" code_alpha="IDR" code_numeric="360" />
-	<currency name="New Israeli shekel" code_alpha="ILS" code_numeric="376" />
-	<currency name="Indian rupee" code_alpha="INR" code_numeric="356" />
-	<currency name="Iraqi dinar" code_alpha="IQD" code_numeric="368" />
-	<currency name="Iranian rial" code_alpha="IRR" code_numeric="364" />
-	<currency name="Iceland krona" code_alpha="ISK" code_numeric="352" />
-	<currency name="Jamaican dollar" code_alpha="JMD" code_numeric="388" />
-	<currency name="Jordanian dinar" code_alpha="JOD" code_numeric="400" />
-	<currency name="Japanese yen" code_alpha="JPY" code_numeric="392" />
-	<currency name="Kenyan shilling" code_alpha="KES" code_numeric="404" />
+	<currency name="New Israeli Sheqel" code_alpha="ILS" code_numeric="376" />
+	<currency name="Indian Rupee" code_alpha="INR" code_numeric="356" />
+	<currency name="Iraqi Dinar" code_alpha="IQD" code_numeric="368" />
+	<currency name="Iranian Rial" code_alpha="IRR" code_numeric="364" />
+	<currency name="Iceland Krona" code_alpha="ISK" code_numeric="352" />
+	<currency name="Jamaican Dollar" code_alpha="JMD" code_numeric="388" />
+	<currency name="Jordanian Dinar" code_alpha="JOD" code_numeric="400" />
+	<currency name="Yen" code_alpha="JPY" code_numeric="392" />
+	<currency name="Kenyan Shilling" code_alpha="KES" code_numeric="404" />
 	<currency name="Som" code_alpha="KGS" code_numeric="417" />
 	<currency name="Riel" code_alpha="KHR" code_numeric="116" />
-	<currency name="Comoro franc" code_alpha="KMF" code_numeric="174" />
-	<currency name="North Korean won" code_alpha="KPW" code_numeric="408" />
-	<currency name="South Korean won" code_alpha="KRW" code_numeric="410" />
-	<currency name="Kuwaiti dinar" code_alpha="KWD" code_numeric="414" />
-	<currency name="Cayman Islands dollar" code_alpha="KYD" code_numeric="136" />
+	<currency name="Comoro Franc" code_alpha="KMF" code_numeric="174" />
+	<currency name="North Korean Won" code_alpha="KPW" code_numeric="408" />
+	<currency name="Won" code_alpha="KRW" code_numeric="410" />
+	<currency name="Kuwaiti Dinar" code_alpha="KWD" code_numeric="414" />
+	<currency name="Cayman Islands Dollar" code_alpha="KYD" code_numeric="136" />
 	<currency name="Tenge" code_alpha="KZT" code_numeric="398" />
 	<currency name="Kip" code_alpha="LAK" code_numeric="418" />
-	<currency name="Lebanese pound" code_alpha="LBP" code_numeric="422" />
-	<currency name="Sri Lanka rupee" code_alpha="LKR" code_numeric="144" />
-	<currency name="Liberian dollar" code_alpha="LRD" code_numeric="430" />
+	<currency name="Lebanese Pound" code_alpha="LBP" code_numeric="422" />
+	<currency name="Sri Lanka Rupee" code_alpha="LKR" code_numeric="144" />
+	<currency name="Liberian Dollar" code_alpha="LRD" code_numeric="430" />
 	<currency name="Loti" code_alpha="LSL" code_numeric="426" />
-	<currency name="Lithuanian litas" code_alpha="LTL" code_numeric="440" />
-	<currency name="Latvian lats" code_alpha="LVL" code_numeric="428" />
-	<currency name="Libyan dinar" code_alpha="LYD" code_numeric="434" />
-	<currency name="Moroccan dirham" code_alpha="MAD" code_numeric="504" />
-	<currency name="Moldovan leu" code_alpha="MDL" code_numeric="498" />
-	<currency name="Malagasy ariary" code_alpha="MGA" code_numeric="969" />
+	<currency name="Libyan Dinar" code_alpha="LYD" code_numeric="434" />
+	<currency name="Moroccan Dirham" code_alpha="MAD" code_numeric="504" />
+	<currency name="Moldovan Leu" code_alpha="MDL" code_numeric="498" />
+	<currency name="Malagasy Ariary" code_alpha="MGA" code_numeric="969" />
 	<currency name="Denar" code_alpha="MKD" code_numeric="807" />
 	<currency name="Kyat" code_alpha="MMK" code_numeric="104" />
 	<currency name="Tugrik" code_alpha="MNT" code_numeric="496" />
 	<currency name="Pataca" code_alpha="MOP" code_numeric="446" />
 	<currency name="Ouguiya" code_alpha="MRO" code_numeric="478" />
-	<currency name="Mauritius rupee" code_alpha="MUR" code_numeric="480" />
+	<currency name="Mauritius Rupee" code_alpha="MUR" code_numeric="480" />
 	<currency name="Rufiyaa" code_alpha="MVR" code_numeric="462" />
-	<currency name="Kwacha" code_alpha="MWK" code_numeric="454" />
-	<currency name="Mexican peso" code_alpha="MXN" code_numeric="484" />
-	<currency name="Malaysian ringgit" code_alpha="MYR" code_numeric="458" />
-	<currency name="Metical" code_alpha="MZN" code_numeric="943" />
-	<currency name="Namibian dollar" code_alpha="NAD" code_numeric="516" />
+	<currency name="Malawi Kwacha" code_alpha="MWK" code_numeric="454" />
+	<currency name="Mexican Peso" code_alpha="MXN" code_numeric="484" />
+	<currency name="Malaysian Ringgit" code_alpha="MYR" code_numeric="458" />
+	<currency name="Mozambique Metical" code_alpha="MZN" code_numeric="943" />
+	<currency name="Namibia Dollar" code_alpha="NAD" code_numeric="516" />
 	<currency name="Naira" code_alpha="NGN" code_numeric="566" />
-	<currency name="Cordoba oro" code_alpha="NIO" code_numeric="558" />
-	<currency name="Norwegian krone" code_alpha="NOK" code_numeric="578" />
-	<currency name="Nepalese rupee" code_alpha="NPR" code_numeric="524" />
-	<currency name="New Zealand dollar" code_alpha="NZD" code_numeric="554" />
+	<currency name="Cordoba Oro" code_alpha="NIO" code_numeric="558" />
+	<currency name="Norwegian Krone" code_alpha="NOK" code_numeric="578" />
+	<currency name="Nepalese Rupee" code_alpha="NPR" code_numeric="524" />
+	<currency name="New Zealand Dollar" code_alpha="NZD" code_numeric="554" />
 	<currency name="Rial Omani" code_alpha="OMR" code_numeric="512" />
 	<currency name="Balboa" code_alpha="PAB" code_numeric="590" />
-	<currency name="Nuevo sol" code_alpha="PEN" code_numeric="604" />
+	<currency name="Sol" code_alpha="PEN" code_numeric="604" />
 	<currency name="Kina" code_alpha="PGK" code_numeric="598" />
-	<currency name="Philippine peso" code_alpha="PHP" code_numeric="608" />
-	<currency name="Pakistan rupee" code_alpha="PKR" code_numeric="586" />
+	<currency name="Philippine Peso" code_alpha="PHP" code_numeric="608" />
+	<currency name="Pakistan Rupee" code_alpha="PKR" code_numeric="586" />
 	<currency name="Zloty" code_alpha="PLN" code_numeric="985" />
 	<currency name="Guarani" code_alpha="PYG" code_numeric="600" />
-	<currency name="Qatari rial" code_alpha="QAR" code_numeric="634" />
-	<currency name="Romanian new leu" code_alpha="RON" code_numeric="946" />
-	<currency name="Serbian dinar" code_alpha="RSD" code_numeric="941" />
-	<currency name="Russian ruble" code_alpha="RUB" code_numeric="643" />
-	<currency name="Rwanda franc" code_alpha="RWF" code_numeric="646" />
-	<currency name="Saudi riyal" code_alpha="SAR" code_numeric="682" />
-	<currency name="Solomon Islands dollar" code_alpha="SBD" code_numeric="090" />
-	<currency name="Seychelles rupee" code_alpha="SCR" code_numeric="690" />
-	<currency name="Sudanese pound" code_alpha="SDG" code_numeric="938" />
-	<currency name="Swedish krona" code_alpha="SEK" code_numeric="752" />
-	<currency name="Singapore dollar" code_alpha="SGD" code_numeric="702" />
-	<currency name="Saint Helena pound" code_alpha="SHP" code_numeric="654" />
-	<currency name="Slovak koruna" code_alpha="SKK" code_numeric="703" />
+	<currency name="Qatari Rial" code_alpha="QAR" code_numeric="634" />
+	<currency name="Romanian Leu" code_alpha="RON" code_numeric="946" />
+	<currency name="Serbian Dinar" code_alpha="RSD" code_numeric="941" />
+	<currency name="Russian Ruble" code_alpha="RUB" code_numeric="643" />
+	<currency name="Rwanda Franc" code_alpha="RWF" code_numeric="646" />
+	<currency name="Saudi Riyal" code_alpha="SAR" code_numeric="682" />
+	<currency name="El Salvador Colon" code_alpha="SVC" code_numeric="222" />
+	<currency name="Solomon Islands Dollar" code_alpha="SBD" code_numeric="090" />
+	<currency name="Seychelles Rupee" code_alpha="SCR" code_numeric="690" />
+	<currency name="Sudanese Pound" code_alpha="SDG" code_numeric="938" />
+	<currency name="South Sudanese Pound" code_alpha="SSP" code_numeric="728" />
+	<currency name="Swedish Krona" code_alpha="SEK" code_numeric="752" />
+	<currency name="Singapore Dollar" code_alpha="SGD" code_numeric="702" />
+	<currency name="Saint Helena Pound" code_alpha="SHP" code_numeric="654" />
 	<currency name="Leone" code_alpha="SLL" code_numeric="694" />
-	<currency name="Somali shilling" code_alpha="SOS" code_numeric="706" />
-	<currency name="Surinam dollar" code_alpha="SRD" code_numeric="968" />
+	<currency name="Somali Shilling" code_alpha="SOS" code_numeric="706" />
+	<currency name="Surinam Dollar" code_alpha="SRD" code_numeric="968" />
 	<currency name="Dobra" code_alpha="STD" code_numeric="678" />
-	<currency name="Syrian pound" code_alpha="SYP" code_numeric="760" />
+	<currency name="Syrian Pound" code_alpha="SYP" code_numeric="760" />
 	<currency name="Lilangeni" code_alpha="SZL" code_numeric="748" />
 	<currency name="Baht" code_alpha="THB" code_numeric="764" />
 	<currency name="Somoni" code_alpha="TJS" code_numeric="972" />
-	<currency name="Manat" code_alpha="TMM" code_numeric="795" />
-	<currency name="Tunisian dinar" code_alpha="TND" code_numeric="788" />
+	<currency name="Turkmenistan New Manat" code_alpha="TMT" code_numeric="934" />
+	<currency name="Tunisian Dinar" code_alpha="TND" code_numeric="788" />
 	<currency name="Pa'anga" code_alpha="TOP" code_numeric="776" />
-	<currency name="New Turkish lira" code_alpha="TRY" code_numeric="949" />
-	<currency name="Trinidad and Tobago dollar" code_alpha="TTD" code_numeric="780" />
-	<currency name="New Taiwan dollar" code_alpha="TWD" code_numeric="901" />
-	<currency name="Tanzanian shilling" code_alpha="TZS" code_numeric="834" />
+	<currency name="Turkish lira" code_alpha="TRY" code_numeric="949" />
+	<currency name="Trinidad and Tobago Dollar" code_alpha="TTD" code_numeric="780" />
+	<currency name="New Taiwan Dollar" code_alpha="TWD" code_numeric="901" />
+	<currency name="Tanzanian Shilling" code_alpha="TZS" code_numeric="834" />
 	<currency name="Hryvnia" code_alpha="UAH" code_numeric="980" />
-	<currency name="Uganda shilling" code_alpha="UGX" code_numeric="800" />
+	<currency name="Uganda Shilling" code_alpha="UGX" code_numeric="800" />
 	<currency name="Peso Uruguayo" code_alpha="UYU" code_numeric="858" />
-	<currency name="Uzbekistan som" code_alpha="UZS" code_numeric="860" />
-	<currency name="Venezuelan bolívar fuerte" code_alpha="VEF" code_numeric="937" />
-	<currency name="Vietnamese đồng" code_alpha="VND" code_numeric="704" />
+	<currency name="Uzbekistan Sum" code_alpha="UZS" code_numeric="860" />
+	<currency name="Bolívar" code_alpha="VEF" code_numeric="937" />
+	<currency name="Dong" code_alpha="VND" code_numeric="704" />
 	<currency name="Vatu" code_alpha="VUV" code_numeric="548" />
-	<currency name="Samoan tala" code_alpha="WST" code_numeric="882" />
-	<currency name="CFA franc BEAC" code_alpha="XAF" code_numeric="950" />
-	<currency name="East Caribbean dollar" code_alpha="XCD" code_numeric="951" />
-	<currency name="Special Drawing Rights" code_alpha="XDR" code_numeric="960" />
+	<currency name="Tala" code_alpha="WST" code_numeric="882" />
+	<currency name="CFA Franc BEAC" code_alpha="XAF" code_numeric="950" />
+	<currency name="East Caribbean Dollar" code_alpha="XCD" code_numeric="951" />
 	<currency name="CFA Franc BCEAO" code_alpha="XOF" code_numeric="952" />
-	<currency name="CFP franc" code_alpha="XPF" code_numeric="953" />
-	<currency name="Yemeni rial" code_alpha="YER" code_numeric="886" />
-	<currency name="South African rand" code_alpha="ZAR" code_numeric="710" />
-	<currency name="Kwacha" code_alpha="ZMK" code_numeric="894" />
-	<currency name="Zimbabwe dollar" code_alpha="ZWD" code_numeric="716" />
+	<currency name="CFP Franc" code_alpha="XPF" code_numeric="953" />
+	<currency name="Yemeni Rial" code_alpha="YER" code_numeric="886" />
+	<currency name="Rand" code_alpha="ZAR" code_numeric="710" />
+	<currency name="Zambian Kwacha" code_alpha="ZMW" code_numeric="967" />
+	<currency name="Zimbabwe Dollar" code_alpha="ZWL" code_numeric="932" />
 </currencies>

--- a/locale/en_US/languages.xml
+++ b/locale/en_US/languages.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2000-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localized list of common languages. Based on ISO 639-1.
+  * Localized list of common languages. Based on ISO 639-1:2002.
   *
   -->
 <languages>
@@ -36,13 +36,13 @@
 	<language code="br" name="Breton"/>
 	<language code="bg" name="Bulgarian"/>
 	<language code="my" name="Burmese"/>
-	<language code="ca" name="Catalan"/>
+	<language code="ca" name="Catalan; Valencian"/>
 	<language code="km" name="Central Khmer"/>
 	<language code="ch" name="Chamorro"/>
 	<language code="ce" name="Chechen"/>
-	<language code="ny" name="Chichewa"/>
+	<language code="ny" name="Chichewa; Chewa; Nyanja"/>
 	<language code="zh" name="Chinese"/>
-	<language code="cu" name="Church Slavic"/>
+	<language code="cu" name="Church Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic"/>
 	<language code="cv" name="Chuvash"/>
 	<language code="kw" name="Cornish"/>
 	<language code="co" name="Corsican"/>
@@ -50,7 +50,7 @@
 	<language code="hr" name="Croatian"/>
 	<language code="cs" name="Czech"/>
 	<language code="da" name="Danish"/>
-	<language code="dv" name="Divehi"/>
+	<language code="dv" name="Divehi; Dhivehi; Maldivian"/>
 	<language code="nl" name="Dutch; Flemish"/>
 	<language code="dz" name="Dzongkha"/>
 	<language code="en" name="English"/>
@@ -62,6 +62,7 @@
 	<language code="fi" name="Finnish"/>
 	<language code="fr" name="French"/>
 	<language code="ff" name="Fulah"/>
+	<language code="gd" name="Gaelic; Scottish Gaelic"/>
 	<language code="gl" name="Galician"/>
 	<language code="lg" name="Ganda"/>
 	<language code="ka" name="Georgian"/>
@@ -69,7 +70,7 @@
 	<language code="el" name="Greek"/>
 	<language code="gn" name="Guarani"/>
 	<language code="gu" name="Gujarati"/>
-	<language code="ht" name="Haitian Creole"/>
+	<language code="ht" name="Haitian; Haitian Creole"/>
 	<language code="ha" name="Hausa"/>
 	<language code="he" name="Hebrew"/>
 	<language code="hz" name="Herero"/>
@@ -80,22 +81,22 @@
 	<language code="io" name="Ido"/>
 	<language code="ig" name="Igbo"/>
 	<language code="id" name="Indonesian"/>
-	<language code="ia" name="Interlingua"/>
-	<language code="ie" name="Interlingue"/>
+	<language code="ia" name="Interlingua (International Auxiliary Language Association)"/>
+	<language code="ie" name="Interlingue; Occidental"/>
 	<language code="iu" name="Inuktitut"/>
 	<language code="ik" name="Inupiaq"/>
 	<language code="ga" name="Irish"/>
 	<language code="it" name="Italian"/>
 	<language code="ja" name="Japanese"/>
 	<language code="jv" name="Javanese"/>
-	<language code="kl" name="Kalaallisut"/>
+	<language code="kl" name="Kalaallisut; Greenlandic"/>
 	<language code="kn" name="Kannada"/>
 	<language code="kr" name="Kanuri"/>
 	<language code="ks" name="Kashmiri"/>
 	<language code="kk" name="Kazakh"/>
 	<language code="ki" name="Kikuyu; Gikuyu"/>
 	<language code="rw" name="Kinyarwanda"/>
-	<language code="ky" name="Kirghiz"/>
+	<language code="ky" name="Kirghiz; Kyrgyz"/>
 	<language code="kv" name="Komi"/>
 	<language code="kg" name="Kongo"/>
 	<language code="ko" name="Korean"/>
@@ -104,11 +105,11 @@
 	<language code="lo" name="Lao"/>
 	<language code="la" name="Latin"/>
 	<language code="lv" name="Latvian"/>
-	<language code="li" name="Limburgish"/>
+	<language code="li" name="Limburgan; Limburger; Limburgish"/>
 	<language code="ln" name="Lingala"/>
 	<language code="lt" name="Lithuanian"/>
 	<language code="lu" name="Luba-Katanga"/>
-	<language code="lb" name="Luxembourgish"/>
+	<language code="lb" name="Luxembourgish; Letzeburgesch"/>
 	<language code="mk" name="Macedonian"/>
 	<language code="mg" name="Malagasy"/>
 	<language code="ms" name="Malay"/>
@@ -118,7 +119,6 @@
 	<language code="mi" name="Maori"/>
 	<language code="mr" name="Marathi"/>
 	<language code="mh" name="Marshallese"/>
-	<language code="mo" name="Moldavian; Moldovan"/>
 	<language code="mn" name="Mongolian"/>
 	<language code="na" name="Nauru"/>
 	<language code="nv" name="Navajo; Navaho"/>
@@ -141,22 +141,19 @@
 	<language code="pt" name="Portuguese"/>
 	<language code="ps" name="Pushto; Pashto"/>
 	<language code="qu" name="Quechua"/>
-	<language code="ro" name="Romanian"/>
+	<language code="ro" name="Romanian; Moldavian; Moldovan"/>
 	<language code="rm" name="Romansh"/>
 	<language code="rn" name="Rundi"/>
 	<language code="ru" name="Russian"/>
-	<language code="ry" name="Rusyn"/>
 	<language code="sm" name="Samoan"/>
 	<language code="sg" name="Sango"/>
 	<language code="sa" name="Sanskrit"/>
 	<language code="sc" name="Sardinian"/>
-	<language code="gd" name="Scottish Gaelic"/>
 	<language code="sr" name="Serbian"/>
-	<language code="sh" name="Serbo-Croatian"/>
 	<language code="sn" name="Shona"/>
-	<language code="ii" name="Sichuan Yi"/>
+	<language code="ii" name="Sichuan Yi; Nuosu"/>
 	<language code="sd" name="Sindhi"/>
-	<language code="si" name="Sinhalese"/>
+	<language code="si" name="Sinhala; Sinhalese"/>
 	<language code="sk" name="Slovak"/>
 	<language code="sl" name="Slovenian"/>
 	<language code="so" name="Somali"/>
@@ -176,13 +173,13 @@
 	<language code="th" name="Thai"/>
 	<language code="bo" name="Tibetan"/>
 	<language code="ti" name="Tigrinya"/>
-	<language code="to" name="Tonga"/>
+	<language code="to" name="Tonga (Tonga Islands)"/>
 	<language code="ts" name="Tsonga"/>
 	<language code="tn" name="Tswana"/>
 	<language code="tr" name="Turkish"/>
 	<language code="tk" name="Turkmen"/>
 	<language code="tw" name="Twi"/>
-	<language code="ug" name="Uighur"/>
+	<language code="ug" name="Uighur; Uyghur"/>
 	<language code="uk" name="Ukrainian"/>
 	<language code="ur" name="Urdu"/>
 	<language code="uz" name="Uzbek"/>

--- a/locale/ru_RU/countries.xml
+++ b/locale/ru_RU/countries.xml
@@ -8,15 +8,17 @@
   * Copyright (c) 2000-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localized list of countries. Based on ISO 3166-1.
-  * Localization information: https://pkp.sfu.ca/wiki/index.php?title=OJS:_Russian_(ru_RU)
+  * Localized list of countries. Based on ISO 3166-1:2006.
+  * Translation based on Russian classification of countries of the world 
+  * ОК (МК (ИСО 3166) 004-97) 025-2001 (with changes dated 26.09.2013).
+  * With updates from Pavel Pisklakov (revising translation). 
   -->
 <countries>
 	<country name="Афганистан" code="AF"/>
-	<country name="Аландские острова" code="AX"/>
+	<country name="Эландские острова" code="AX"/>
 	<country name="Албания" code="AL"/>
 	<country name="Алжир" code="DZ"/>
-	<country name="Американское Самоа" code="AS"/>
+	<country name="Американские Самоа" code="AS"/>
 	<country name="Андорра" code="AD"/>
 	<country name="Ангола" code="AO"/>
 	<country name="Ангилья" code="AI"/>
@@ -38,59 +40,59 @@
 	<country name="Бенин" code="BJ"/>
 	<country name="Бермуды" code="BM"/>
 	<country name="Бутан" code="BT"/>
-	<country name="Боливия" code="BO"/>
-	<country name="Бонайре, Синт-Эстатиус и Саба" code="BQ"/>
+	<country name="Боливия, Многонациональное государство" code="BO"/>
+	<country name="Бонэйр, Синт-Эстатиус и Саба" code="BQ"/>
 	<country name="Босния и Герцеговина" code="BA"/>
 	<country name="Ботсвана" code="BW"/>
 	<country name="Остров Буве" code="BV"/>
 	<country name="Бразилия" code="BR"/>
 	<country name="Британская территория в Индийском океане" code="IO"/>
-	<country name="Бруней" code="BN"/>
+	<country name="Бруней-Даруссалам" code="BN"/>
 	<country name="Болгария" code="BG"/>
 	<country name="Буркина-Фасо" code="BF"/>
 	<country name="Бурунди" code="BI"/>
+	<country name="Кабо-Верде" code="CV"/>
 	<country name="Камбоджа" code="KH"/>
 	<country name="Камерун" code="CM"/>
 	<country name="Канада" code="CA"/>
-	<country name="Кабо-Верде" code="CV"/>
-	<country name="Каймановы острова" code="KY"/>
-	<country name="ЦАР" code="CF"/>
+	<country name="Острова Кайман" code="KY"/>
+	<country name="Центрально-Африканская Республика" code="CF"/>
 	<country name="Чад" code="TD"/>
 	<country name="Чили" code="CL"/>
-	<country name="КНР" code="CN"/>
+	<country name="Китай" code="CN"/>
 	<country name="Остров Рождества" code="CX"/>
-	<country name="Кокосовые острова" code="CC"/>
+	<country name="Кокосовые (Килинг) острова" code="CC"/>
 	<country name="Колумбия" code="CO"/>
 	<country name="Коморы" code="KM"/>
-	<country name="Республика Конго" code="CG"/>
-	<country name="Демократическая Республика Конго" code="CD"/>
+	<country name="Конго" code="CG"/>
+	<country name="Конго, Демократическая Республика" code="CD"/>
 	<country name="Острова Кука" code="CK"/>
 	<country name="Коста-Рика" code="CR"/>
-	<country name="Кот-д'Ивуар" code="CI"/>
+	<country name="Кот д'Ивуар" code="CI"/>
 	<country name="Хорватия" code="HR"/>
 	<country name="Куба" code="CU"/>
 	<country name="Кюрасао" code="CW"/>
 	<country name="Кипр" code="CY"/>
-	<country name="Чехия" code="CZ"/>
+	<country name="Чешская Республика" code="CZ"/>
 	<country name="Дания" code="DK"/>
 	<country name="Джибути" code="DJ"/>
 	<country name="Доминика" code="DM"/>
 	<country name="Доминиканская Республика" code="DO"/>
 	<country name="Эквадор" code="EC"/>
 	<country name="Египет" code="EG"/>
-	<country name="Сальвадор" code="SV"/>
+	<country name="Эль-Сальвадор" code="SV"/>
 	<country name="Экваториальная Гвинея" code="GQ"/>
 	<country name="Эритрея" code="ER"/>
 	<country name="Эстония" code="EE"/>
 	<country name="Эфиопия" code="ET"/>
-	<country name="Фолклендские острова" code="FK"/>
+	<country name="Фолклендские острова (Мальвинские)" code="FK"/>
 	<country name="Фарерские острова" code="FO"/>
 	<country name="Фиджи" code="FJ"/>
 	<country name="Финляндия" code="FI"/>
 	<country name="Франция" code="FR"/>
-	<country name="Гвиана" code="GF"/>
+	<country name="Французская Гвиана" code="GF"/>
 	<country name="Французская Полинезия" code="PF"/>
-	<country name="Французские Южные и Антарктические Территории" code="TF"/>
+	<country name="Французские южные территории" code="TF"/>
 	<country name="Габон" code="GA"/>
 	<country name="Гамбия" code="GM"/>
 	<country name="Грузия" code="GE"/>
@@ -108,15 +110,15 @@
 	<country name="Гвинея-Бисау" code="GW"/>
 	<country name="Гайана" code="GY"/>
 	<country name="Гаити" code="HT"/>
-	<country name="Херд и Макдональд" code="HM"/>
-	<country name="Ватикан" code="VA"/>
+	<country name="Остров Херд и острова МакДональд" code="HM"/>
+	<country name="Папский Престол (Государство-город Ватикан)" code="VA"/>
 	<country name="Гондурас" code="HN"/>
 	<country name="Гонконг" code="HK"/>
 	<country name="Венгрия" code="HU"/>
 	<country name="Исландия" code="IS"/>
 	<country name="Индия" code="IN"/>
 	<country name="Индонезия" code="ID"/>
-	<country name="Иран" code="IR"/>
+	<country name="Иран, Исламская Республика" code="IR"/>
 	<country name="Ирак" code="IQ"/>
 	<country name="Ирландия" code="IE"/>
 	<country name="Остров Мэн" code="IM"/>
@@ -124,16 +126,16 @@
 	<country name="Италия" code="IT"/>
 	<country name="Ямайка" code="JM"/>
 	<country name="Япония" code="JP"/>
-	<country name="Джерси (остров)" code="JE"/>
+	<country name="Джерси" code="JE"/>
 	<country name="Иордания" code="JO"/>
 	<country name="Казахстан" code="KZ"/>
 	<country name="Кения" code="KE"/>
 	<country name="Кирибати" code="KI"/>
-	<country name="КНДР" code="KP"/>
-	<country name="Республика Корея" code="KR"/>
+	<country name="Корея, Народно-Демократическая Республика" code="KP"/>
+	<country name="Корея, Республика" code="KR"/>
 	<country name="Кувейт" code="KW"/>
 	<country name="Киргизия" code="KG"/>
-	<country name="Лаос" code="LA"/>
+	<country name="Лаосская Народно-Демократическая Республика" code="LA"/>
 	<country name="Латвия" code="LV"/>
 	<country name="Ливан" code="LB"/>
 	<country name="Лесото" code="LS"/>
@@ -143,21 +145,21 @@
 	<country name="Литва" code="LT"/>
 	<country name="Люксембург" code="LU"/>
 	<country name="Макао" code="MO"/>
-	<country name="Македония" code="MK"/>
+	<country name="Республика Македония" code="MK"/>
 	<country name="Мадагаскар" code="MG"/>
 	<country name="Малави" code="MW"/>
 	<country name="Малайзия" code="MY"/>
 	<country name="Мальдивы" code="MV"/>
 	<country name="Мали" code="ML"/>
 	<country name="Мальта" code="MT"/>
-	<country name="Маршалловы Острова" code="MH"/>
+	<country name="Маршалловы острова" code="MH"/>
 	<country name="Мартиника" code="MQ"/>
 	<country name="Мавритания" code="MR"/>
 	<country name="Маврикий" code="MU"/>
 	<country name="Майотта" code="YT"/>
 	<country name="Мексика" code="MX"/>
-	<country name="Микронезия" code="FM"/>
-	<country name="Молдавия" code="MD"/>
+	<country name="Микронезия, Федеративные Штаты" code="FM"/>
+	<country name="Молдова, Республика" code="MD"/>
 	<country name="Монако" code="MC"/>
 	<country name="Монголия" code="MN"/>
 	<country name="Черногория" code="ME"/>
@@ -181,13 +183,13 @@
 	<country name="Оман" code="OM"/>
 	<country name="Пакистан" code="PK"/>
 	<country name="Палау" code="PW"/>
-	<country name="Государство Палестина" code="PS"/>
+	<country name="Палестина, Государство" code="PS"/>
 	<country name="Панама" code="PA"/>
-	<country name="Папуа - Новая Гвинея" code="PG"/>
+	<country name="Папуа-Новая Гвинея" code="PG"/>
 	<country name="Парагвай" code="PY"/>
 	<country name="Перу" code="PE"/>
 	<country name="Филиппины" code="PH"/>
-	<country name="Острова Питкэрн" code="PN"/>
+	<country name="Питкерн" code="PN"/>
 	<country name="Польша" code="PL"/>
 	<country name="Португалия" code="PT"/>
 	<country name="Пуэрто-Рико" code="PR"/>
@@ -197,7 +199,7 @@
 	<country name="Россия" code="RU"/>
 	<country name="Руанда" code="RW"/>
 	<country name="Сен-Бартелеми" code="BL"/>
-	<country name="Острова Святой Елены, Вознесения и Тристан-да-Кунья" code="SH"/>
+	<country name="Святая Елена, Остров Вознесения, Тристан-да-Кунья" code="SH"/>
 	<country name="Сент-Китс и Невис" code="KN"/>
 	<country name="Сент-Люсия" code="LC"/>
 	<country name="Сен-Мартен" code="MF"/>
@@ -209,31 +211,31 @@
 	<country name="Саудовская Аравия" code="SA"/>
 	<country name="Сенегал" code="SN"/>
 	<country name="Сербия" code="RS"/>
-	<country name="Сейшельские Острова" code="SC"/>
+	<country name="Сейшелы" code="SC"/>
 	<country name="Сьерра-Леоне" code="SL"/>
 	<country name="Сингапур" code="SG"/>
-	<country name="Синт-Мартен (нидерландская часть)" code="SX"/>
+	<country name="Сен-Мартен (нидерландская часть)" code="SX"/>
 	<country name="Словакия" code="SK"/>
 	<country name="Словения" code="SI"/>
 	<country name="Соломоновы Острова" code="SB"/>
 	<country name="Сомали" code="SO"/>
-	<country name="ЮАР" code="ZA"/>
-	<country name="Южная Георгия и Южные Сандвичевы острова" code="GS"/>
+	<country name="Южная Африка" code="ZA"/>
+	<country name="Южная Джорджия и Южные Сандвичевы острова" code="GS"/>
 	<country name="Испания" code="ES"/>
 	<country name="Шри-Ланка" code="LK"/>
 	<country name="Судан" code="SD"/>
 	<country name="Суринам" code="SR"/>
 	<country name="Южный Судан" code="SS"/>
-	<country name="Шпицберген и Ян-Майен" code="SJ"/>
+	<country name="Шпицберген и Ян Майен" code="SJ"/>
 	<country name="Свазиленд" code="SZ"/>
 	<country name="Швеция" code="SE"/>
 	<country name="Швейцария" code="CH"/>
-	<country name="Сирия" code="SY"/>
-	<country name="Китайская республика" code="TW"/>
+	<country name="Сирийская Арабская Республика" code="SY"/>
+	<country name="Тайвань (Китай)" code="TW"/>
 	<country name="Таджикистан" code="TJ"/>
-	<country name="Танзания" code="TZ"/>
+	<country name="Танзания, Объединенная республика" code="TZ"/>
 	<country name="Таиланд" code="TH"/>
-	<country name="Восточный Тимор" code="TL"/>
+	<country name="Тимор-Лесте" code="TL"/>
 	<country name="Того" code="TG"/>
 	<country name="Токелау" code="TK"/>
 	<country name="Тонга" code="TO"/>
@@ -241,21 +243,21 @@
 	<country name="Тунис" code="TN"/>
 	<country name="Турция" code="TR"/>
 	<country name="Туркмения" code="TM"/>
-	<country name="Тёркс и Кайкос" code="TC"/>
+	<country name="Острова Теркс и Кайкос" code="TC"/>
 	<country name="Тувалу" code="TV"/>
 	<country name="Уганда" code="UG"/>
 	<country name="Украина" code="UA"/>
-	<country name="ОАЭ" code="AE"/>
-	<country name="Великобритания" code="GB"/>
-	<country name="США" code="US"/>
-	<country name="Внешние малые острова (США)" code="UM"/>
+	<country name="Объединённые Арабские Эмираты" code="AE"/>
+	<country name="Соединенное Королевство" code="GB"/>
+	<country name="Малые Тихоокеанские Отдаленные острова Соединенных Штатов" code="UM"/>
+	<country name="Соединенные штаты" code="US"/>
 	<country name="Уругвай" code="UY"/>
 	<country name="Узбекистан" code="UZ"/>
 	<country name="Вануату" code="VU"/>
-	<country name="Венесуэла" code="VE"/>
+	<country name="Венесуэла Боливарианская Республика" code="VE"/>
 	<country name="Вьетнам" code="VN"/>
-	<country name="Британские Виргинские острова" code="VG"/>
-	<country name="Американские Виргинские острова" code="VI"/>
+	<country name="Виргинские острова, Британские" code="VG"/>
+	<country name="Виргинские острова, США" code="VI"/>
 	<country name="Уоллис и Футуна" code="WF"/>
 	<country name="Западная Сахара" code="EH"/>
 	<country name="Йемен" code="YE"/>

--- a/locale/ru_RU/currencies.xml
+++ b/locale/ru_RU/currencies.xml
@@ -8,8 +8,10 @@
   * Copyright (c) 2000-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Currencies data XML file. Based on ISO 4217.
-  * Localization information: https://pkp.sfu.ca/wiki/index.php?title=OJS:_Russian_(ru_RU)
+  * Currencies data XML file. Based on ISO 4217:2015.
+  * Translation based on Russian classification of currencies 
+  * ОК (МК (ИСО 4217) 003-97) 014-2000 (with changes dated 02.06.2016).
+  * With updates from Pavel Pisklakov (revising translation). 
   -->
 
 <currencies locale="ru_RU">
@@ -35,28 +37,26 @@
 	<currency name="Бермудский доллар" code_alpha="BMD" code_numeric="060" />
 	<currency name="Брунейский доллар" code_alpha="BND" code_numeric="096" />
 	<currency name="Боливиано" code_alpha="BOB" code_numeric="068" />
-	<currency name="Мвдол" code_alpha="BOV" code_numeric="984" />
 	<currency name="Бразильский реал" code_alpha="BRL" code_numeric="986" />
 	<currency name="Багамский доллар" code_alpha="BSD" code_numeric="044" />
 	<currency name="Нгултрум" code_alpha="BTN" code_numeric="064" />
 	<currency name="Пула" code_alpha="BWP" code_numeric="072" />
-	<currency name="Белорусский рубль" code_alpha="BYR" code_numeric="974" />
+	<currency name="Белорусский рубль" code_alpha="BYN" code_numeric="933" />
 	<currency name="Белизский доллар" code_alpha="BZD" code_numeric="084" />
 	<currency name="Конголезский франк" code_alpha="CDF" code_numeric="976" />
 	<currency name="Швейцарский франк" code_alpha="CHF" code_numeric="756" />
 	<currency name="Чилийское песо" code_alpha="CLP" code_numeric="152" />
 	<currency name="Юань" code_alpha="CNY" code_numeric="156" />
 	<currency name="Колумбийское песо" code_alpha="COP" code_numeric="170" />
-	<currency name="Единица реальной стоимости" code_alpha="COU" code_numeric="970" />
 	<currency name="Костариканский колон" code_alpha="CRC" code_numeric="188" />
 	<currency name="Кубинское песо" code_alpha="CUP" code_numeric="192" />
+	<currency name="Конвертируемое песо" code_alpha="CUC" code_numeric="931" />
 	<currency name="Эскудо Кабо-Верде" code_alpha="CVE" code_numeric="132" />
 	<currency name="Чешская крона" code_alpha="CZK" code_numeric="203" />
 	<currency name="Франк Джибути" code_alpha="DJF" code_numeric="262" />
 	<currency name="Датская крона" code_alpha="DKK" code_numeric="208" />
 	<currency name="Доминиканское песо" code_alpha="DOP" code_numeric="214" />
 	<currency name="Алжирский динар" code_alpha="DZD" code_numeric="012" />
-	<currency name="Крона" code_alpha="EEK" code_numeric="233" />
 	<currency name="Египетский фунт" code_alpha="EGP" code_numeric="818" />
 	<currency name="Накфа" code_alpha="ERN" code_numeric="232" />
 	<currency name="Эфиопский быр" code_alpha="ETB" code_numeric="230" />
@@ -72,7 +72,7 @@
 	<currency name="Гайанский доллар" code_alpha="GYD" code_numeric="328" />
 	<currency name="Гонконгский доллар" code_alpha="HKD" code_numeric="344" />
 	<currency name="Лемпира" code_alpha="HNL" code_numeric="340" />
-	<currency name="Хорватская куна" code_alpha="HRK" code_numeric="191" />
+	<currency name="Куна" code_alpha="HRK" code_numeric="191" />
 	<currency name="Гурд" code_alpha="HTG" code_numeric="332" />
 	<currency name="Форинт" code_alpha="HUF" code_numeric="348" />
 	<currency name="Рупия" code_alpha="IDR" code_numeric="360" />
@@ -98,8 +98,6 @@
 	<currency name="Шри-Ланкийская рупия" code_alpha="LKR" code_numeric="144" />
 	<currency name="Либерийский доллар" code_alpha="LRD" code_numeric="430" />
 	<currency name="Лоти" code_alpha="LSL" code_numeric="426" />
-	<currency name="Литовский лит" code_alpha="LTL" code_numeric="440" />
-	<currency name="Латвийский лат" code_alpha="LVL" code_numeric="428" />
 	<currency name="Ливийский динар" code_alpha="LYD" code_numeric="434" />
 	<currency name="Марокканский дирхам" code_alpha="MAD" code_numeric="504" />
 	<currency name="Молдавский лей" code_alpha="MDL" code_numeric="498" />
@@ -123,25 +121,26 @@
 	<currency name="Новозеландский доллар" code_alpha="NZD" code_numeric="554" />
 	<currency name="Оманский риал" code_alpha="OMR" code_numeric="512" />
 	<currency name="Бальбоа" code_alpha="PAB" code_numeric="590" />
-	<currency name="Новый соль" code_alpha="PEN" code_numeric="604" />
+	<currency name="Соль" code_alpha="PEN" code_numeric="604" />
 	<currency name="Кина" code_alpha="PGK" code_numeric="598" />
 	<currency name="Филиппинское песо" code_alpha="PHP" code_numeric="608" />
 	<currency name="Пакистанская рупия" code_alpha="PKR" code_numeric="586" />
 	<currency name="Злотый" code_alpha="PLN" code_numeric="985" />
 	<currency name="Гуарани" code_alpha="PYG" code_numeric="600" />
 	<currency name="Катарский риал" code_alpha="QAR" code_numeric="634" />
-	<currency name="Новый румынский лей" code_alpha="RON" code_numeric="946" />
+	<currency name="Румынский лей" code_alpha="RON" code_numeric="946" />
 	<currency name="Сербский динар" code_alpha="RSD" code_numeric="941" />
 	<currency name="Российский рубль" code_alpha="RUB" code_numeric="643" />
 	<currency name="Франк Руанды" code_alpha="RWF" code_numeric="646" />
 	<currency name="Саудовский риял" code_alpha="SAR" code_numeric="682" />
+	<currency name="Сальвадорский колон" code_alpha="SVC" code_numeric="222" />
 	<currency name="Доллар Соломоновых Островов" code_alpha="SBD" code_numeric="090" />
 	<currency name="Сейшельская рупия" code_alpha="SCR" code_numeric="690" />
 	<currency name="Суданский фунт" code_alpha="SDG" code_numeric="938" />
+	<currency name="Южносуданский фунт" code_alpha="SSP" code_numeric="728" />
 	<currency name="Шведская крона" code_alpha="SEK" code_numeric="752" />
 	<currency name="Сингапурский доллар" code_alpha="SGD" code_numeric="702" />
 	<currency name="Фунт Святой Елены" code_alpha="SHP" code_numeric="654" />
-	<currency name="Словацкая крона" code_alpha="SKK" code_numeric="703" />
 	<currency name="Леоне" code_alpha="SLL" code_numeric="694" />
 	<currency name="Сомалийский шиллинг" code_alpha="SOS" code_numeric="706" />
 	<currency name="Суринамский доллар" code_alpha="SRD" code_numeric="968" />
@@ -150,7 +149,7 @@
 	<currency name="Лилангени" code_alpha="SZL" code_numeric="748" />
 	<currency name="Бат" code_alpha="THB" code_numeric="764" />
 	<currency name="Сомони" code_alpha="TJS" code_numeric="972" />
-	<currency name="Манат" code_alpha="TMM" code_numeric="795" />
+	<currency name="Новый туркменский манат" code_alpha="TMT" code_numeric="934" />
 	<currency name="Тунисский динар" code_alpha="TND" code_numeric="788" />
 	<currency name="Паанга" code_alpha="TOP" code_numeric="776" />
 	<currency name="Турецкая лира" code_alpha="TRY" code_numeric="949" />
@@ -161,17 +160,16 @@
 	<currency name="Угандийский шиллинг" code_alpha="UGX" code_numeric="800" />
 	<currency name="Уругвайское песо" code_alpha="UYU" code_numeric="858" />
 	<currency name="Узбекский сум" code_alpha="UZS" code_numeric="860" />
-	<currency name="Боливар фуерте" code_alpha="VEF" code_numeric="937" />
+	<currency name="Боливар" code_alpha="VEF" code_numeric="937" />
 	<currency name="Донг" code_alpha="VND" code_numeric="704" />
 	<currency name="Вату" code_alpha="VUV" code_numeric="548" />
 	<currency name="Тала" code_alpha="WST" code_numeric="882" />
 	<currency name="Франк КФА BEAC" code_alpha="XAF" code_numeric="950" />
 	<currency name="Восточно-карибский доллар" code_alpha="XCD" code_numeric="951" />
-	<currency name="СДР (специальные права заимствования)" code_alpha="XDR" code_numeric="960" />
 	<currency name="Франк КФА BCEAO" code_alpha="XOF" code_numeric="952" />
 	<currency name="Франк КФП" code_alpha="XPF" code_numeric="953" />
 	<currency name="Йеменский риал" code_alpha="YER" code_numeric="886" />
 	<currency name="Рэнд" code_alpha="ZAR" code_numeric="710" />
-	<currency name="Замбийская квача" code_alpha="ZMK" code_numeric="894" />
-	<currency name="Доллар Зимбабве" code_alpha="ZWD" code_numeric="716" />
+	<currency name="Замбийская квача" code_alpha="ZMW" code_numeric="967" />
+	<currency name="Доллар Зимбабве" code_alpha="ZWL" code_numeric="932" />
 </currencies>

--- a/locale/ru_RU/languages.xml
+++ b/locale/ru_RU/languages.xml
@@ -7,12 +7,13 @@
   * Copyright (c) 2000-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localized list of common languages. Based on ISO 639-1.
-  * Localization information: https://pkp.sfu.ca/wiki/index.php?title=OJS:_Russian_(ru_RU)
+  * Localized list of common languages. Based on ISO 639-1:2002.
+  * Translation based on Russian GOST 7.75-97 
+  * With updates from Pavel Pisklakov (revising translation). 
   -->
 <languages>
 	<language code="ab" name="Абхазский"/>
-	<language code="aa" name="Афарский"/>
+	<language code="aa" name="Афар"/>
 	<language code="af" name="Африкаанс"/>
 	<language code="ak" name="Акан"/>
 	<language code="sq" name="Албанский"/>
@@ -30,7 +31,7 @@
 	<language code="eu" name="Баскский"/>
 	<language code="be" name="Белорусский"/>
 	<language code="bn" name="Бенгальский"/>
-	<language code="bh" name="Бихарские языки"/>
+	<language code="bh" name="Бихари"/>
 	<language code="bi" name="Бислама"/>
 	<language code="bs" name="Боснийский"/>
 	<language code="br" name="Бретонский"/>
@@ -42,7 +43,7 @@
 	<language code="ce" name="Чеченский"/>
 	<language code="ny" name="Ньянджа"/>
 	<language code="zh" name="Китайский"/>
-	<language code="cu" name="Церковнославянский"/>
+	<language code="cu" name="Церковно-славянский"/>
 	<language code="cv" name="Чувашский"/>
 	<language code="kw" name="Корнский"/>
 	<language code="co" name="Корсиканский"/>
@@ -62,11 +63,12 @@
 	<language code="fi" name="Финский"/>
 	<language code="fr" name="Французский"/>
 	<language code="ff" name="Фулах"/>
+	<language code="gd" name="Гэльский (Гаэльский, Шотландский)"/>
 	<language code="gl" name="Галисийский"/>
 	<language code="lg" name="Ганда"/>
 	<language code="ka" name="Грузинский"/>
 	<language code="de" name="Немецкий"/>
-	<language code="el" name="Греческий"/>
+	<language code="el" name="Греческий (новогреческий)"/>
 	<language code="gn" name="Гуарани"/>
 	<language code="gu" name="Гуджарати"/>
 	<language code="ht" name="Гаитянский креольский"/>
@@ -88,14 +90,14 @@
 	<language code="it" name="Итальянский"/>
 	<language code="ja" name="Японский"/>
 	<language code="jv" name="Яванский"/>
-	<language code="kl" name="Гренландский"/>
+	<language code="kl" name="Эскимосский"/>
 	<language code="kn" name="Каннада"/>
 	<language code="kr" name="Канури"/>
 	<language code="ks" name="Кашмири"/>
 	<language code="kk" name="Казахский"/>
 	<language code="ki" name="Кикуйю"/>
-	<language code="rw" name="Руанда"/>
-	<language code="ky" name="Киргизский"/>
+	<language code="rw" name="Киньяруанда"/>
+	<language code="ky" name="Киргизский (Кыргызский)"/>
 	<language code="kv" name="Коми"/>
 	<language code="kg" name="Конго"/>
 	<language code="ko" name="Корейский"/>
@@ -107,18 +109,17 @@
 	<language code="li" name="Лимбургский"/>
 	<language code="ln" name="Лингала"/>
 	<language code="lt" name="Литовский"/>
-	<language code="lu" name="Луба-катанга"/>
+	<language code="lu" name="Луба-Катанга"/>
 	<language code="lb" name="Люксембургский"/>
 	<language code="mk" name="Македонский"/>
 	<language code="mg" name="Малагасийский"/>
 	<language code="ms" name="Малайский"/>
 	<language code="ml" name="Малаялам"/>
 	<language code="mt" name="Мальтийский"/>
-	<language code="gv" name="Мэнский (Мэнкский)"/>
+	<language code="gv" name="Мэнкский"/>
 	<language code="mi" name="Маори"/>
 	<language code="mr" name="Маратхи"/>
-	<language code="mh" name="Маршалльский"/>
-	<language code="mo" name="Молдавский"/>
+	<language code="mh" name="Маршальский"/>
 	<language code="mn" name="Монгольский"/>
 	<language code="na" name="Науру"/>
 	<language code="nv" name="Навахо"/>
@@ -130,12 +131,12 @@
 	<language code="nb" name="Норвежский букмол"/>
 	<language code="nn" name="Нюнорск (новонорвежский)"/>
 	<language code="oc" name="Окситанский"/>
-	<language code="oj" name="Оджибве"/>
+	<language code="oj" name="Оджибва"/>
 	<language code="or" name="Ория"/>
 	<language code="om" name="Оромо"/>
 	<language code="os" name="Осетинский"/>
 	<language code="pi" name="Пали"/>
-	<language code="pa" name="Пенджабский"/>
+	<language code="pa" name="Панджаби"/>
 	<language code="fa" name="Персидский"/>
 	<language code="pl" name="Польский"/>
 	<language code="pt" name="Португальский"/>
@@ -145,38 +146,35 @@
 	<language code="rm" name="Ретороманский"/>
 	<language code="rn" name="Рунди"/>
 	<language code="ru" name="Русский"/>
-	<language code="ry" name="Русинский"/>
 	<language code="sm" name="Самоанский"/>
 	<language code="sg" name="Санго"/>
 	<language code="sa" name="Санскрит"/>
 	<language code="sc" name="Сардинский"/>
-	<language code="gd" name="Гэльский"/>
 	<language code="sr" name="Сербский"/>
-	<language code="sh" name="Сербохорватский"/>
 	<language code="sn" name="Шона"/>
-	<language code="ii" name="Носу"/>
+	<language code="ii" name="Сычуаньский и; Носу"/>
 	<language code="sd" name="Синдхи"/>
 	<language code="si" name="Сингальский"/>
 	<language code="sk" name="Словацкий"/>
 	<language code="sl" name="Словенский"/>
 	<language code="so" name="Сомали"/>
-	<language code="st" name="Сото южный"/>
+	<language code="st" name="Сото Южный"/>
 	<language code="nr" name="Ндебеле южный"/>
 	<language code="es" name="Испанский"/>
 	<language code="su" name="Сунданский"/>
 	<language code="sw" name="Суахили"/>
 	<language code="ss" name="Свази"/>
 	<language code="sv" name="Шведский"/>
-	<language code="tl" name="Тагальский"/>
+	<language code="tl" name="Тагалог"/>
 	<language code="ty" name="Таитянский"/>
 	<language code="tg" name="Таджикский"/>
 	<language code="ta" name="Тамильский"/>
 	<language code="tt" name="Татарский"/>
 	<language code="te" name="Телугу"/>
-	<language code="th" name="Тайский"/>
+	<language code="th" name="Таи"/>
 	<language code="bo" name="Тибетский"/>
 	<language code="ti" name="Тигринья"/>
-	<language code="to" name="Тонганский"/>
+	<language code="to" name="Тонга (Тонга Исландский)"/>
 	<language code="ts" name="Тсонга"/>
 	<language code="tn" name="Тсвана"/>
 	<language code="tr" name="Турецкий"/>
@@ -190,12 +188,12 @@
 	<language code="vi" name="Вьетнамский"/>
 	<language code="vo" name="Волапюк"/>
 	<language code="wa" name="Валлонский"/>
-	<language code="cy" name="Валлийский"/>
+	<language code="cy" name="Валлийский (Уэльский)"/>
 	<language code="fy" name="Фризский"/>
 	<language code="wo" name="Волоф"/>
 	<language code="xh" name="Коса"/>
 	<language code="yi" name="Идиш"/>
 	<language code="yo" name="Йоруба"/>
-	<language code="za" name="Чжуанский"/>
+	<language code="za" name="Чжуань"/>
 	<language code="zu" name="Зулу"/>
 </languages>


### PR DESCRIPTION
After discussion in PR #2162 with @asmecher I’ve checked the lists of countries, languages and currencies with ISO standards. 

Here is the update for en_US and translation for ru_RU (the translation is based on the Russian standards mentioned in the header of each file).
