### PR TITLE
Always use context specific reply-to address in notifications, if available

### DIFF
--- a/classes/notification/PKPNotificationOperationManager.inc.php
+++ b/classes/notification/PKPNotificationOperationManager.inc.php
@@ -326,7 +326,13 @@ abstract class PKPNotificationOperationManager implements INotificationInfoProvi
 		}
 
 		$mail = $this->getMailTemplate($template);
-		$mail->setReplyTo($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
+		
+		if ($context) {
+			$mail->setReplyTo($context->getContactEmail(), $context->getContactName());
+		} else {
+			$mail->setReplyTo($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
+		}
+		
 		$mail->assignParams($params);
 		$mail->addRecipient($email);
 		$mail->send();
@@ -447,7 +453,13 @@ abstract class PKPNotificationOperationManager implements INotificationInfoProvi
 			$context = $request->getContext();
 			$site = $request->getSite();
 			$mail = $this->getMailTemplate('NOTIFICATION');
-			$mail->setReplyTo($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
+			
+			if ($context) {
+				$mail->setReplyTo($context->getContactEmail(), $context->getContactName());
+			} else {
+				$mail->setReplyTo($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
+			}
+			
 			$mail->assignParams(array(
 				'notificationContents' => $this->getNotificationContents($request, $notification),
 				'url' => $this->getNotificationUrl($request, $notification),


### PR DESCRIPTION
Details here: http://forum.pkp.sfu.ca/t/ojs3-notifications-sender-and-reply-to-address/28703

