### PR TITLE
pkp/pkp-lib#2444: Refactor GridCellProvider::__construct()

### DIFF
--- a/classes/controllers/grid/ArrayGridCellProvider.inc.php
+++ b/classes/controllers/grid/ArrayGridCellProvider.inc.php
@@ -16,23 +16,13 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class ArrayGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element =& $row->getData();

--- a/classes/controllers/grid/CategoryGridHandler.inc.php
+++ b/classes/controllers/grid/CategoryGridHandler.inc.php
@@ -39,8 +39,10 @@ class CategoryGridHandler extends GridHandler {
 		parent::__construct($dataProvider);
 
 		import('lib.pkp.classes.controllers.grid.NullGridCellProvider');
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
 		$this->addColumn(new GridColumn('indent', null, null, null,
-			new NullGridCellProvider(), array('indent' => true, 'width' => 2)));
+			new NullGridCellProvider($request), array('indent' => true, 'width' => 2)));
 	}
 
 

--- a/classes/controllers/grid/CategoryGridHandler.inc.php
+++ b/classes/controllers/grid/CategoryGridHandler.inc.php
@@ -39,7 +39,7 @@ class CategoryGridHandler extends GridHandler {
 		parent::__construct($dataProvider);
 
 		import('lib.pkp.classes.controllers.grid.NullGridCellProvider');
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		$this->addColumn(new GridColumn('indent', null, null, null,
 			new NullGridCellProvider($request), array('indent' => true, 'width' => 2)));

--- a/classes/controllers/grid/ColumnBasedGridCellProvider.inc.php
+++ b/classes/controllers/grid/ColumnBasedGridCellProvider.inc.php
@@ -22,19 +22,11 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class ColumnBasedGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-
 	//
 	// Implement protected template methods from GridCellProvider
 	//
 	/**
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		// Delegate to the column to provide template variables.

--- a/classes/controllers/grid/DataObjectGridCellProvider.inc.php
+++ b/classes/controllers/grid/DataObjectGridCellProvider.inc.php
@@ -23,13 +23,6 @@ class DataObjectGridCellProvider extends GridCellProvider {
 	/** @var string the locale to be retrieved. */
 	var $_locale = null;
 
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Setters and Getters
 	//
@@ -57,10 +50,7 @@ class DataObjectGridCellProvider extends GridCellProvider {
 	 * This implementation assumes an element that is a
 	 * DataObject. It will retrieve an element in the
 	 * configured locale.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();

--- a/classes/controllers/grid/DateGridCellProvider.inc.php
+++ b/classes/controllers/grid/DateGridCellProvider.inc.php
@@ -24,11 +24,12 @@ class DateGridCellProvider extends GridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 * @param $dataProvider DataProvider The object to wrap
 	 * @param $format string See strftime
 	 */
-	function __construct($dataProvider, $format) {
-		parent::__construct();
+	function __construct($request, $dataProvider, $format) {
+		parent::__construct($request);
 		$this->_dataProvider = $dataProvider;
 		$this->_format = $format;
 	}
@@ -39,9 +40,7 @@ class DateGridCellProvider extends GridCellProvider {
 	/**
 	 * Fetch a value from the provided DataProvider (in constructor)
 	 * and format it as a date.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$v = $this->_dataProvider->getTemplateVarsFromRowColumn($row, $column);

--- a/classes/controllers/grid/GridCategoryRow.inc.php
+++ b/classes/controllers/grid/GridCategoryRow.inc.php
@@ -26,7 +26,7 @@ class GridCategoryRow extends GridRow {
 	function __construct() {
 		parent::__construct();
 
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 
 		// Set a default cell provider that will get the cell template

--- a/classes/controllers/grid/GridCategoryRow.inc.php
+++ b/classes/controllers/grid/GridCategoryRow.inc.php
@@ -26,9 +26,12 @@ class GridCategoryRow extends GridRow {
 	function __construct() {
 		parent::__construct();
 
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
+
 		// Set a default cell provider that will get the cell template
 		// variables from the category grid row.
-		$this->setCellProvider(new GridCategoryRowCellProvider());
+		$this->setCellProvider(new GridCategoryRowCellProvider($request));
 	}
 
 

--- a/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
+++ b/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
@@ -17,13 +17,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class GridCategoryRowCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Implemented methods from GridCellProvider.
 	//

--- a/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
+++ b/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
@@ -44,9 +44,9 @@ class GridCategoryRowCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * @see GridCellProvider::render()
+	 * @copydoc GridCellProvider::render()
 	 */
-	function render($request, $row, $column) {
+	function render($row, $column) {
 		// Default category rows will only have the first column
 		// as label columns.
 		if ($column->hasFlag('firstColumn')) {
@@ -57,7 +57,7 @@ class GridCategoryRowCellProvider extends GridCellProvider {
 			$column->setTemplate('controllers/grid/gridCell.tpl');
 
 			// Render the cell.
-			$renderedCell = parent::render($request, $row, $column);
+			$renderedCell = parent::render($row, $column);
 
 			// Restore the original column template.
 			$column->setTemplate($template);

--- a/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
+++ b/classes/controllers/grid/GridCategoryRowCellProvider.inc.php
@@ -36,7 +36,7 @@ class GridCategoryRowCellProvider extends GridCellProvider {
 	/**
 	 * @see GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		// Get cell actions from the row, that are
 		// positioned with the GRID_ACTION_POSITION_ROW_CLICK
 		// constant.

--- a/classes/controllers/grid/GridCellProvider.inc.php
+++ b/classes/controllers/grid/GridCellProvider.inc.php
@@ -59,7 +59,7 @@ class GridCellProvider {
 		$templateMgr->assign(array(
 			'id' => $cellId,
 			'column' => $column,
-			'actions' => $this->getCellActions($this->_request, $row, $column),
+			'actions' => $this->getCellActions($row, $column),
 			'flags' => $column->getFlags(),
 			'formLocales' => AppLocale::getSupportedFormLocales(),
 		));

--- a/classes/controllers/grid/GridCellProvider.inc.php
+++ b/classes/controllers/grid/GridCellProvider.inc.php
@@ -18,10 +18,16 @@
 
 
 class GridCellProvider {
+
+	/** @var PKPRequest the requesting context for this provider */
+	var $_request;
+
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 */
-	function __construct() {
+	function __construct($request) {
+		$this->_request = $request;
 	}
 
 	//
@@ -36,7 +42,7 @@ class GridCellProvider {
 	 * @param $column GridColumn
 	 * @return string the rendered representation of the element for the given column
 	 */
-	function render($request, $row, $column) {
+	function render($row, $column) {
 		$columnId = $column->getId();
 		assert(!empty($columnId));
 
@@ -45,7 +51,7 @@ class GridCellProvider {
 		$cellId = isset($rowId)?$rowId.'-'.$columnId:null;
 
 		// Assign values extracted from the element for the cell.
-		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr = TemplateManager::getManager($this->_request);
 		$templateVars = $this->getTemplateVarsFromRowColumn($row, $column);
 		foreach ($templateVars as $varName => $varValue) {
 			$templateMgr->assign($varName, $varValue);
@@ -53,7 +59,7 @@ class GridCellProvider {
 		$templateMgr->assign(array(
 			'id' => $cellId,
 			'column' => $column,
-			'actions' => $this->getCellActions($request, $row, $column),
+			'actions' => $this->getCellActions($this->_request, $row, $column),
 			'flags' => $column->getFlags(),
 			'formLocales' => AppLocale::getSupportedFormLocales(),
 		));
@@ -86,14 +92,13 @@ class GridCellProvider {
 	 * be row-specific actions in which case action instantiation
 	 * should be delegated to the row.
 	 *
-	 * @param $request Request
 	 * @param $row GridRow
 	 * @param $column GridColumn
 	 * @param $position int GRID_ACTION_POSITION_...
 	 * @return array an array of LinkAction instances
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
-		return $column->getCellActions($request, $row, $position);
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+		return $column->getCellActions($this->_request, $row, $position);
 	}
 }
 

--- a/classes/controllers/grid/GridColumn.inc.php
+++ b/classes/controllers/grid/GridColumn.inc.php
@@ -115,7 +115,9 @@ class GridColumn extends GridBodyElement {
 		if (is_null(parent::getCellProvider())) {
 			// provide a sensible default cell provider
 			import('lib.pkp.classes.controllers.grid.ArrayGridCellProvider');
-			$cellProvider = new ArrayGridCellProvider();
+			// TODO: Where should the request come from?
+			$request = PKPApplication::getRequest();
+			$cellProvider = new ArrayGridCellProvider($request);
 			$this->setCellProvider($cellProvider);
 		}
 

--- a/classes/controllers/grid/GridColumn.inc.php
+++ b/classes/controllers/grid/GridColumn.inc.php
@@ -115,7 +115,7 @@ class GridColumn extends GridBodyElement {
 		if (is_null(parent::getCellProvider())) {
 			// provide a sensible default cell provider
 			import('lib.pkp.classes.controllers.grid.ArrayGridCellProvider');
-			// TODO: Where should the request come from?
+			// TODO: pkp/pkp-lib#2444 Where should the request come from?
 			$request = PKPApplication::getRequest();
 			$cellProvider = new ArrayGridCellProvider($request);
 			$this->setCellProvider($cellProvider);

--- a/classes/controllers/grid/GridHandler.inc.php
+++ b/classes/controllers/grid/GridHandler.inc.php
@@ -1086,7 +1086,7 @@ class GridHandler extends PKPHandler {
 		if ( is_null($element) && $row->getIsModified() ) {
 			import('lib.pkp.classes.controllers.grid.GridCellProvider');
 			$cellProvider = new GridCellProvider($request);
-			return $cellProvider->render($request, $row, $column);
+			return $cellProvider->render($row, $column);
 		}
 
 		// Otherwise, get the cell content.
@@ -1099,7 +1099,7 @@ class GridHandler extends PKPHandler {
 			$cellProvider = $column->getCellProvider();
 		}
 
-		return $cellProvider->render($request, $row, $column);
+		return $cellProvider->render($row, $column);
 	}
 
 	/**

--- a/classes/controllers/grid/GridHandler.inc.php
+++ b/classes/controllers/grid/GridHandler.inc.php
@@ -1085,7 +1085,7 @@ class GridHandler extends PKPHandler {
 		$element =& $row->getData();
 		if ( is_null($element) && $row->getIsModified() ) {
 			import('lib.pkp.classes.controllers.grid.GridCellProvider');
-			$cellProvider = new GridCellProvider();
+			$cellProvider = new GridCellProvider($request);
 			return $cellProvider->render($request, $row, $column);
 		}
 

--- a/classes/controllers/grid/LiteralGridCellProvider.inc.php
+++ b/classes/controllers/grid/LiteralGridCellProvider.inc.php
@@ -16,23 +16,13 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class LiteralGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//
 	/**
 	 * This implementation assumes a data element that is a literal value.
 	 * If desired, the 'id' column can be used to present the row ID.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		switch ($column->getId()) {

--- a/classes/controllers/grid/MapGridCellProvider.inc.php
+++ b/classes/controllers/grid/MapGridCellProvider.inc.php
@@ -16,23 +16,13 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class MapGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//
 	/**
 	 * This implementation assumes a simple data element array that
 	 * has column ids as keys.
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element =& $row->getData();

--- a/classes/controllers/grid/NullGridCellProvider.inc.php
+++ b/classes/controllers/grid/NullGridCellProvider.inc.php
@@ -18,20 +18,13 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class NullGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//
 	/**
 	 * @see GridCellProvider::render()
 	 */
-	function render($request, $row, $column) {
+	function render($row, $column) {
 		return null;
 	}
 }

--- a/classes/controllers/grid/feature/selectableItems/ItemSelectionGridColumn.inc.php
+++ b/classes/controllers/grid/feature/selectableItems/ItemSelectionGridColumn.inc.php
@@ -30,7 +30,9 @@ class ItemSelectionGridColumn extends GridColumn {
 		$this->_selectName = $selectName;
 
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		$cellProvider = new ColumnBasedGridCellProvider();
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
+		$cellProvider = new ColumnBasedGridCellProvider($request);
 		parent::__construct('select', 'common.select', null, 'controllers/grid/gridRowSelectInput.tpl', $cellProvider,
 				array('width' => 3));
 	}

--- a/classes/controllers/grid/feature/selectableItems/ItemSelectionGridColumn.inc.php
+++ b/classes/controllers/grid/feature/selectableItems/ItemSelectionGridColumn.inc.php
@@ -30,7 +30,7 @@ class ItemSelectionGridColumn extends GridColumn {
 		$this->_selectName = $selectName;
 
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		$cellProvider = new ColumnBasedGridCellProvider($request);
 		parent::__construct('select', 'common.select', null, 'controllers/grid/gridRowSelectInput.tpl', $cellProvider,

--- a/classes/controllers/grid/filter/FilterGridCellProvider.inc.php
+++ b/classes/controllers/grid/filter/FilterGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class FilterGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//
@@ -30,10 +23,7 @@ class FilterGridCellProvider extends GridCellProvider {
 	 * This implementation assumes an element that is a
 	 * Filter. It will display the filter name and information
 	 * about filter parameters (if any).
-	 * @see GridCellProvider::getTemplateVarsFromRowColumn()
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$filter =& $row->getData();

--- a/classes/controllers/grid/filter/PKPFilterGridHandler.inc.php
+++ b/classes/controllers/grid/filter/PKPFilterGridHandler.inc.php
@@ -143,7 +143,7 @@ class PKPFilterGridHandler extends GridHandler {
 		);
 
 		// Columns
-		$cellProvider = new FilterGridCellProvider();
+		$cellProvider = new FilterGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'displayName',

--- a/classes/controllers/grid/plugins/PluginGridHandler.inc.php
+++ b/classes/controllers/grid/plugins/PluginGridHandler.inc.php
@@ -53,7 +53,7 @@ abstract class PluginGridHandler extends CategoryGridHandler {
 
 		// Columns
 		import('lib.pkp.controllers.grid.plugins.PluginGridCellProvider');
-		$pluginCellProvider = new PluginGridCellProvider();
+		$pluginCellProvider = new PluginGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn('name',
 				'common.name',

--- a/classes/controllers/grid/users/reviewer/PKPReviewerGridHandler.inc.php
+++ b/classes/controllers/grid/users/reviewer/PKPReviewerGridHandler.inc.php
@@ -136,7 +136,7 @@ class PKPReviewerGridHandler extends GridHandler {
 			);
 
 		// Columns
-		$cellProvider = new ReviewerGridCellProvider();
+		$cellProvider = new ReviewerGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'name',

--- a/controllers/grid/admin/context/ContextGridCellProvider.inc.php
+++ b/controllers/grid/admin/context/ContextGridCellProvider.inc.php
@@ -17,18 +17,7 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class ContextGridCellProvider extends GridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();

--- a/controllers/grid/admin/context/ContextGridHandler.inc.php
+++ b/controllers/grid/admin/context/ContextGridHandler.inc.php
@@ -84,7 +84,7 @@ class ContextGridHandler extends GridHandler {
 		// Grid columns.
 		//
 		import('lib.pkp.controllers.grid.admin.context.ContextGridCellProvider');
-		$contextGridCellProvider = new ContextGridCellProvider();
+		$contextGridCellProvider = new ContextGridCellProvider($request);
 
 		// Context name.
 		$this->addColumn(

--- a/controllers/grid/admin/systemInfo/InfoGridCellProvider.inc.php
+++ b/controllers/grid/admin/systemInfo/InfoGridCellProvider.inc.php
@@ -22,18 +22,16 @@ class InfoGridCellProvider extends GridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
+	 * @param $translate boolean
 	 */
-	function __construct($translate = false) {
-		parent::__construct();
+	function __construct($request, $translate = false) {
+		parent::__construct($request);
 		$this->_translate = $translate;
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();

--- a/controllers/grid/admin/systemInfo/ServerInfoGridHandler.inc.php
+++ b/controllers/grid/admin/systemInfo/ServerInfoGridHandler.inc.php
@@ -69,7 +69,7 @@ class ServerInfoGridHandler extends GridHandler {
 		//
 		// Grid columns.
 		//
-		$infoGridCellProvider = new InfoGridCellProvider(true);
+		$infoGridCellProvider = new InfoGridCellProvider($request, true);
 
 		// Setting name.
 		$this->addColumn(

--- a/controllers/grid/admin/systemInfo/SystemInfoGridHandler.inc.php
+++ b/controllers/grid/admin/systemInfo/SystemInfoGridHandler.inc.php
@@ -73,7 +73,7 @@ class SystemInfoGridHandler extends CategoryGridHandler {
 		// Grid columns.
 		//
 		import('lib.pkp.controllers.grid.admin.systemInfo.InfoGridCellProvider');
-		$infoGridCellProvider = new InfoGridCellProvider();
+		$infoGridCellProvider = new InfoGridCellProvider($request);
 
 		// setting name.
 		$this->addColumn(

--- a/controllers/grid/admin/systemInfo/VersionInfoGridHandler.inc.php
+++ b/controllers/grid/admin/systemInfo/VersionInfoGridHandler.inc.php
@@ -69,7 +69,7 @@ class VersionInfoGridHandler extends GridHandler {
 		//
 		// Grid columns.
 		//
-		$infoGridCellProvider = new InfoGridCellProvider();
+		$infoGridCellProvider = new InfoGridCellProvider($request);
 
 		// Version number.
 		$this->addColumn(

--- a/controllers/grid/announcements/AnnouncementGridCellProvider.inc.php
+++ b/controllers/grid/announcements/AnnouncementGridCellProvider.inc.php
@@ -16,29 +16,21 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class AnnouncementGridCellProvider extends GridCellProvider {
-
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		switch ($column->getId()) {
 			case 'title':
 				$announcement = $row->getData();
-				$router = $request->getRouter();
+				$router = $this->_request->getRouter();
 				$actionArgs = array('announcementId' => $row->getId());
 
 				import('lib.pkp.classes.linkAction.request.AjaxModal');
 				return array(new LinkAction(
 					'moreInformation',
 					new AjaxModal(
-						$router->url($request, null, null, 'moreInformation', null, $actionArgs),
+						$router->url($this->_request, null, null, 'moreInformation', null, $actionArgs),
 						$announcement->getLocalizedTitle(),
 						null,
 						true
@@ -47,15 +39,11 @@ class AnnouncementGridCellProvider extends GridCellProvider {
 					'moreInformation'
 				));
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$announcement = $row->getData();

--- a/controllers/grid/announcements/AnnouncementGridHandler.inc.php
+++ b/controllers/grid/announcements/AnnouncementGridHandler.inc.php
@@ -72,7 +72,7 @@ class AnnouncementGridHandler extends GridHandler {
 
 		// Columns
 		import('lib.pkp.controllers.grid.announcements.AnnouncementGridCellProvider');
-		$announcementCellProvider = new AnnouncementGridCellProvider();
+		$announcementCellProvider = new AnnouncementGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn('title',
 				'common.title',
@@ -93,7 +93,8 @@ class AnnouncementGridHandler extends GridHandler {
 		);
 
 		$dateCellProvider = new DateGridCellProvider(
-			new DataObjectGridCellProvider(),
+			$request,
+			new DataObjectGridCellProvider($request),
 			Config::getVar('general', 'date_format_short')
 		);
 		$this->addColumn(

--- a/controllers/grid/announcements/AnnouncementTypeGridCellProvider.inc.php
+++ b/controllers/grid/announcements/AnnouncementTypeGridCellProvider.inc.php
@@ -16,44 +16,32 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class AnnouncementTypeGridCellProvider extends GridCellProvider {
-
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		switch ($column->getId()) {
 			case 'name':
 				$announcementType = $row->getData();
-				$router = $request->getRouter();
+				$router = $this->_request->getRouter();
 				$actionArgs = array('announcementTypeId' => $row->getId());
 
 				import('lib.pkp.classes.linkAction.request.AjaxModal');
 				return array(new LinkAction(
 					'edit',
 					new AjaxModal(
-						$router->url($request, null, null, 'editAnnouncementType', null, $actionArgs),
+						$router->url($this->_request, null, null, 'editAnnouncementType', null, $actionArgs),
 						__('grid.action.edit'),
 						null,
 						true),
 					$announcementType->getLocalizedTypeName()
 				));
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$announcementType = $row->getData();

--- a/controllers/grid/announcements/AnnouncementTypeGridHandler.inc.php
+++ b/controllers/grid/announcements/AnnouncementTypeGridHandler.inc.php
@@ -72,7 +72,7 @@ class AnnouncementTypeGridHandler extends GridHandler {
 
 		// Columns
 		import('lib.pkp.controllers.grid.announcements.AnnouncementTypeGridCellProvider');
-		$announcementTypeCellProvider = new AnnouncementTypeGridCellProvider();
+		$announcementTypeCellProvider = new AnnouncementTypeGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn('name',
 				'common.name',

--- a/controllers/grid/eventLog/EventLogGridCellProvider.inc.php
+++ b/controllers/grid/eventLog/EventLogGridCellProvider.inc.php
@@ -16,22 +16,11 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class EventLogGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();

--- a/controllers/grid/eventLog/SubmissionEventLogGridHandler.inc.php
+++ b/controllers/grid/eventLog/SubmissionEventLogGridHandler.inc.php
@@ -92,7 +92,7 @@ class SubmissionEventLogGridHandler extends GridHandler {
 		);
 
 		// Columns
-		$cellProvider = new EventLogGridCellProvider();
+		$cellProvider = new EventLogGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'date',
@@ -100,6 +100,7 @@ class SubmissionEventLogGridHandler extends GridHandler {
 				null,
 				null,
 				new DateGridCellProvider(
+					$request,
 					$cellProvider,
 					Config::getVar('general', 'date_format_short')
 				)

--- a/controllers/grid/files/FileNameGridColumn.inc.php
+++ b/controllers/grid/files/FileNameGridColumn.inc.php
@@ -38,7 +38,9 @@ class FileNameGridColumn extends GridColumn {
 		$this->_removeHistoryTab = $removeHistoryTab;
 
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		$cellProvider = new ColumnBasedGridCellProvider();
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
+		$cellProvider = new ColumnBasedGridCellProvider($request);
 
 		parent::__construct('name', 'common.name', null, null, $cellProvider,
 			array('width' => 70, 'alignment' => COLUMN_ALIGNMENT_LEFT, 'anyhtml' => true));

--- a/controllers/grid/files/FileNameGridColumn.inc.php
+++ b/controllers/grid/files/FileNameGridColumn.inc.php
@@ -38,7 +38,7 @@ class FileNameGridColumn extends GridColumn {
 		$this->_removeHistoryTab = $removeHistoryTab;
 
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		$cellProvider = new ColumnBasedGridCellProvider($request);
 

--- a/controllers/grid/files/LibraryFileGridCellProvider.inc.php
+++ b/controllers/grid/files/LibraryFileGridCellProvider.inc.php
@@ -17,18 +17,7 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class LibraryFileGridCellProvider extends GridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element =& $row->getData();
@@ -47,16 +36,16 @@ class LibraryFileGridCellProvider extends GridCellProvider {
 	 * @param $column GridColumn
 	 * @return array an array of LinkAction instances
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		switch ($column->getId()) {
 			case 'files':
 				$element = $row->getData();
 				assert(is_a($element, 'LibraryFile'));
 				// Create the cell action to download a file.
 				import('lib.pkp.controllers.api.file.linkAction.DownloadLibraryFileLinkAction');
-				return array(new DownloadLibraryFileLinkAction($request, $element));
+				return array(new DownloadLibraryFileLinkAction($this->_request, $element));
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 }
 

--- a/controllers/grid/files/LibraryFileGridHandler.inc.php
+++ b/controllers/grid/files/LibraryFileGridHandler.inc.php
@@ -160,12 +160,14 @@ class LibraryFileGridHandler extends CategoryGridHandler {
 	 */
 	function getFileNameColumn() {
 		import('lib.pkp.controllers.grid.files.LibraryFileGridCellProvider');
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
 		return new GridColumn(
 			'files',
 			'grid.libraryFiles.column.files',
 			null,
 			null,
-			new LibraryFileGridCellProvider()
+			new LibraryFileGridCellProvider($request)
 		);
 	}
 

--- a/controllers/grid/files/LibraryFileGridHandler.inc.php
+++ b/controllers/grid/files/LibraryFileGridHandler.inc.php
@@ -160,7 +160,7 @@ class LibraryFileGridHandler extends CategoryGridHandler {
 	 */
 	function getFileNameColumn() {
 		import('lib.pkp.controllers.grid.files.LibraryFileGridCellProvider');
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		return new GridColumn(
 			'files',

--- a/controllers/grid/files/UploaderUserGroupGridColumn.inc.php
+++ b/controllers/grid/files/UploaderUserGroupGridColumn.inc.php
@@ -25,7 +25,9 @@ class UploaderUserGroupGridColumn extends GridColumn {
 	 */
 	function __construct($userGroup, $flags = array()) {
 		$this->_userGroup = $userGroup;
-		$cellProvider = new ColumnBasedGridCellProvider();
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
+		$cellProvider = new ColumnBasedGridCellProvider($request);
 		parent::__construct(
 			'userGroup-' . $userGroup->getId(),
 			null, $userGroup->getLocalizedName(),

--- a/controllers/grid/files/UploaderUserGroupGridColumn.inc.php
+++ b/controllers/grid/files/UploaderUserGroupGridColumn.inc.php
@@ -25,7 +25,7 @@ class UploaderUserGroupGridColumn extends GridColumn {
 	 */
 	function __construct($userGroup, $flags = array()) {
 		$this->_userGroup = $userGroup;
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		$cellProvider = new ColumnBasedGridCellProvider($request);
 		parent::__construct(

--- a/controllers/grid/files/fileList/FileGenreGridColumn.inc.php
+++ b/controllers/grid/files/fileList/FileGenreGridColumn.inc.php
@@ -21,7 +21,9 @@ class FileGenreGridColumn extends GridColumn {
 	 */
 	function __construct() {
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		$cellProvider = new ColumnBasedGridCellProvider();
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
+		$cellProvider = new ColumnBasedGridCellProvider($request);
 		parent::__construct('type', 'common.component', null, null, $cellProvider);
 	}
 

--- a/controllers/grid/files/fileList/FileGenreGridColumn.inc.php
+++ b/controllers/grid/files/fileList/FileGenreGridColumn.inc.php
@@ -21,7 +21,7 @@ class FileGenreGridColumn extends GridColumn {
 	 */
 	function __construct() {
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		$cellProvider = new ColumnBasedGridCellProvider($request);
 		parent::__construct('type', 'common.component', null, null, $cellProvider);

--- a/controllers/grid/languages/LanguageGridCellProvider.inc.php
+++ b/controllers/grid/languages/LanguageGridCellProvider.inc.php
@@ -17,13 +17,6 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class LanguageGridCellProvider extends GridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
@@ -65,12 +58,12 @@ class LanguageGridCellProvider extends GridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		import('lib.pkp.classes.linkAction.request.RemoteActionConfirmationModal');
 		import('lib.pkp.classes.linkAction.request.AjaxAction');
 
 		$element = $row->getData();
-		$router = $request->getRouter();
+		$router = $this->_request->getRouter();
 		$actions = array();
 		$actionArgs = array('rowId' => $row->getId());
 
@@ -83,47 +76,47 @@ class LanguageGridCellProvider extends GridCellProvider {
 				if ($enabled) {
 					$action = 'disable-' . $row->getId();
 					$actionRequest = new RemoteActionConfirmationModal(
-						$request->getSession(),
+						$this->_request->getSession(),
 						__('admin.languages.confirmDisable'),
 						__('common.disable'),
-						$router->url($request, null, null, 'disableLocale', null, $actionArgs)
+						$router->url($this->_request, null, null, 'disableLocale', null, $actionArgs)
 					);
 				} else {
 					$action = 'enable-' . $row->getId();
-					$actionRequest = new AjaxAction($router->url($request, null, null, 'enableLocale', null, $actionArgs));
+					$actionRequest = new AjaxAction($router->url($this->_request, null, null, 'enableLocale', null, $actionArgs));
 				}
 				break;
 			case 'sitePrimary':
 				$primary = $element['primary'];
 				if (!$primary) {
 					$action = 'setPrimary-' . $row->getId();
-					$actionRequest = new AjaxAction($router->url($request, null, null, 'setPrimaryLocale', null, $actionArgs));
+					$actionRequest = new AjaxAction($router->url($this->_request, null, null, 'setPrimaryLocale', null, $actionArgs));
 				}
 				break;
 			case 'contextPrimary':
 				$primary = $element['primary'];
 				if (!$primary) {
 					$action = 'setPrimary-' . $row->getId();
-					$actionRequest = new AjaxAction($router->url($request, null, null, 'setContextPrimaryLocale', null, $actionArgs));
+					$actionRequest = new AjaxAction($router->url($this->_request, null, null, 'setContextPrimaryLocale', null, $actionArgs));
 				}
 				break;
 			case 'uiLocale':
 				$action = 'setUiLocale-' . $row->getId();
 				$actionArgs['setting'] = 'supportedLocales';
 				$actionArgs['value'] = !$element['supportedLocales'];
-				$actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
+				$actionRequest = new AjaxAction($router->url($this->_request, null, null, 'saveLanguageSetting', null, $actionArgs));
 				break;
 			case 'submissionLocale':
 				$action = 'setSubmissionLocale-' . $row->getId();
 				$actionArgs['setting'] = 'supportedSubmissionLocales';
 				$actionArgs['value'] = !$element['supportedSubmissionLocales'];
-				$actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
+				$actionRequest = new AjaxAction($router->url($this->_request, null, null, 'saveLanguageSetting', null, $actionArgs));
 				break;
 			case 'formLocale':
 				$action = 'setFormLocale-' . $row->getId();
 				$actionArgs['setting'] = 'supportedFormLocales';
 				$actionArgs['value'] = !$element['supportedFormLocales'];
-				$actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
+				$actionRequest = new AjaxAction($router->url($this->_request, null, null, 'saveLanguageSetting', null, $actionArgs));
 				break;
 		}
 

--- a/controllers/grid/languages/LanguageGridHandler.inc.php
+++ b/controllers/grid/languages/LanguageGridHandler.inc.php
@@ -131,7 +131,9 @@ class LanguageGridHandler extends GridHandler {
 	 * @return GridCellProvider
 	 */
 	function getCellProvider() {
-		return new LanguageGridCellProvider();
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
+		return new LanguageGridCellProvider($request);
 	}
 
 	/**

--- a/controllers/grid/languages/LanguageGridHandler.inc.php
+++ b/controllers/grid/languages/LanguageGridHandler.inc.php
@@ -131,7 +131,7 @@ class LanguageGridHandler extends GridHandler {
 	 * @return GridCellProvider
 	 */
 	function getCellProvider() {
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		return new LanguageGridCellProvider($request);
 	}

--- a/controllers/grid/notifications/NotificationsGridCellProvider.inc.php
+++ b/controllers/grid/notifications/NotificationsGridCellProvider.inc.php
@@ -19,40 +19,33 @@ import('lib.pkp.classes.linkAction.request.AjaxAction');
 
 class NotificationsGridCellProvider extends GridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Get cell actions associated with this row/column combination
 	 * @param $row GridRow
 	 * @param $column GridColumn
 	 * @return array an array of LinkAction instances
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		assert($column->getId() == 'task');
 
-		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr = TemplateManager::getManager($this->_request);
 
 		$notification = $row->getData();
 		$contextDao = Application::getContextDAO();
 		$context = $contextDao->getById($notification->getContextId());
 
 		$notificationMgr = new NotificationManager();
-		$router = $request->getRouter();
+		$router = $this->_request->getRouter();
 
 		$templateMgr->assign(array(
 			'notificationMgr'         => $notificationMgr,
 			'notification'            => $notification,
 			'context'                 => $context,
 			'notificationObjectTitle' => $this->_getTitle($notification),
-			'message'                 => PKPString::stripUnsafeHtml($notificationMgr->getNotificationMessage($request, $notification)),
+			'message'                 => PKPString::stripUnsafeHtml($notificationMgr->getNotificationMessage($this->_request, $notification)),
 		));
 
 		// See if we're working in a multi-context environment
-		$user = $request->getUser();
+		$user = $this->_request->getUser();
 		$contextDao = Application::getContextDAO();
 		$contexts = $contextDao->getAvailable($user?$user->getId():null)->toArray();
 		$templateMgr->assign('isMultiContext', count($contexts) > 1);
@@ -60,7 +53,7 @@ class NotificationsGridCellProvider extends GridCellProvider {
 		return array(new LinkAction(
 			'details',
 			new AjaxAction($router->url(
-				$request, null, null, 'markRead',
+				$this->_request, null, null, 'markRead',
 				null,
 				array('redirect' => 1, 'selectedElements' => array($notification->getId()))
 			)),
@@ -73,11 +66,7 @@ class NotificationsGridCellProvider extends GridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		assert($column->getId()=='task');

--- a/controllers/grid/notifications/NotificationsGridHandler.inc.php
+++ b/controllers/grid/notifications/NotificationsGridHandler.inc.php
@@ -40,7 +40,7 @@ class NotificationsGridHandler extends GridHandler {
 
 		$this->_selectedNotificationIds = (array) $request->getUserVar('selectedNotificationIds');
 
-		$cellProvider = new NotificationsGridCellProvider();
+		$cellProvider = new NotificationsGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'task',

--- a/controllers/grid/plugins/PluginGalleryGridCellProvider.inc.php
+++ b/controllers/grid/plugins/PluginGalleryGridCellProvider.inc.php
@@ -17,18 +17,7 @@ import('lib.pkp.classes.linkAction.request.AjaxModal');
 
 class PluginGalleryGridCellProvider extends GridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();
@@ -74,15 +63,15 @@ class PluginGalleryGridCellProvider extends GridCellProvider {
 	 * @param $column GridColumn
 	 * @return array an array of LinkAction instances
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		$element = $row->getData();
 		switch ($column->getId()) {
 			case 'name':
-				$router = $request->getRouter();
+				$router = $this->_request->getRouter();
 				return array(new LinkAction(
 					'moreInformation',
 					new AjaxModal(
-						$router->url($request, null, null, 'viewPlugin', null, array('rowId' => $row->getId()+1)),
+						$router->url($this->_request, null, null, 'viewPlugin', null, array('rowId' => $row->getId()+1)),
 						$element->getLocalizedName(),
 						'modal_information',
 						true
@@ -91,7 +80,7 @@ class PluginGalleryGridCellProvider extends GridCellProvider {
 					'details'
 				));
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 }
 

--- a/controllers/grid/plugins/PluginGalleryGridHandler.inc.php
+++ b/controllers/grid/plugins/PluginGalleryGridHandler.inc.php
@@ -55,7 +55,7 @@ class PluginGalleryGridHandler extends GridHandler {
 		// Grid columns.
 		//
 		import('lib.pkp.controllers.grid.plugins.PluginGalleryGridCellProvider');
-		$pluginGalleryGridCellProvider = new PluginGalleryGridCellProvider();
+		$pluginGalleryGridCellProvider = new PluginGalleryGridCellProvider($request);
 
 		// Plugin name.
 		$this->addColumn(

--- a/controllers/grid/plugins/PluginGridCellProvider.inc.php
+++ b/controllers/grid/plugins/PluginGridCellProvider.inc.php
@@ -16,20 +16,8 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class PluginGridCellProvider extends GridCellProvider {
-
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$plugin =& $row->getData();
@@ -62,7 +50,7 @@ class PluginGridCellProvider extends GridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		switch ($column->getId()) {
 			case 'enabled':
 				$plugin = $row->getData(); /* @var $plugin Plugin */
@@ -77,10 +65,10 @@ class PluginGridCellProvider extends GridCellProvider {
 						return array(new LinkAction(
 							'disable',
 							new RemoteActionConfirmationModal(
-								$request->getSession(),
+								$this->_request->getSession(),
 								__('grid.plugin.disable'),
 								__('common.disable'),
-								$request->url(null, null, 'disable', null, $requestArgs)
+								$this->_request->url(null, null, 'disable', null, $requestArgs)
 							),
 							__('manager.plugins.disable'),
 							null
@@ -92,7 +80,7 @@ class PluginGridCellProvider extends GridCellProvider {
 						return array(new LinkAction(
 							'enable',
 							new AjaxAction(
-								$request->url(null, null, 'enable', null, $requestArgs)
+								$this->_request->url(null, null, 'enable', null, $requestArgs)
 							),
 							__('manager.plugins.enable'),
 							null
@@ -100,7 +88,7 @@ class PluginGridCellProvider extends GridCellProvider {
 					break;
 				}
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 }
 

--- a/controllers/grid/queries/QueriesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueriesGridCellProvider.inc.php
@@ -27,12 +27,13 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 * @param $submission Submission
 	 * @param $stageId int
 	 * @param $queriesAccessHelper QueriesAccessHelper
 	 */
-	function __construct($submission, $stageId, $queriesAccessHelper) {
-		parent::__construct();
+	function __construct($request, $submission, $stageId, $queriesAccessHelper) {
+		parent::__construct($request);
 		$this->_submission = $submission;
 		$this->_stageId = $stageId;
 		$this->_queriesAccessHelper = $queriesAccessHelper;
@@ -42,11 +43,7 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();
@@ -82,12 +79,12 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		import('lib.pkp.classes.linkAction.request.RemoteActionConfirmationModal');
 		import('lib.pkp.classes.linkAction.request.AjaxAction');
 
 		$element = $row->getData();
-		$router = $request->getRouter();
+		$router = $this->_request->getRouter();
 		$actionArgs = $this->getRequestArgs($row);
 		switch ($column->getId()) {
 			case 'closed':
@@ -96,20 +93,20 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 					if ($enabled) {
 						return array(new LinkAction(
 							'close-' . $row->getId(),
-							new AjaxAction($router->url($request, null, null, 'closeQuery', null, $actionArgs)),
+							new AjaxAction($router->url($this->_request, null, null, 'closeQuery', null, $actionArgs)),
 							null, null
 						));
 					} else {
 						return array(new LinkAction(
 							'open-' . $row->getId(),
-							new AjaxAction($router->url($request, null, null, 'openQuery', null, $actionArgs)),
+							new AjaxAction($router->url($this->_request, null, null, 'openQuery', null, $actionArgs)),
 							null, null
 						));
 					}
 				}
 				break;
 		}
-		return parent::getCellActions($request, $row, $column);
+		return parent::getCellActions($row, $column);
 	}
 
 	/**

--- a/controllers/grid/queries/QueriesGridHandler.inc.php
+++ b/controllers/grid/queries/QueriesGridHandler.inc.php
@@ -90,7 +90,7 @@ class QueriesGridHandler extends GridHandler {
 	 */
 	function getCellProvider() {
 		import('lib.pkp.controllers.grid.queries.QueriesGridCellProvider');
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		return new QueriesGridCellProvider(
 			$request,

--- a/controllers/grid/queries/QueriesGridHandler.inc.php
+++ b/controllers/grid/queries/QueriesGridHandler.inc.php
@@ -90,7 +90,10 @@ class QueriesGridHandler extends GridHandler {
 	 */
 	function getCellProvider() {
 		import('lib.pkp.controllers.grid.queries.QueriesGridCellProvider');
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
 		return new QueriesGridCellProvider(
+			$request,
 			$this->getSubmission(),
 			$this->getStageId(),
 			$this->getAccessHelper()

--- a/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
@@ -21,10 +21,11 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 * @param $submission Submission
 	 */
-	function __construct($submission) {
-		parent::__construct();
+	function __construct($request, $submission) {
+		parent::__construct($request);
 		$this->_submission = $submission;
 	}
 
@@ -32,11 +33,7 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 	// Template methods from GridCellProvider
 	//
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();
@@ -55,7 +52,7 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		switch ($column->getId()) {
 			case 'contents':
 				$element = $row->getData();
@@ -69,11 +66,11 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 				import('lib.pkp.controllers.api.file.linkAction.DownloadFileLinkAction');
 				$actions = array();
 				foreach ($submissionFiles as $submissionFile) {
-					$actions[] = new DownloadFileLinkAction($request, $submissionFile, $request->getUserVar('stageId'));
+					$actions[] = new DownloadFileLinkAction($this->_request, $submissionFile, $request->getUserVar('stageId'));
 				}
 				return $actions;
 		}
-		return parent::getCellActions($request, $row, $column);
+		return parent::getCellActions($row, $column);
 	}
 }
 

--- a/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
@@ -66,7 +66,7 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 				import('lib.pkp.controllers.api.file.linkAction.DownloadFileLinkAction');
 				$actions = array();
 				foreach ($submissionFiles as $submissionFile) {
-					$actions[] = new DownloadFileLinkAction($this->_request, $submissionFile, $request->getUserVar('stageId'));
+					$actions[] = new DownloadFileLinkAction($this->_request, $submissionFile, $this->_request->getUserVar('stageId'));
 				}
 				return $actions;
 		}

--- a/controllers/grid/queries/QueryNotesGridHandler.inc.php
+++ b/controllers/grid/queries/QueryNotesGridHandler.inc.php
@@ -93,7 +93,7 @@ class QueryNotesGridHandler extends GridHandler {
 		);
 
 		import('lib.pkp.controllers.grid.queries.QueryNotesGridCellProvider');
-		$cellProvider = new QueryNotesGridCellProvider($this->getSubmission());
+		$cellProvider = new QueryNotesGridCellProvider($request, $this->getSubmission());
 
 		// Columns
 		$this->addColumn(

--- a/controllers/grid/queries/QueryTitleGridColumn.inc.php
+++ b/controllers/grid/queries/QueryTitleGridColumn.inc.php
@@ -28,7 +28,7 @@ class QueryTitleGridColumn extends GridColumn {
 		$this->_actionArgs = $actionArgs;
 
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		// TODO: Where should the request come from?
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
 		$request = PKPApplication::getRequest();
 		$cellProvider = new ColumnBasedGridCellProvider($request);
 

--- a/controllers/grid/queries/QueryTitleGridColumn.inc.php
+++ b/controllers/grid/queries/QueryTitleGridColumn.inc.php
@@ -28,7 +28,9 @@ class QueryTitleGridColumn extends GridColumn {
 		$this->_actionArgs = $actionArgs;
 
 		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
-		$cellProvider = new ColumnBasedGridCellProvider();
+		// TODO: Where should the request come from?
+		$request = PKPApplication::getRequest();
+		$cellProvider = new ColumnBasedGridCellProvider($request);
 
 		parent::__construct('name', 'common.name', null, null, $cellProvider,
 			array('width' => 60, 'alignment' => COLUMN_ALIGNMENT_LEFT));

--- a/controllers/grid/settings/genre/GenreGridHandler.inc.php
+++ b/controllers/grid/settings/genre/GenreGridHandler.inc.php
@@ -89,7 +89,7 @@ class GenreGridHandler extends SetupGridHandler {
 		);
 
 		// Columns
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$cellProvider->setLocale(AppLocale::getLocale());
 		$this->addColumn(
 			new GridColumn('name',

--- a/controllers/grid/settings/metadata/MetadataGridCellProvider.inc.php
+++ b/controllers/grid/settings/metadata/MetadataGridCellProvider.inc.php
@@ -22,11 +22,12 @@ class MetadataGridCellProvider extends GridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 * @param $context Context
 	 */
-	function __construct($context) {
+	function __construct($request, $context) {
 		$this->_context = $context;
-		parent::__construct();
+		parent::__construct($request);
 	}
 
 	/**

--- a/controllers/grid/settings/metadata/MetadataGridHandler.inc.php
+++ b/controllers/grid/settings/metadata/MetadataGridHandler.inc.php
@@ -45,7 +45,7 @@ class MetadataGridHandler extends GridHandler {
 		// Basic grid configuration.
 		$this->setTitle('submission.metadata');
 
-		$cellProvider = new MetadataGridCellProvider($request->getContext());
+		$cellProvider = new MetadataGridCellProvider($request, $request->getContext());
 
 		// Field name.
 		$this->addColumn(

--- a/controllers/grid/settings/preparedEmails/PreparedEmailsGridCellProvider.inc.php
+++ b/controllers/grid/settings/preparedEmails/PreparedEmailsGridCellProvider.inc.php
@@ -17,18 +17,7 @@ import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class PreparedEmailsGridCellProvider extends DataObjectGridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $element mixed
-	 * @param $columnId string
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element =& $row->getData();

--- a/controllers/grid/settings/preparedEmails/PreparedEmailsGridCellProvider.inc.php
+++ b/controllers/grid/settings/preparedEmails/PreparedEmailsGridCellProvider.inc.php
@@ -49,20 +49,20 @@ class PreparedEmailsGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		switch ($column->getId()) {
 			case 'enabled':
 				$element = $row->getData(); /* @var $element DataObject */
-				$router = $request->getRouter();
+				$router = $this->_request->getRouter();
 				import('lib.pkp.classes.linkAction.LinkAction');
 				if ($element->getCanDisable()) {
 					if ($element->getEnabled()) {
 						return array(new LinkAction(
 							'disableEmail',
 							new RemoteActionConfirmationModal(
-								$request->getSession(),
+								$this->_request->getSession(),
 								__('manager.emails.disable.message'), null,
-								$router->url($request, null, 'grid.settings.preparedEmails.PreparedEmailsGridHandler',
+								$router->url($this->_request, null, 'grid.settings.preparedEmails.PreparedEmailsGridHandler',
 									'disableEmail', null, array('emailKey' => $element->getEmailKey()))
 							),
 							__('manager.emails.disable'),
@@ -72,9 +72,9 @@ class PreparedEmailsGridCellProvider extends DataObjectGridCellProvider {
 						return array(new LinkAction(
 							'enableEmail',
 							new RemoteActionConfirmationModal(
-								$request->getSession(),
+								$this->_request->getSession(),
 								__('manager.emails.enable.message'), null,
-								$router->url($request, null, 'grid.settings.preparedEmails.PreparedEmailsGridHandler',
+								$router->url($this->_request, null, 'grid.settings.preparedEmails.PreparedEmailsGridHandler',
 									'enableEmail', null, array('emailKey' => $element->getEmailKey()))
 							),
 							__('manager.emails.enable'),
@@ -83,7 +83,7 @@ class PreparedEmailsGridCellProvider extends DataObjectGridCellProvider {
 					}
 			}
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 }
 

--- a/controllers/grid/settings/preparedEmails/PreparedEmailsGridHandler.inc.php
+++ b/controllers/grid/settings/preparedEmails/PreparedEmailsGridHandler.inc.php
@@ -82,7 +82,7 @@ class PreparedEmailsGridHandler extends GridHandler {
 
 		// Columns
 		import('lib.pkp.controllers.grid.settings.preparedEmails.PreparedEmailsGridCellProvider');
-		$cellProvider = new PreparedEmailsGridCellProvider();
+		$cellProvider = new PreparedEmailsGridCellProvider($request);
 		$this->addColumn(new GridColumn('name', 'common.name', null, null, $cellProvider, array('width' => 40)));
 		$this->addColumn(new GridColumn('sender', 'email.sender', null, null, $cellProvider, array('width' => 10)));
 		$this->addColumn(new GridColumn('recipient', 'email.recipient', null, null, $cellProvider));

--- a/controllers/grid/settings/reviewForms/ReviewFormElementGridCellProvider.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormElementGridCellProvider.inc.php
@@ -15,13 +15,6 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class ReviewFormElementGridCellProvider extends GridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Extracts variables for a given column from a data element
 	 * so that they may be assigned to template before rendering.
 	 * @param $row GridRow

--- a/controllers/grid/settings/reviewForms/ReviewFormElementsGridHandler.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormElementsGridHandler.inc.php
@@ -96,7 +96,7 @@ class ReviewFormElementsGridHandler extends GridHandler {
 		// Grid columns.
 		//
 		import('lib.pkp.controllers.grid.settings.reviewForms.ReviewFormElementGridCellProvider');
-		$reviewFormElementGridCellProvider = new ReviewFormElementGridCellProvider();
+		$reviewFormElementGridCellProvider = new ReviewFormElementGridCellProvider($request);
 
 		// Review form element name.
 		$this->addColumn(

--- a/controllers/grid/settings/reviewForms/ReviewFormGridCellProvider.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormGridCellProvider.inc.php
@@ -51,22 +51,22 @@ class ReviewFormGridCellProvider extends GridCellProvider {
 	/**
 	 * @see GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		switch ($column->getId()) {
 			case 'active':
 				$element = $row->getData(); /* @var $element DataObject */
 
-				$router = $request->getRouter();
+				$router = $this->_request->getRouter();
 				import('lib.pkp.classes.linkAction.LinkAction');
 
 				if ($element->getActive()) return array(new LinkAction(
 					'deactivateReviewForm',
 					new RemoteActionConfirmationModal(
-						$request->getSession(),
+						$this->_request->getSession(),
 						__('manager.reviewForms.confirmDeactivate'),
 						null,
 						$router->url(
-							$request,
+							$this->_request,
 							null,
 							'grid.settings.reviewForms.ReviewFormGridHandler',
 							'deactivateReviewForm',
@@ -78,11 +78,11 @@ class ReviewFormGridCellProvider extends GridCellProvider {
 				else return array(new LinkAction(
 					'activateReviewForm',
 					new RemoteActionConfirmationModal(
-						$request->getSession(),
+						$this->_request->getSession(),
 						__('manager.reviewForms.confirmActivate'),
 						null,
 						$router->url(
-							$request,
+							$this->_request,
 							null,
 							'grid.settings.reviewForms.ReviewFormGridHandler',
 							'activateReviewForm',
@@ -92,7 +92,7 @@ class ReviewFormGridCellProvider extends GridCellProvider {
 					)
 				));
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 }
 

--- a/controllers/grid/settings/reviewForms/ReviewFormGridCellProvider.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormGridCellProvider.inc.php
@@ -16,13 +16,6 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class ReviewFormGridCellProvider extends GridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Extracts variables for a given column from a data element
 	 * so that they may be assigned to template before rendering.
 	 * @param $row GridRow

--- a/controllers/grid/settings/reviewForms/ReviewFormGridHandler.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormGridHandler.inc.php
@@ -79,7 +79,7 @@ class ReviewFormGridHandler extends GridHandler {
 		// Grid columns.
 		//
 		import('lib.pkp.controllers.grid.settings.reviewForms.ReviewFormGridCellProvider');
-		$reviewFormGridCellProvider = new ReviewFormGridCellProvider();
+		$reviewFormGridCellProvider = new ReviewFormGridCellProvider($request);
 
 		// Review form name.
 		$this->addColumn(

--- a/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
+++ b/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
@@ -16,14 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class UserGroupGridCellProvider extends GridCellProvider {
-
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	/**
 	 * Extracts variables for a given column from a data element
 	 * so that they may be assigned to template before rendering.

--- a/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
+++ b/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
@@ -57,7 +57,7 @@ class UserGroupGridCellProvider extends GridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		$workflowStages = Application::getApplicationStages();
 		$columnId = $column->getId();
 
@@ -66,7 +66,7 @@ class UserGroupGridCellProvider extends GridCellProvider {
 			$userGroupDao = DAORegistry::getDAO('UserGroupDAO'); /* @var $userGroupDao UserGroupDAO */
 			$assignedStages = $userGroupDao->getAssignedStagesByUserGroupId($userGroup->getContextId(), $userGroup->getId());
 
-			$router = $request->getRouter();
+			$router = $this->_request->getRouter();
 			$roleDao = DAORegistry::getDAO('RoleDAO'); /* @var $roleDao RoleDAO */
 
 			if (!in_array($columnId, $roleDao->getForbiddenStages($userGroup->getRoleId()))) {
@@ -80,7 +80,7 @@ class UserGroupGridCellProvider extends GridCellProvider {
 				$actionArgs = array_merge(array('stageId' => $columnId),
 					$row->getRequestArgs());
 
-				$actionUrl = $router->url($request, null, null, $operation, null, $actionArgs);
+				$actionUrl = $router->url($this->_request, null, null, $operation, null, $actionArgs);
 				import('lib.pkp.classes.linkAction.request.AjaxAction');
 				$actionRequest = new AjaxAction($actionUrl);
 
@@ -95,7 +95,7 @@ class UserGroupGridCellProvider extends GridCellProvider {
 			}
 		}
 
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 }
 

--- a/controllers/grid/settings/roles/UserGroupGridHandler.inc.php
+++ b/controllers/grid/settings/roles/UserGroupGridHandler.inc.php
@@ -122,7 +122,7 @@ class UserGroupGridHandler extends GridHandler {
 		);
 
 		import('lib.pkp.controllers.grid.settings.roles.UserGroupGridCellProvider');
-		$cellProvider = new UserGroupGridCellProvider();
+		$cellProvider = new UserGroupGridCellProvider($request);
 
 		$workflowStagesLocales = WorkflowStageDAO::getWorkflowStageTranslationKeys();
 

--- a/controllers/grid/settings/user/UserGridHandler.inc.php
+++ b/controllers/grid/settings/user/UserGridHandler.inc.php
@@ -88,7 +88,7 @@ class UserGridHandler extends GridHandler {
 		//
 
 		// First Name.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'firstName',
@@ -100,7 +100,7 @@ class UserGridHandler extends GridHandler {
 		);
 
 		// Last Name.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'lastName',
@@ -112,7 +112,7 @@ class UserGridHandler extends GridHandler {
 		);
 
 		// User name.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'username',
@@ -124,7 +124,7 @@ class UserGridHandler extends GridHandler {
 		);
 
 		// Email.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'email',

--- a/controllers/grid/submissions/SubmissionsListGridCellProvider.inc.php
+++ b/controllers/grid/submissions/SubmissionsListGridCellProvider.inc.php
@@ -69,9 +69,9 @@ class SubmissionsListGridCellProvider extends DataObjectGridCellProvider {
 	 * @param $column GridColumn
 	 * @return array an array of LinkAction instances
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		$submission = $row->getData();
-		$user = $request->getUser();
+		$user = $this->_request->getUser();
 		switch ($column->getId()) {
 			case 'editor':
 				$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO'); /* @var $stageAssignmentDao StageAssignmentDAO */
@@ -109,8 +109,8 @@ class SubmissionsListGridCellProvider extends DataObjectGridCellProvider {
 					return array(new LinkAction(
 						'itemWorkflow',
 						new RedirectAction(
-							$request->getDispatcher()->url(
-								$request, ROUTE_PAGE,
+							$this->_request->getDispatcher()->url(
+								$this->_request, ROUTE_PAGE,
 								null,
 								'reviewer', 'submission',
 								$submission->getId()
@@ -122,12 +122,12 @@ class SubmissionsListGridCellProvider extends DataObjectGridCellProvider {
 				return array(new LinkAction(
 					'itemWorkflow',
 					new RedirectAction(
-						SubmissionsListGridCellProvider::getUrlByUserRoles($request, $submission)
+						SubmissionsListGridCellProvider::getUrlByUserRoles($this->_request, $submission)
 					),
 					$stage
 				));
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 
 	//

--- a/controllers/grid/submissions/SubmissionsListGridCellProvider.inc.php
+++ b/controllers/grid/submissions/SubmissionsListGridCellProvider.inc.php
@@ -25,13 +25,16 @@ class SubmissionsListGridCellProvider extends DataObjectGridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
+	 * @param $user PKPUser
+	 * @param $authorizedRoles mixed
 	 */
-	function __construct($user, $authorizedRoles = null) {
+	function __construct($request, $user, $authorizedRoles = null) {
 		if ($authorizedRoles) {
 			$this->_authorizedRoles = $authorizedRoles;
 		}
 		$this->user = $user;
-		parent::__construct();
+		parent::__construct($request);
 	}
 
 

--- a/controllers/grid/submissions/SubmissionsListGridHandler.inc.php
+++ b/controllers/grid/submissions/SubmissionsListGridHandler.inc.php
@@ -65,7 +65,7 @@ class SubmissionsListGridHandler extends GridHandler {
 		$this->_isManager = in_array(ROLE_ID_MANAGER, $authorizedRoles);
 
 		// If there is more than one context in the system, add a context column
-		$cellProvider = new SubmissionsListGridCellProvider($request->getUser(), $authorizedRoles);
+		$cellProvider = new SubmissionsListGridCellProvider($request, $request->getUser(), $authorizedRoles);
 		$this->addColumn(
 			new GridColumn(
 				'id',

--- a/controllers/grid/submissions/activeSubmissions/ActiveSubmissionsListGridHandler.inc.php
+++ b/controllers/grid/submissions/activeSubmissions/ActiveSubmissionsListGridHandler.inc.php
@@ -54,7 +54,7 @@ class ActiveSubmissionsListGridHandler extends SubmissionsListGridHandler {
 		// Fetch the authorized roles and determine if the user is a manager.
 		$authorizedRoles = $this->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES);
 		$this->_isManager = in_array(ROLE_ID_MANAGER, $authorizedRoles);
-		$cellProvider = new SubmissionsListGridCellProvider($request->getUser(), $authorizedRoles);
+		$cellProvider = new SubmissionsListGridCellProvider($request, $request->getUser(), $authorizedRoles);
 
 		$columns =& $this->getColumns();
 		$editorColumn = new GridColumn(

--- a/controllers/grid/users/author/AuthorGridHandler.inc.php
+++ b/controllers/grid/users/author/AuthorGridHandler.inc.php
@@ -118,7 +118,7 @@ class AuthorGridHandler extends GridHandler {
 		}
 
 		// Columns
-		$cellProvider = new PKPAuthorGridCellProvider();
+		$cellProvider = new PKPAuthorGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'name',

--- a/controllers/grid/users/author/PKPAuthorGridCellProvider.inc.php
+++ b/controllers/grid/users/author/PKPAuthorGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class PKPAuthorGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/grid/users/exportableUsers/ExportableUsersGridHandler.inc.php
+++ b/controllers/grid/users/exportableUsers/ExportableUsersGridHandler.inc.php
@@ -88,7 +88,7 @@ class ExportableUsersGridHandler extends GridHandler {
 		//
 
 		// First Name.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'firstName',
@@ -100,7 +100,7 @@ class ExportableUsersGridHandler extends GridHandler {
 		);
 
 		// Last Name.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'lastName',
@@ -112,7 +112,7 @@ class ExportableUsersGridHandler extends GridHandler {
 		);
 
 		// User name.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 				new GridColumn(
 					'username',
@@ -124,7 +124,7 @@ class ExportableUsersGridHandler extends GridHandler {
 		);
 
 		// Email.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'email',

--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -147,7 +147,7 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 			'stageId' => $reviewAssignment->getStageId()
 		);
 
-		$router = $request->getRouter();
+		$router = $this->_request->getRouter();
 		$action = false;
 		$submissionDao = Application::getSubmissionDAO();
 		$submission = $submissionDao->getById($reviewAssignment->getSubmissionId());
@@ -160,20 +160,20 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 				case 'overdue':
 				case 'overdue_response':
 					import('lib.pkp.controllers.api.task.SendReminderLinkAction');
-					return array(new SendReminderLinkAction($request, 'editor.review.reminder', $actionArgs));
+					return array(new SendReminderLinkAction($this->_request, 'editor.review.reminder', $actionArgs));
 				case 'read':
 					import('lib.pkp.controllers.api.task.SendThankYouLinkAction');
-					return array(new SendThankYouLinkAction($request, 'editor.review.thankReviewer', $actionArgs));
+					return array(new SendThankYouLinkAction($this->_request, 'editor.review.thankReviewer', $actionArgs));
 				case 'completed':
 					import('lib.pkp.controllers.review.linkAction.UnconsiderReviewLinkAction');
-					return array(new UnconsiderReviewLinkAction($request, $reviewAssignment, $submission));
+					return array(new UnconsiderReviewLinkAction($this->_request, $reviewAssignment, $submission));
 				case 'reviewReady':
-					$user = $request->getUser();
+					$user = $this->_request->getUser();
 					import('lib.pkp.controllers.review.linkAction.ReviewNotesLinkAction');
-					return array(new ReviewNotesLinkAction($request, $reviewAssignment, $submission, $user, true));
+					return array(new ReviewNotesLinkAction($this->_request, $reviewAssignment, $submission, $user, true));
 			}
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 
 	/**

--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -19,14 +19,6 @@ import('lib.pkp.classes.linkAction.request.AjaxModal');
 import('lib.pkp.classes.linkAction.request.AjaxAction');
 
 class ReviewerGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -139,7 +139,7 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 	 * @param $column GridColumn
 	 * @return array an array of LinkAction instances
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		$reviewAssignment = $row->getData();
 		$actionArgs = array(
 			'submissionId' => $reviewAssignment->getSubmissionId(),

--- a/controllers/grid/users/reviewerSelect/ReviewerSelectGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewerSelect/ReviewerSelectGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class ReviewerSelectGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/grid/users/reviewerSelect/ReviewerSelectGridHandler.inc.php
+++ b/controllers/grid/users/reviewerSelect/ReviewerSelectGridHandler.inc.php
@@ -68,7 +68,7 @@ class ReviewerSelectGridHandler extends GridHandler {
 		$this->setTitle('editor.submission.findAndSelectReviewer');
 
 		// Columns
-		$cellProvider = new ReviewerSelectGridCellProvider();
+		$cellProvider = new ReviewerSelectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'select',

--- a/controllers/grid/users/stageParticipant/StageParticipantGridCellProvider.inc.php
+++ b/controllers/grid/users/stageParticipant/StageParticipantGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class StageParticipantGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/grid/users/stageParticipant/StageParticipantGridHandler.inc.php
+++ b/controllers/grid/users/stageParticipant/StageParticipantGridHandler.inc.php
@@ -106,7 +106,7 @@ class StageParticipantGridHandler extends CategoryGridHandler {
 
 		// Columns
 		import('lib.pkp.controllers.grid.users.stageParticipant.StageParticipantGridCellProvider');
-		$cellProvider = new StageParticipantGridCellProvider();
+		$cellProvider = new StageParticipantGridCellProvider($request);
 		$this->addColumn(new GridColumn(
 			'participants',
 			null,

--- a/controllers/grid/users/userSelect/UserSelectGridCellProvider.inc.php
+++ b/controllers/grid/users/userSelect/UserSelectGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class UserSelectGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/grid/users/userSelect/UserSelectGridHandler.inc.php
+++ b/controllers/grid/users/userSelect/UserSelectGridHandler.inc.php
@@ -76,7 +76,7 @@ class UserSelectGridHandler extends GridHandler {
 		$this->setTitle('editor.submission.findAndSelectUser');
 
 		// Columns
-		$cellProvider = new UserSelectGridCellProvider();
+		$cellProvider = new UserSelectGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'select',

--- a/controllers/listbuilder/files/FileListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/files/FileListbuilderGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class FileListbuilderGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/listbuilder/files/FilesListbuilderHandler.inc.php
+++ b/controllers/listbuilder/files/FilesListbuilderHandler.inc.php
@@ -74,7 +74,7 @@ class FilesListbuilderHandler extends ListbuilderHandler {
 		// Add the file column
 		$itemColumn = new ListbuilderGridColumn($this, 'name', 'common.name', null, null, null, array('anyhtml' => true));
 		import('lib.pkp.controllers.listbuilder.files.FileListbuilderGridCellProvider');
-		$itemColumn->setCellProvider(new FileListbuilderGridCellProvider());
+		$itemColumn->setCellProvider(new FileListbuilderGridCellProvider($request));
 		$this->addColumn($itemColumn);
 	}
 

--- a/controllers/listbuilder/settings/BlockPluginsListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/settings/BlockPluginsListbuilderGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class BlockPluginsListbuilderGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/listbuilder/settings/BlockPluginsListbuilderHandler.inc.php
+++ b/controllers/listbuilder/settings/BlockPluginsListbuilderHandler.inc.php
@@ -61,7 +61,7 @@ class BlockPluginsListbuilderHandler extends MultipleListsListbuilderHandler {
 		$this->addList(new ListbuilderList('unselected', 'manager.setup.layout.unselected'));
 
 		import('lib.pkp.controllers.listbuilder.settings.BlockPluginsListbuilderGridCellProvider');
-		$nameColumn->setCellProvider(new BlockPluginsListbuilderGridCellProvider());
+		$nameColumn->setCellProvider(new BlockPluginsListbuilderGridCellProvider($request));
 		$this->addColumn($nameColumn);
 	}
 

--- a/controllers/listbuilder/settings/SubEditorsListbuilderHandler.inc.php
+++ b/controllers/listbuilder/settings/SubEditorsListbuilderHandler.inc.php
@@ -133,7 +133,7 @@ class SubEditorsListbuilderHandler extends SetupListbuilderHandler {
 
 		// We can reuse the User cell provider because getFullName
 		import('lib.pkp.controllers.listbuilder.users.UserListbuilderGridCellProvider');
-		$nameColumn->setCellProvider(new UserListbuilderGridCellProvider());
+		$nameColumn->setCellProvider(new UserListbuilderGridCellProvider($request));
 		$this->addColumn($nameColumn);
 	}
 }

--- a/controllers/listbuilder/settings/reviewForms/ReviewFormElementResponseItemListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/settings/reviewForms/ReviewFormElementResponseItemListbuilderGridCellProvider.inc.php
@@ -15,13 +15,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class ReviewFormElementResponseItemListbuilderGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/listbuilder/settings/reviewForms/ReviewFormElementResponseItemListbuilderHandler.inc.php
+++ b/controllers/listbuilder/settings/reviewForms/ReviewFormElementResponseItemListbuilderHandler.inc.php
@@ -47,7 +47,7 @@ class ReviewFormElementResponseItemListbuilderHandler extends SetupListbuilderHa
 		// Possible response column
 		$responseColumn = new MultilingualListbuilderGridColumn($this, 'possibleResponse', 'manager.reviewFormElements.possibleResponse', null, null, null, null, array('tabIndex' => 1));
 		import('lib.pkp.controllers.listbuilder.settings.reviewForms.ReviewFormElementResponseItemListbuilderGridCellProvider');
-	 	$responseColumn->setCellProvider(new ReviewFormElementResponseItemListbuilderGridCellProvider());	
+	 	$responseColumn->setCellProvider(new ReviewFormElementResponseItemListbuilderGridCellProvider($request));	
 		$this->addColumn($responseColumn);
 	}
 

--- a/controllers/listbuilder/users/UserGroupListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/users/UserGroupListbuilderGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class UserGroupListbuilderGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/listbuilder/users/UserListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/users/UserListbuilderGridCellProvider.inc.php
@@ -16,13 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class UserListbuilderGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 	//
 	// Template methods from GridCellProvider
 	//

--- a/controllers/listbuilder/users/UserUserGroupListbuilderHandler.inc.php
+++ b/controllers/listbuilder/users/UserUserGroupListbuilderHandler.inc.php
@@ -181,7 +181,7 @@ class UserUserGroupListbuilderHandler extends ListbuilderHandler {
 		$this->setSaveFieldName('roles');
 
 		import('lib.pkp.controllers.listbuilder.users.UserGroupListbuilderGridCellProvider');
-		$cellProvider = new UserGroupListbuilderGridCellProvider();
+		$cellProvider = new UserGroupListbuilderGridCellProvider($request);
 
 		// Name column
 		$nameColumn = new ListbuilderGridColumn(

--- a/controllers/listbuilder/users/UsersListbuilderHandler.inc.php
+++ b/controllers/listbuilder/users/UsersListbuilderHandler.inc.php
@@ -54,7 +54,7 @@ abstract class UsersListbuilderHandler extends ListbuilderHandler {
 		// Name column
 		$nameColumn = new ListbuilderGridColumn($this, 'name', 'common.name');
 		import('lib.pkp.controllers.listbuilder.users.UserListbuilderGridCellProvider');
-		$cellProvider = new UserListbuilderGridCellProvider();
+		$cellProvider = new UserListbuilderGridCellProvider($request);
 		$nameColumn->setCellProvider($cellProvider);
 		$this->addColumn($nameColumn);
 	}


### PR DESCRIPTION
`GridCellProvider::__construct()` will store an initial `PKPRequest` object, then use this request object for other methods rather than passing it as a parameter.

Part of stage one of pkp/pkp-lib#2444: specifically, the GridCellProvider component.