### PR TITLE
pkp/pkp-lib#2420: Log email sending failures, even if PHPMailer doesn't raise an exception.

### DIFF
--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -473,6 +473,11 @@ class Mail extends DataObject {
 			$mailer->Host = Config::getVar('email', 'smtp_server');
 			$mailer->Username = Config::getVar('email', 'smtp_username');
 			$mailer->Password = Config::getVar('email', 'smtp_password');
+			if (Config::getVar('debug', 'show_stacktrace')) {
+				// debug level 3 represents client and server interaction, plus initial connection debugging
+				$mailer->SMTPDebug = 3;
+				$mailer->Debugoutput = 'error_log';
+			}
 		}
 		$mailer->CharSet = Config::getVar('i18n', 'client_charset');
 		if (($t = $this->getContentType()) != null) $mailer->ContentType = $t;
@@ -514,7 +519,11 @@ class Mail extends DataObject {
 		}
 
 		try {
-			$mailer->Send();
+			$success = $mailer->Send();
+			if (!$success) {
+				error_log($mailer->ErrorInfo);
+				return false;
+			}
 		} catch (phpmailerException $e) {
 			error_log($mailer->ErrorInfo);
 			return false;


### PR DESCRIPTION
Resolves pkp/pkp-lib#2420.

Why does the `catch (phpmailerException $e)` log `$mailer->ErrorInfo` and not `$e->errorMessage`?
https://github.com/pkp/pkp-lib/blob/91da80b797e2f7dd98014134251c2884de6f30c5/classes/mail/Mail.inc.php#L519
