### PR TITLE
add dateConfirmed check to responseoverdue status message

### DIFF
--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -54,7 +54,7 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 				if (!$reviewAssignment->getDateCompleted()) {
 					if ($reviewAssignment->getDateDue() < Core::getCurrentDate(strtotime('tomorrow'))) {
 						return 'overdue';
-					} elseif($reviewAssignment->getDateResponseDue() < Core::getCurrentDate(strtotime('tomorrow'))) {
+					} elseif($reviewAssignment->getDateResponseDue() < Core::getCurrentDate(strtotime('tomorrow')) && !$reviewAssignment->getDateConfirmed()) {
 						return 'overdue_response';
 					} else {
 						if (!$reviewAssignment->getDateConfirmed()) {


### PR DESCRIPTION
Described here: https://github.com/pkp/pkp-lib/issues/2275

When printing the review assignment status the code did not consider the situation where an assignment is accepted and the response due date has passed. 