### PR TITLE
pkp/pkp-lib#2003 download file names and their extensions

### DIFF
--- a/classes/file/SubmissionFileManager.inc.php
+++ b/classes/file/SubmissionFileManager.inc.php
@@ -95,6 +95,7 @@ class SubmissionFileManager extends BaseSubmissionFileManager {
 			// Send the file to the user.
 			$filePath = $submissionFile->getFilePath();
 			$mediaType = $submissionFile->getFileType();
+			if(!isset($filename)) $filename = $submissionFile->getClientFileName();
 			$returner = parent::downloadFile($filePath, $mediaType, $inline, $filename);
 		}
 

--- a/classes/submission/SubmissionFile.inc.php
+++ b/classes/submission/SubmissionFile.inc.php
@@ -252,7 +252,7 @@ class SubmissionFile extends PKPFile {
 	function getExtension() {
 		import('lib.pkp.classes.file.FileManager');
 		$fileManager = new FileManager();
-		return strtoupper($fileManager->parseFileExtension($this->getOriginalFileName()));
+		return $fileManager->parseFileExtension($this->getOriginalFileName());
 	}
 
 	/**
@@ -561,7 +561,7 @@ class SubmissionFile extends PKPFile {
 			$this->getFileStage() . '-' .
 			$timestamp .
 			'.' .
-			strtolower_codesafe($this->getExtension());
+			$this->getExtension();
 	}
 
 	//


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/2003

This uses client file name (instead of server file name) for the submission file downloads (by readers). The extension in the client file name preserves the original upper and lower cases.