### PR TITLE
pkp/pkp-lib#1709 consider query files and source attribute, and use the same file id for all revisions imports

### DIFF
--- a/classes/plugins/importexport/PKPImportExportDeployment.inc.php
+++ b/classes/plugins/importexport/PKPImportExportDeployment.inc.php
@@ -212,9 +212,20 @@ class PKPImportExportDeployment {
 	 * @param $revisionId integer
 	 * @return integer
 	 */
-	function getFileDBId($fileId, $revisionId) {
-		if (array_key_exists($fileId, $this->_fileDBIds) && array_key_exists($revisionId, $this->_fileDBIds[$fileId])) {
-			return $this->_fileDBIds[$fileId][$revisionId];
+	function getFileDBId($fileId, $revisionId = null) {
+		if (array_key_exists($fileId, $this->_fileDBIds)) {
+			// is there already the revisionId?
+			if ($revisionId) {
+				if (array_key_exists($revisionId, $this->_fileDBIds[$fileId])) {
+					return $this->_fileDBIds[$fileId][$revisionId];
+				} else {
+					return null;
+				}
+			} else {
+				// the revisionId is not important, but the fileId
+				// the DB Id is unique for a fileId
+				return current($this->_fileDBIds[$fileId]);
+			}
 		}
 		return null;
 	}

--- a/plugins/importexport/native/PKPNativeImportExportDeployment.inc.php
+++ b/plugins/importexport/native/PKPNativeImportExportDeployment.inc.php
@@ -85,6 +85,7 @@ class PKPNativeImportExportDeployment extends PKPImportExportDeployment {
 			'attachment' => SUBMISSION_FILE_ATTACHMENT,
 			'review_revision' => SUBMISSION_FILE_REVIEW_REVISION,
 			'dependent' => SUBMISSION_FILE_DEPENDENT,
+			'query' => SUBMISSION_FILE_QUERY,
 		);
 	}
 }

--- a/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
@@ -116,6 +116,12 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 
 		$revisionId = $node->getAttribute('number');
 
+		$source = $node->getAttribute('source');
+		$sourceFileAndRevision = null;
+		if ($source) {
+			$sourceFileAndRevision = explode('-', $source);
+		}
+
 		$genreId = null;
 		$genreName = $node->getAttribute('genre');
 		if ($genreName) {
@@ -188,6 +194,15 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 		$submissionFile->setFileType($fileType);
 
 		$submissionFile->setRevision($revisionId);
+
+		if ($sourceFileAndRevision) {
+			// the source file revision should already be processed, so get the new source file ID
+			$sourceFileId = $deployment->getFileDBId($sourceFileAndRevision[0], $sourceFileAndRevision[1]);
+			if ($sourceFileId) {
+				$submissionFile->setSourceFileId($sourceFileId);
+				$submissionFile->setSourceRevision($sourceFileAndRevision[1]);
+			}
+		}
 
 		if ($errorOccured) {
 			// if error occured, the file cannot be inserted into DB, becase

--- a/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
@@ -194,6 +194,9 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 			// genre, uploader and user group are required (e.g. at name generation).
 			$submissionFile = null;
 		} else {
+			// if the same file is already inserted, take its DB file ID
+			$DBId = $deployment->getFileDBId($fileId);
+			if ($DBId) $submissionFile->setFileId($DBId);
 			$insertedSubmissionFile = $submissionFileDao->insertObject($submissionFile, $filename, false);
 			$deployment->setFileDBId($fileId, $revisionId, $insertedSubmissionFile->getFileId());
 		}


### PR DESCRIPTION
s. b1), b2) and b3) here: https://github.com/pkp/pkp-lib/issues/1709
This is a cherry-pick to ojs-stable-3_0_2