### PR TITLE
pkp/pkp-lib#1955 no XML validation option for the export plugins

### DIFF
--- a/classes/xslt/XMLTypeDescription.inc.php
+++ b/classes/xslt/XMLTypeDescription.inc.php
@@ -60,6 +60,13 @@ class XMLTypeDescription extends TypeDescription {
 		return TYPE_DESCRIPTION_NAMESPACE_XML;
 	}
 
+	/**
+	 * Set the validation strategy
+	 * @param $validationStrategy string XML_TYPE_DESCRIPTION_VALIDATE_...
+	 */
+	function setValidationStrategy($validationStrategy) {
+		$this->_validationStrategy = $validationStrategy;
+	}
 
 	//
 	// Implement abstract template methods from TypeDescription

--- a/plugins/importexport/native/filter/NativeExportFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeExportFilter.inc.php
@@ -16,6 +16,11 @@
 import('lib.pkp.plugins.importexport.native.filter.NativeImportExportFilter');
 
 class NativeExportFilter extends NativeImportExportFilter {
+
+	/** @var boolean If set to true no validation (e.g. XML validation) will be done */
+	var $_noValidation = null;
+
+
 	/**
 	 * Constructor
 	 * @param $filterGroup FilterGroup
@@ -24,6 +29,46 @@ class NativeExportFilter extends NativeImportExportFilter {
 		parent::__construct($filterGroup);
 	}
 
+	/**
+	 * Set no validation option
+	 * @param $noValidation boolean
+	 */
+	function setNoValidation($noValidation) {
+		$this->_noValidation = $noValidation;
+	}
+
+	/**
+	 * Get no validation option
+	 * @return boolean true|null
+	 */
+	function getNoValidation() {
+		return $this->_noValidation;
+	}
+
+	//
+	// Public methods
+	//
+	/**
+	 * @copydoc Filter::supports()
+	 */
+	function supports(&$input, &$output) {
+		// Validate input
+		$inputType =& $this->getInputType();
+		$validInput = $inputType->isCompatible($input);
+
+		// If output is null then we're done
+		if (is_null($output)) return $validInput;
+
+		// Validate output
+		$outputType =& $this->getOutputType();
+
+		if (is_a($outputType, 'XMLTypeDescription') && $this->getNoValidation()) {
+			$outputType->setValidationStrategy(XML_TYPE_DESCRIPTION_VALIDATE_NONE);
+		}
+		$validOutput = $outputType->isCompatible($output);
+
+		return $validInput && $validOutput;
+	}
 
 	//
 	// Helper functions


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/1955
this PR introduces the option not to validate XML when exporting...
A note for an easier code review: The function `isCompatible` is copied from the parent class with the only difference that she is calling the `checkType` with the new parameter