### PR TITLE
pkp/pkp-lib#333, pkp/pkp-lib#2076: update Submission::getPageArray() to deal appropriately with empty page values.

### DIFF
--- a/classes/submission/Submission.inc.php
+++ b/classes/submission/Submission.inc.php
@@ -935,6 +935,12 @@ class Submission extends DataObject {
 				$pages = preg_replace('/^[[:alpha:]]+[:.]?/', '', $pages);
 			}
 		}
+		// strip leading and trailing space
+		$pages = trim($pages);
+		// shortcut the explode/foreach if the remainder is an empty value
+		if ($pages === '') {
+			return array();
+		}
 		// commas indicate distinct ranges
 		$ranges = explode(',', $pages);
 		$pageArray = array();

--- a/tests/classes/submission/SubmissionTest.inc.php
+++ b/tests/classes/submission/SubmissionTest.inc.php
@@ -72,6 +72,21 @@ class SubmissionTest extends PKPTestCase {
 		$this->submission->setPages('pp:  a6 -a12,   b43');
 		$pageArray = $this->submission->getPageArray();
 		$this->assertSame($expected,$pageArray);
+		$this->submission->setPages('  a6 -a12,   b43 ');
+		$pageArray = $this->submission->getPageArray();
+		$this->assertSame($expected,$pageArray);
+		// empty-ish values
+		$expected = array();
+		$this->submission->setPages('');
+		$pageArray = $this->submission->getPageArray();
+		$this->assertSame($expected,$pageArray);
+		$this->submission->setPages(' ');
+		$pageArray = $this->submission->getPageArray();
+		$this->assertSame($expected,$pageArray);
+		$expected = array(array('0'));
+		$this->submission->setPages('0');
+		$pageArray = $this->submission->getPageArray();
+		$this->assertSame($expected,$pageArray);
 	}
 }
 


### PR DESCRIPTION
This is a small bugfix for pkp/pkp-lib#333, and affects pkp/pkp-lib#2076.

The problem was that `Submission::getPageArray()` was returning `array(array(''))` when pages has been set to an empty string.  That certainly was not my intent and seems counter intuitive.  The return should have been just an empty array.
