### PR TITLE
pkp/pkp-lib#1923: Refactor GridCellProvider::getTemplateVarsFromRowColumn() to include current $request object

### DIFF
--- a/classes/controllers/grid/ArrayGridCellProvider.inc.php
+++ b/classes/controllers/grid/ArrayGridCellProvider.inc.php
@@ -29,12 +29,9 @@ class ArrayGridCellProvider extends GridCellProvider {
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element =& $row->getData();
 		$columnId = $column->getId();
 		switch ($columnId) {

--- a/classes/controllers/grid/ColumnBasedGridCellProvider.inc.php
+++ b/classes/controllers/grid/ColumnBasedGridCellProvider.inc.php
@@ -34,9 +34,9 @@ class ColumnBasedGridCellProvider extends GridCellProvider {
 	// Implement protected template methods from GridCellProvider
 	//
 	/**
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		// Delegate to the column to provide template variables.
 		return $column->getTemplateVarsFromRow($row);
 	}

--- a/classes/controllers/grid/DataObjectGridCellProvider.inc.php
+++ b/classes/controllers/grid/DataObjectGridCellProvider.inc.php
@@ -57,12 +57,9 @@ class DataObjectGridCellProvider extends GridCellProvider {
 	 * This implementation assumes an element that is a
 	 * DataObject. It will retrieve an element in the
 	 * configured locale.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));

--- a/classes/controllers/grid/DateGridCellProvider.inc.php
+++ b/classes/controllers/grid/DateGridCellProvider.inc.php
@@ -39,12 +39,10 @@ class DateGridCellProvider extends GridCellProvider {
 	/**
 	 * Fetch a value from the provided DataProvider (in constructor)
 	 * and format it as a date.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
-		$v = $this->_dataProvider->getTemplateVarsFromRowColumn($row, $column);
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
+		$v = $this->_dataProvider->getTemplateVarsFromRowColumn($request, $row, $column);
 		$v['label'] = strftime($this->_format, strtotime($v['label']));
 		return $v;
 	}

--- a/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
+++ b/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
@@ -28,9 +28,9 @@ class GridCategoryRowCellProvider extends GridCellProvider {
 	// Implemented methods from GridCellProvider.
 	//
 	/**
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		// Default category rows will only have the first column
 		// as label columns.
 		if ($column->hasFlag('firstColumn')) {

--- a/classes/controllers/grid/GridCellProvider.inc.php
+++ b/classes/controllers/grid/GridCellProvider.inc.php
@@ -32,6 +32,7 @@ class GridCellProvider {
 	 * To be used by a GridRow to generate a rendered representation of
 	 * the element for the given column.
 	 *
+	 * @param $request PKPRequest
 	 * @param $row GridRow
 	 * @param $column GridColumn
 	 * @return string the rendered representation of the element for the given column
@@ -46,7 +47,7 @@ class GridCellProvider {
 
 		// Assign values extracted from the element for the cell.
 		$templateMgr = TemplateManager::getManager($request);
-		$templateVars = $this->getTemplateVarsFromRowColumn($row, $column);
+		$templateVars = $this->getTemplateVarsFromRowColumn($request, $row, $column);
 		foreach ($templateVars as $varName => $varValue) {
 			$templateMgr->assign($varName, $varValue);
 		}
@@ -69,11 +70,13 @@ class GridCellProvider {
 	 * Subclasses have to implement this method to extract variables
 	 * for a given column from a data element so that they may be assigned
 	 * to template before rendering.
+	 * 
+	 * @param $request PKPRequest
 	 * @param $row GridRow
 	 * @param $column GridColumn
 	 * @return array
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		return array();
 	}
 
@@ -86,7 +89,7 @@ class GridCellProvider {
 	 * be row-specific actions in which case action instantiation
 	 * should be delegated to the row.
 	 *
-	 * @param $request Request
+	 * @param $request PKPRequest
 	 * @param $row GridRow
 	 * @param $column GridColumn
 	 * @param $position int GRID_ACTION_POSITION_...

--- a/classes/controllers/grid/LiteralGridCellProvider.inc.php
+++ b/classes/controllers/grid/LiteralGridCellProvider.inc.php
@@ -29,12 +29,9 @@ class LiteralGridCellProvider extends GridCellProvider {
 	/**
 	 * This implementation assumes a data element that is a literal value.
 	 * If desired, the 'id' column can be used to present the row ID.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		switch ($column->getId()) {
 			case 'id':
 				return array('label' => $row->getId());

--- a/classes/controllers/grid/MapGridCellProvider.inc.php
+++ b/classes/controllers/grid/MapGridCellProvider.inc.php
@@ -29,12 +29,9 @@ class MapGridCellProvider extends GridCellProvider {
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element =& $row->getData();
 		$columnId = $column->getId();
 		assert(is_array($element) && in_array($columnId, array_keys($element)));

--- a/classes/controllers/grid/filter/FilterGridCellProvider.inc.php
+++ b/classes/controllers/grid/filter/FilterGridCellProvider.inc.php
@@ -30,12 +30,9 @@ class FilterGridCellProvider extends GridCellProvider {
 	 * This implementation assumes an element that is a
 	 * Filter. It will display the filter name and information
 	 * about filter parameters (if any).
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$filter =& $row->getData();
 		assert(is_a($filter, 'Filter'));
 		switch($column->getId()) {

--- a/controllers/grid/admin/context/ContextGridCellProvider.inc.php
+++ b/controllers/grid/admin/context/ContextGridCellProvider.inc.php
@@ -24,13 +24,9 @@ class ContextGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'Context') && !empty($columnId));

--- a/controllers/grid/admin/systemInfo/InfoGridCellProvider.inc.php
+++ b/controllers/grid/admin/systemInfo/InfoGridCellProvider.inc.php
@@ -29,13 +29,9 @@ class InfoGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(!empty($columnId));

--- a/controllers/grid/announcements/AnnouncementGridCellProvider.inc.php
+++ b/controllers/grid/announcements/AnnouncementGridCellProvider.inc.php
@@ -51,13 +51,9 @@ class AnnouncementGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$announcement = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($announcement, 'Announcement') && !empty($columnId));
@@ -80,7 +76,7 @@ class AnnouncementGridCellProvider extends GridCellProvider {
 				break;
 		}
 
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 }
 

--- a/controllers/grid/announcements/AnnouncementTypeGridCellProvider.inc.php
+++ b/controllers/grid/announcements/AnnouncementTypeGridCellProvider.inc.php
@@ -49,13 +49,9 @@ class AnnouncementTypeGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$announcementType = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($announcementType, 'AnnouncementType') && !empty($columnId));
@@ -68,7 +64,7 @@ class AnnouncementTypeGridCellProvider extends GridCellProvider {
 				break;
 		}
 
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 }
 

--- a/controllers/grid/eventLog/EventLogGridCellProvider.inc.php
+++ b/controllers/grid/eventLog/EventLogGridCellProvider.inc.php
@@ -27,13 +27,9 @@ class EventLogGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));

--- a/controllers/grid/files/LibraryFileGridCellProvider.inc.php
+++ b/controllers/grid/files/LibraryFileGridCellProvider.inc.php
@@ -24,13 +24,9 @@ class LibraryFileGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element =& $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));

--- a/controllers/grid/languages/LanguageGridCellProvider.inc.php
+++ b/controllers/grid/languages/LanguageGridCellProvider.inc.php
@@ -26,7 +26,7 @@ class LanguageGridCellProvider extends GridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		switch ($columnId) {

--- a/controllers/grid/notifications/NotificationsGridCellProvider.inc.php
+++ b/controllers/grid/notifications/NotificationsGridCellProvider.inc.php
@@ -73,13 +73,9 @@ class NotificationsGridCellProvider extends GridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		assert($column->getId()=='task');
 
 		// The action has the label.

--- a/controllers/grid/plugins/PluginGalleryGridCellProvider.inc.php
+++ b/controllers/grid/plugins/PluginGalleryGridCellProvider.inc.php
@@ -24,13 +24,9 @@ class PluginGalleryGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'GalleryPlugin') && !empty($columnId));

--- a/controllers/grid/plugins/PluginGridCellProvider.inc.php
+++ b/controllers/grid/plugins/PluginGridCellProvider.inc.php
@@ -25,13 +25,9 @@ class PluginGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$plugin =& $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($plugin, 'Plugin') && !empty($columnId));
@@ -56,7 +52,7 @@ class PluginGridCellProvider extends GridCellProvider {
 				break;
 		}
 
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 
 	/**

--- a/controllers/grid/queries/QueriesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueriesGridCellProvider.inc.php
@@ -42,13 +42,9 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));
@@ -76,7 +72,7 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 					'disabled' => !$this->_queriesAccessHelper->getCanOpenClose($element->getId()),
 				);
 		}
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 
 	/**

--- a/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
@@ -32,13 +32,9 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));
@@ -49,7 +45,7 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 				return array('label' => ($user?$user->getUsername():'&mdash;') . '<br />' . date('M d', strtotime($element->getDateCreated())));
 		}
 
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 
 	/**

--- a/controllers/grid/settings/metadata/MetadataGridCellProvider.inc.php
+++ b/controllers/grid/settings/metadata/MetadataGridCellProvider.inc.php
@@ -32,7 +32,7 @@ class MetadataGridCellProvider extends GridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		switch ($columnId) {

--- a/controllers/grid/settings/preparedEmails/PreparedEmailsGridCellProvider.inc.php
+++ b/controllers/grid/settings/preparedEmails/PreparedEmailsGridCellProvider.inc.php
@@ -24,13 +24,9 @@ class PreparedEmailsGridCellProvider extends DataObjectGridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $element mixed
-	 * @param $columnId string
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element =& $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));

--- a/controllers/grid/settings/reviewForms/ReviewFormElementGridCellProvider.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormElementGridCellProvider.inc.php
@@ -22,13 +22,9 @@ class ReviewFormElementGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'ReviewFormElement') && !empty($columnId));

--- a/controllers/grid/settings/reviewForms/ReviewFormGridCellProvider.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormGridCellProvider.inc.php
@@ -23,13 +23,9 @@ class ReviewFormGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'ReviewForm') && !empty($columnId));

--- a/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
+++ b/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
@@ -25,13 +25,9 @@ class UserGroupGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$userGroup = $row->getData(); /* @var $userGroup UserGroup */
 		$columnId = $column->getId();
 		$workflowStages = Application::getApplicationStages();
@@ -59,7 +55,7 @@ class UserGroupGridCellProvider extends GridCellProvider {
 				break;
 		}
 
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 
 	/**

--- a/controllers/grid/submissions/SubmissionsListGridCellProvider.inc.php
+++ b/controllers/grid/submissions/SubmissionsListGridCellProvider.inc.php
@@ -131,13 +131,9 @@ class SubmissionsListGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$submission = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($submission, 'DataObject') && !empty($columnId));

--- a/controllers/grid/users/author/PKPAuthorGridCellProvider.inc.php
+++ b/controllers/grid/users/author/PKPAuthorGridCellProvider.inc.php
@@ -27,13 +27,9 @@ class PKPAuthorGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));
@@ -43,7 +39,7 @@ class PKPAuthorGridCellProvider extends DataObjectGridCellProvider {
 			case 'role':
 				return array('label' => $element->getLocalizedUserGroupName());
 			case 'email':
-				return parent::getTemplateVarsFromRowColumn($row, $column);
+				return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 			case 'principalContact':
 				return array('isPrincipalContact' => $element->getPrimaryContact());
 			case 'includeInBrowse':

--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -119,13 +119,9 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));
@@ -141,7 +137,7 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 				return array('label' => '');
 		}
 
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 
 	/**

--- a/controllers/grid/users/reviewerSelect/ReviewerSelectGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewerSelect/ReviewerSelectGridCellProvider.inc.php
@@ -27,13 +27,9 @@ class ReviewerSelectGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		assert(is_a($element, 'User'));
 		switch ($column->getId()) {

--- a/controllers/grid/users/stageParticipant/StageParticipantGridCellProvider.inc.php
+++ b/controllers/grid/users/stageParticipant/StageParticipantGridCellProvider.inc.php
@@ -27,13 +27,9 @@ class StageParticipantGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		switch ($column->getId()) {
 			case 'participants':
 				$stageAssignment = $row->getData();

--- a/controllers/grid/users/userSelect/UserSelectGridCellProvider.inc.php
+++ b/controllers/grid/users/userSelect/UserSelectGridCellProvider.inc.php
@@ -27,13 +27,9 @@ class UserSelectGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		assert(is_a($element, 'User'));
 		switch ($column->getId()) {

--- a/controllers/listbuilder/files/FileListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/files/FileListbuilderGridCellProvider.inc.php
@@ -29,12 +29,9 @@ class FileListbuilderGridCellProvider extends GridCellProvider {
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$file = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($file, 'SubmissionFile') && !empty($columnId));
@@ -45,7 +42,7 @@ class FileListbuilderGridCellProvider extends GridCellProvider {
 					'label' => '<span class="label before_actions">' . $file->getFileId() . '-' . $file->getRevision() . '</span>' . htmlspecialchars($file->getFileLabel())
 				);
 		}
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 }
 

--- a/controllers/listbuilder/settings/BlockPluginsListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/settings/BlockPluginsListbuilderGridCellProvider.inc.php
@@ -29,12 +29,9 @@ class BlockPluginsListbuilderGridCellProvider extends GridCellProvider {
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$plugin =& $row->getData();
 		$columnId = $column->getId();
 		assert((is_a($plugin, 'Plugin')) && !empty($columnId));

--- a/controllers/listbuilder/settings/reviewForms/ReviewFormElementResponseItemListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/settings/reviewForms/ReviewFormElementResponseItemListbuilderGridCellProvider.inc.php
@@ -26,9 +26,9 @@ class ReviewFormElementResponseItemListbuilderGridCellProvider extends GridCellP
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		switch ($column->getId()) {
 			case 'possibleResponse':
 				$possibleResponse = $row->getData();

--- a/controllers/listbuilder/users/UserGroupListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/users/UserGroupListbuilderGridCellProvider.inc.php
@@ -29,12 +29,9 @@ class UserGroupListbuilderGridCellProvider extends GridCellProvider {
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$userGroup =& $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($userGroup, 'UserGroup') && !empty($columnId));

--- a/controllers/listbuilder/users/UserListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/users/UserListbuilderGridCellProvider.inc.php
@@ -29,12 +29,9 @@ class UserListbuilderGridCellProvider extends GridCellProvider {
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$user =& $row->getData();
 		$columnId = $column->getId();
 		// Allow for either Users or Authors (both have a getFullName method).


### PR DESCRIPTION
Possible refactoring of GridCellProvider method to provide access to the request.  Another approach would be the full refactoring of all controllers to be constructed with the request stored by reference.  Discussion in pkp/pkp-lib#1923.

This can serve as a foundation for refactoring plugins' getEnabled() method to take the context as a parameter.

Will require refactoring of each application as well.