### PR TITLE
pkp/pkp-lib#2367: Add proxy support to ReCaptcha form validator.

### DIFF
--- a/classes/form/validation/FormValidatorReCaptcha.inc.php
+++ b/classes/form/validation/FormValidatorReCaptcha.inc.php
@@ -67,6 +67,20 @@ class FormValidatorReCaptcha extends FormValidator {
 			),
 		);
 
+		$proxySettings = array(
+			'host' => Config::getVar('proxy', 'http_host'),
+			'port' => Config::getVar('proxy', 'http_port'),
+			'user' => Config::getVar('proxy', 'proxy_username'),
+			'pass' => Config::getVar('proxy', 'proxy_password'),
+		);
+		if (!empty($proxySettings['host'])) {
+			$requestOptions['http']['proxy'] = $proxySettings['host'] . ((!empty($proxySettings['port'])) ? ':'.$proxySettings['port'] : '');
+			$requestOptions['http']['request_fulluri'] = true;
+			if (!empty($proxySettings['user'])) {
+				$requestOptions['http']['header'] .= 'Proxy-Authorization: Basic ' . base64_encode($proxySettings['user'].':'.$proxySettings['pass']);
+			}
+		}
+
 		$requestContext = stream_context_create($requestOptions);
 		$response = file_get_contents(RECAPTCHA_HOST . RECAPTCHA_PATH, false, $requestContext);
 		if ($response === false) {


### PR DESCRIPTION
Should resolve pkp/pkp-lib#2367.  Linted only; I don't have a proxied instance for testing.