### PR TITLE
Remove nl2br from submissions template for author guidelines

### DIFF
--- a/templates/frontend/pages/submissions.tpl
+++ b/templates/frontend/pages/submissions.tpl
@@ -53,7 +53,7 @@
 			{translate key="about.authorGuidelines"}
 			{include file="frontend/components/editLink.tpl" page="management" op="settings" path="journal" anchor="guidelines" sectionTitleKey="about.authorGuidelines"}
 		</h2>
-		{$currentContext->getLocalizedSetting('authorGuidelines')|nl2br}
+		{$currentContext->getLocalizedSetting('authorGuidelines')}
 	</div>
 	{/if}
 


### PR DESCRIPTION
The template here https://github.com/pkp/pkp-lib/blob/master/templates/frontend/pages/submissions.tpl
calls for the author guidelines setting. However, it includes the nl2br function which adds new linebreaks. The text is already edited with wysiwyg.