### PR TITLE
If restrictReviewerFileAccess not selected, show review files in review step 1

### DIFF
--- a/classes/security/authorization/internal/SubmissionFileAssignedReviewerAccessPolicy.inc.php
+++ b/classes/security/authorization/internal/SubmissionFileAssignedReviewerAccessPolicy.inc.php
@@ -43,11 +43,12 @@ class SubmissionFileAssignedReviewerAccessPolicy extends SubmissionFileBaseAcces
 		$submissionFile = $this->getSubmissionFile($request);
 		if (!is_a($submissionFile, 'SubmissionFile')) return AUTHORIZATION_DENY;
 
+		$context = $request->getContext();
 		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
 		$reviewAssignments = $reviewAssignmentDao->getByUserId($user->getId());
 		$reviewFilesDao = DAORegistry::getDAO('ReviewFilesDAO');
 		foreach ($reviewAssignments as $reviewAssignment) {
-			if (!$reviewAssignment->getDateConfirmed()) continue;
+			if ($context->getSetting('restrictReviewerFileAccess') && !$reviewAssignment->getDateConfirmed()) continue;
 
 			if (
 				$submissionFile->getSubmissionId() == $reviewAssignment->getSubmissionId() &&

--- a/classes/submission/reviewer/form/ReviewerReviewStep1Form.inc.php
+++ b/classes/submission/reviewer/form/ReviewerReviewStep1Form.inc.php
@@ -47,11 +47,8 @@ class ReviewerReviewStep1Form extends ReviewerReviewForm {
 		$templateMgr->assign(array(
 			'reviewAssignment' => $reviewAssignment,
 			'reviewRoundId' => $reviewAssignment->getReviewRoundId(),
-			'reviewerRecommendationOptions' => ReviewAssignment::getReviewerRecommendationOptions(),
-		));		
-		
-		// Check for reviewer file access
-		$templateMgr->assign('restrictReviewerFileAccess', $context->getSetting('restrictReviewerFileAccess'));
+			'restrictReviewerFileAccess' => $context->getSetting('restrictReviewerFileAccess'),
+		));
 		
 		// Add reviewer request text.
 		$templateMgr->assign('reviewerRequest', __('reviewer.step1.requestBoilerplate'));

--- a/classes/submission/reviewer/form/ReviewerReviewStep1Form.inc.php
+++ b/classes/submission/reviewer/form/ReviewerReviewStep1Form.inc.php
@@ -44,8 +44,15 @@ class ReviewerReviewStep1Form extends ReviewerReviewForm {
 		// Add review assignment.
 		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
 		$reviewAssignment = $reviewAssignmentDao->getById($submission->getReviewId());
-		$templateMgr->assign('reviewAssignment', $reviewAssignment);
-
+		$templateMgr->assign(array(
+			'reviewAssignment' => $reviewAssignment,
+			'reviewRoundId' => $reviewAssignment->getReviewRoundId(),
+			'reviewerRecommendationOptions' => ReviewAssignment::getReviewerRecommendationOptions(),
+		));		
+		
+		// Check for reviewer file access
+		$templateMgr->assign('restrictReviewerFileAccess', $context->getSetting('restrictReviewerFileAccess'));
+		
 		// Add reviewer request text.
 		$templateMgr->assign('reviewerRequest', __('reviewer.step1.requestBoilerplate'));
 

--- a/templates/reviewer/review/step1.tpl
+++ b/templates/reviewer/review/step1.tpl
@@ -31,7 +31,12 @@
 	{fbvFormSection label=$descriptionFieldKey}
 		{$submission->getLocalizedAbstract()|strip_unsafe_html}
 	{/fbvFormSection}
-
+	
+	{if !$restrictReviewerFileAccess}
+	{url|assign:reviewFilesGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.files.review.ReviewerReviewFilesGridHandler" op="fetchGrid" submissionId=$submission->getId() stageId=$reviewAssignment->getStageId() reviewRoundId=$reviewRoundId reviewAssignmentId=$reviewAssignment->getId() escape=false}
+	{load_url_in_div id="reviewFiles" url=$reviewFilesGridUrl}	
+	{/if}
+	
 	<div class="pkp_linkActions">
 		{include file="linkAction/linkAction.tpl" action=$viewMetadataAction contextId="reviewStep1Form"}
 	</div>


### PR DESCRIPTION
Hi, @asmecher 

This is a pr to solve https://github.com/pkp/pkp-lib/issues/1875

If "Reviewers will have access to the submission file only after agreeing to review it" option is **not** selected, the review files should be shown already in review step 1. This pr adds the file grid to that step and changes the access policy to check for status of `restrictReviewerFileAccess `setting.