### PR TITLE
remove html2text from SubmissionMailTemplate

### DIFF
--- a/classes/mail/SubmissionMailTemplate.inc.php
+++ b/classes/mail/SubmissionMailTemplate.inc.php
@@ -54,7 +54,7 @@ class SubmissionMailTemplate extends MailTemplate {
 			array(
 				'submissionTitle' => strip_tags($submission->getLocalizedTitle()),
 				'submissionId' => $submission->getId(),
-				'submissionAbstract' => PKPString::html2text($submission->getLocalizedAbstract()),
+				'submissionAbstract' => PKPString::stripUnsafeHtml($submission->getLocalizedAbstract()),
 				'authorString' => strip_tags($submission->getAuthorString()),
 			),
 			$paramArray


### PR DESCRIPTION
Described here: https://github.com/pkp/pkp-lib/issues/2249

Using `PKPString::stripUnsafeHtml` insted, not sure if necessary, but no harm I guess.

Also, maybe worth checking other uses as well, like https://github.com/pkp/pkp-lib/blob/master/classes/mail/Mail.inc.php ?