### PR TITLE
Log an error when json_encode() fails

### DIFF
--- a/classes/core/JSONMessage.inc.php
+++ b/classes/core/JSONMessage.inc.php
@@ -159,7 +159,13 @@ class JSONMessage {
 		}
 
 		// Encode the object.
-		return json_encode($jsonObject);
+		$json = json_encode($jsonObject);
+
+		if ($json === false) {
+			error_log(json_last_error_msg());
+		}
+
+		return $json;
 	}
 }
 


### PR DESCRIPTION
Wasted about three hours today trying to figure out why an ajax request was failing. This logs an error message that will help identify with `json_encode()` fails.