### PR TITLE
Missing keys for skip nav

### DIFF
--- a/locale/de_DE/common.xml
+++ b/locale/de_DE/common.xml
@@ -368,6 +368,9 @@
 	<message key="navigation.settings">Einstellungen</message>
 	<message key="navigation.setup">Einrichtung</message>
 	<message key="navigation.sitemap">Site Map</message>
+	<message key="navigation.skip.main">Zum Inhalt springen</message>
+	<message key="navigation.skip.nav">Zur Hauptnavigation springen</message>
+	<message key="navigation.skip.footer">Zur Fußzeile springen</message>
 	<message key="navigation.stepNumber">Schritt {$step}</message>
 	<message key="navigation.submissions">Einreichungen</message>
 	<message key="navigation.system">System</message>


### PR DESCRIPTION
Added keys for skip navigation on journal site: `#navigation.skip.main`, `#navigation.skip.nav`and `#navigation.skip.footer`