### PR TITLE
pkp/pkp-lib#1930 consider empty prefix in the title

### DIFF
--- a/classes/submission/Submission.inc.php
+++ b/classes/submission/Submission.inc.php
@@ -382,7 +382,9 @@ abstract class Submission extends DataObject {
 	function getLocalizedTitle($preferredLocale = null, $includePrefix = true) {
 		$title = $this->getLocalizedData('title', $preferredLocale);
 		if ($includePrefix) {
-			$title = $this->getLocalizedPrefix() . ' ' . $title;
+			$prefix = $this->getLocalizedPrefix();
+			if (!empty($prefix)) $prefix .= ' ';
+			$title = $prefix . $title;
 		}
 		return $title;
 	}
@@ -398,10 +400,14 @@ abstract class Submission extends DataObject {
 		if ($includePrefix) {
 			if (is_array($title)) {
 				foreach($title as $locale => $currentTitle) {
-					$title[$locale] = $this->getPrefix($locale) . ' ' . $currentTitle;
+					$prefix = $this->getPrefix($locale);
+					if (!empty($prefix)) $prefix .= ' ';
+					$title[$locale] = $prefix . $currentTitle;
 				}
 			} else {
-				$title = $this->getPrefix($locale) . ' ' . $title;
+				$prefix = $this->getPrefix($locale);
+				if (!empty($prefix)) $prefix .= ' ';
+				$title = $prefix . $title;
 			}
 		}
 		return $title;


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/1930

If there is no prefix the empty space ' '  will be added in front of the title -- this shouldn't be -- this is a fix for that...