### PR TITLE
Default download file name to client file name

### DIFF
--- a/classes/file/SubmissionFileManager.inc.php
+++ b/classes/file/SubmissionFileManager.inc.php
@@ -95,6 +95,7 @@ class SubmissionFileManager extends BaseSubmissionFileManager {
 			// Send the file to the user.
 			$filePath = $submissionFile->getFilePath();
 			$mediaType = $submissionFile->getFileType();
+			if(!isset($filename)) $filename = $submissionFile->getClientFileName();
 			$returner = parent::downloadFile($filePath, $mediaType, $inline, $filename);
 		}
 


### PR DESCRIPTION
As proposed in #2003. This is a fix I applied on Nov 28 to my OJS3 installation. I am not sure whether this was fixed somewhere else.