### PR TITLE
Fix context in reminders sent using Acron

### DIFF
--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -152,12 +152,11 @@ class MailTemplate extends Mail {
 
 		if ($this->context) {
 			// Add context-specific variables
-			$router = $request->getRouter();
 			$dispatcher = $application->getDispatcher();
 			$params = array_merge(array(
 				'principalContactSignature' => $this->context->getSetting('contactName'),
 				'contextName' => $this->context->getLocalizedName(),
-				'contextUrl' => $dispatcher->url($request, ROUTE_PAGE, $router->getRequestedContextPath($request)),
+				'contextUrl' => $dispatcher->url($request, ROUTE_PAGE, $this->context->getPath()),
 			), $params);
 		} else {
 			// No context available

--- a/classes/task/ReviewReminder.inc.php
+++ b/classes/task/ReviewReminder.inc.php
@@ -142,7 +142,7 @@ class ReviewReminder extends ScheduledTask {
 			// Avoid review assignments that a reminder exists for.
 			if ($reviewAssignment->getDateReminded() !== null) continue;
 
-			// Fetch the submission and the context.
+			// Fetch the submission
 			if ($submission == null || $submission->getId() != $reviewAssignment->getSubmissionId()) {
 				unset($submission);
 				$submission = $submissionDao->getById($reviewAssignment->getSubmissionId());
@@ -151,14 +151,16 @@ class ReviewReminder extends ScheduledTask {
 
 				if ($submission->getStatus() != STATUS_QUEUED) continue;
 
-				if ($context == null || $context->getId() != $submission->getContextId()) {
-					unset($context);
-					$context = $contextDao->getById($submission->getContextId());
-
-					$inviteReminderDays = $context->getSetting('numDaysBeforeInviteReminder');
-					$submitReminderDays = $context->getSetting('numDaysBeforeSubmitReminder');
-				}
 			}
+
+			// Fetch the context
+			if ($context == null || $context->getId() != $submission->getContextId()) {
+				unset($context);
+				$context = $contextDao->getById($submission->getContextId());
+
+				$inviteReminderDays = $context->getSetting('numDaysBeforeInviteReminder');
+				$submitReminderDays = $context->getSetting('numDaysBeforeSubmitReminder');
+			}			
 
 			$reminderType = false;
 			if ($submitReminderDays>=1 && $reviewAssignment->getDateDue() != null) {


### PR DESCRIPTION
There are two changes / issues here.

1. If you send automated reminders with Acron the current code in https://github.com/pkp/pkp-lib/blob/master/classes/mail/MailTemplate.inc.php#L160 may use the wrong $context in multijournal installations and show the wrong `contextUrl` value in the email

2. Another issue occurs in some reminders and changes several context values in the email. This happens also in multijournal installations and dependes on several circumtances. Details explained here https://github.com/pkp/pkp-lib/issues/2274#issuecomment-283079770 . 

