### PR TITLE
pkp/pkp-lib#2075: Migrate corrected versions of Article::getStartingPage() and Article::getEndingPage() to Submission.

### DIFF
--- a/classes/submission/Submission.inc.php
+++ b/classes/submission/Submission.inc.php
@@ -898,6 +898,28 @@ abstract class Submission extends DataObject {
 	}
 
 	/**
+	 * Get starting page of a submission.  Note the return type of string - this is not to be used for page counting.
+	 * @return string
+	 */
+	function getStartingPage() {
+		$ranges = $this->getPageArray();
+		$firstRange = array_pop(array_reverse($ranges));
+		$firstPage = is_array($firstRange) ? array_pop(array_reverse($firstRange)) : "";
+		return isset($firstPage) ? $firstPage : "";
+	}
+
+	/**
+	 * Get ending page of a submission.  Note the return type of string - this is not to be used for page counting.
+	 * @return string
+	 */
+	function getEndingPage() {
+		$ranges = $this->getPageArray();
+		$lastRange = array_pop($ranges);
+		$lastPage = is_array($lastRange) ? array_pop($lastRange) : "";
+		return isset($lastPage) ? $lastPage : "";
+	}
+
+	/**
 	 * get pages as a nested array of page ranges
 	 * for example, pages of "pp. ii-ix, 9,15-18,a2,b2-b6" will return array( array(0 => 'ii', 1, => 'ix'), array(0 => '9'), array(0 => '15', 1 => '18'), array(0 => 'a2'), array(0 => 'b2', 1 => 'b6') )
 	 * @return array

--- a/tests/classes/submission/SubmissionTest.php
+++ b/tests/classes/submission/SubmissionTest.php
@@ -82,5 +82,111 @@ class SubmissionTest extends PKPTestCase {
 		$pageArray = $this->submission->getPageArray();
 		$this->assertSame($expected,$pageArray);
 	}
+
+	/**
+	 * @covers Submission
+	 */
+	public function testGetStartingPage() {
+		$expected = 'i';
+		// strip prefix and spaces
+		$this->submission->setPages('pg. i-ix, 6-11, 19, 21');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		// no spaces
+		$this->submission->setPages('i-ix,6-11,19,21');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		// double-hyphen
+		$this->submission->setPages('i--ix,6--11,19,21');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		// single page
+		$expected = '16';
+		$this->submission->setPages('16');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		// spaces in a range
+		$this->submission->setPages('16 - 20');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		// pages are alphanumeric
+		$expected = 'a6';
+		$this->submission->setPages('a6-a12,b43');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		// inconsisent formatting
+		$this->submission->setPages('pp:  a6 -a12,   b43');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		$this->submission->setPages('  a6 -a12,   b43 ');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		// empty-ish values
+		$expected = '';
+		$this->submission->setPages('');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		$this->submission->setPages(' ');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+		$expected = '0';
+		$this->submission->setPages('0');
+		$startingPage = $this->submission->getStartingPage();
+		$this->assertSame($expected,$startingPage);
+	}
+
+	/**
+	 * @covers Submission
+	 */
+	public function testGetEndingPage() {
+		$expected = '21';
+		// strip prefix and spaces
+		$this->submission->setPages('pg. i-ix, 6-11, 19, 21');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		// no spaces
+		$this->submission->setPages('i-ix,6-11,19,21');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		// double-hyphen
+		$this->submission->setPages('i--ix,6--11,19,21');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		// single page
+		$expected = '16';
+		$this->submission->setPages('16');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		// spaces in a range
+		$expected = '20';
+		$this->submission->setPages('16 - 20');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		// pages are alphanumeric
+		$expected = 'b43';
+		$this->submission->setPages('a6-a12,b43');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		// inconsisent formatting
+		$this->submission->setPages('pp:  a6 -a12,   b43');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		$this->submission->setPages('  a6 -a12,   b43 ');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		// empty-ish values
+		$expected = '';
+		$this->submission->setPages('');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		$this->submission->setPages(' ');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+		$expected = '0';
+		$this->submission->setPages('0');
+		$endingPage = $this->submission->getEndingPage();
+		$this->assertSame($expected,$endingPage);
+	}
+
 }
 ?>


### PR DESCRIPTION
This PR adds `Submission::getStartingPage()` and `Submission::getEndingPage()` functions which replace faulty versions of these methods previously attached to the OJS `Article` class.  The previous versions returned integers and were incorrectly used for page counting.  I didn't find a clear when in PHPdoc to describe this change.

This will have an interdependency with a similar OJS pull to remove the methods from the `Article` class.

Together, these will resolve pkp/pkp-lib#2075.