### PR TITLE
Add hex value entry for colour picker

### DIFF
--- a/js/controllers/form/ThemeOptionsHandler.js
+++ b/js/controllers/form/ThemeOptionsHandler.js
@@ -34,8 +34,9 @@
 				$colourInput.spectrum({
 					preferredFormat: 'hex',
 					showInitial: true,
+					showInput: true,
 					showButtons: false,
-					change: function(colour)  {
+					change: function(colour) {
 						/** @type {{toHexString: function()}} */
 						hexColour = colour.toHexString();
 						$colourInput.val(hexColour);


### PR DESCRIPTION
As described in issue #2242 the colour picker allows to enter rgb hex values when called with `showInput` as parameter. It should make entering precise colour values easier.