### PR TITLE
fr_CA locale: fixed wrong DTD link

### DIFF
--- a/plugins/citationLookup/crossref/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/crossref/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationLookup/crossref/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationLookup/isbndb/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/isbndb/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationLookup/isbndb/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationLookup/pubmed/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/pubmed/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationLookup/pubmed/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationLookup/worldcat/locale/fr_CA/locale.xml
+++ b/plugins/citationLookup/worldcat/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationLookup/worldcat/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationOutput/abnt/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/abnt/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationOutput/abnt/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationOutput/apa/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/apa/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationOutput/apa/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationOutput/mla/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/mla/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationOutput/mla/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationOutput/vancouver/locale/fr_CA/locale.xml
+++ b/plugins/citationOutput/vancouver/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationOutput/vancouver/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationParser/freecite/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/freecite/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationParser/freecite/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationParser/paracite/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/paracite/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationParser/paracite/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationParser/parscit/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/parscit/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationParser/parscit/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/citationParser/regex/locale/fr_CA/locale.xml
+++ b/plugins/citationParser/regex/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/citationParser/regex/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/generic/usageEvent/locale/fr_CA/locale.xml
+++ b/plugins/generic/usageEvent/locale/fr_CA/locale.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/generic/usageEvent/locale/fr_CA/locale.xml
   *
-  * Copyright (c) 2014-2016 Simon Fraser University Library
+  * Copyright (c) 2013-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *

--- a/plugins/generic/usageStats/locale/fr_CA/locale.xml
+++ b/plugins/generic/usageStats/locale/fr_CA/locale.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/generic/usageStats/locale/fr_CA/locale.xml
   *
-  * Copyright (c) 2014-2016 Simon Fraser University Library
+  * Copyright (c) 2013-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings.
+  * Localization strings
   -->
 
 <locale name="fr_CA" full_name="Français (Canada)">

--- a/plugins/metadata/dc11/locale/fr_CA/locale.xml
+++ b/plugins/metadata/dc11/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/metadata/dc11/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/metadata/mods34/locale/fr_CA/locale.xml
+++ b/plugins/metadata/mods34/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/metadata/mods34/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/metadata/nlm30/locale/fr_CA/locale.xml
+++ b/plugins/metadata/nlm30/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/metadata/nlm30/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky
@@ -12,8 +12,11 @@
   -->
 
 <locale name="fr_CA" full_name="Français (Canada)">
+	<!-- plug-in -->
 	<message key="plugins.metadata.nlm30.displayName">Schéma de métadonnées NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.description">Pour utiliser le schéma de métadonnées et les adaptateurs du NLM 3.0</message>
+
+	<!-- citation meta-data adapter -->
 	<message key="plugins.metadata.nlm30.citationAdapter.displayName">Adaptateur de citations de NLM 3.0</message>
 	<message key="plugins.metadata.nlm30.citationAdapter.description">Extrait/injecte les métadonnées de/dans les citations</message>
 	<message key="plugins.metadata.nlm30.citationParsers.displayName">Services pour générer des citations</message>

--- a/plugins/metadata/openurl10/locale/fr_CA/locale.xml
+++ b/plugins/metadata/openurl10/locale/fr_CA/locale.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../dtd/locale.dtd">
 
 <!--
-  * locale/fr_CA/locale.xml
+  * plugins/metadata/openurl10/locale/fr_CA/locale.xml
   *
   * Copyright (c) 2014-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky

--- a/plugins/oaiMetadataFormats/dc/locale/fr_CA/locale.xml
+++ b/plugins/oaiMetadataFormats/dc/locale/fr_CA/locale.xml
@@ -9,7 +9,6 @@
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
   * Localization strings for the fr_CA (Français (Canada)) locale.
-  *
   -->
  
 <locale name="fr_CA" full_name="Français (Canada)">


### PR DESCRIPTION
#2126 contained wrong links to the xml DTD, corrected and updated some other information in the file headers (paths and copyright)