### PR TITLE
pkp/pkp-lib#2500: Modify NativeXMLSubmissionFileFilter::handleRevisionChildElement() to consistently return a temporary filename.

### DIFF
--- a/classes/plugins/importexport/PKPImportExportDeployment.inc.php
+++ b/classes/plugins/importexport/PKPImportExportDeployment.inc.php
@@ -33,6 +33,9 @@ class PKPImportExportDeployment {
 	/** @var array Connection between the file and revision IDs from the XML import file and the DB file IDs */
 	var $_fileDBIds;
 
+	/** @var string Base path for the import source */
+	var $_baseImportPath = '';
+
 	/**
 	 * Constructor
 	 * @param $context Context
@@ -238,6 +241,22 @@ class PKPImportExportDeployment {
 	 */
 	function setFileDBId($fileId, $revisionId, $DBId) {
 		return $this->_fileDBIds[$fileId][$revisionId]= $DBId;
+	}
+
+	/**
+	 * Set the directory location for the import source
+	 * @param $path string
+	 */
+	function setImportPath($path) {
+		$this->_baseImportPath = $path;
+	}
+
+	/**
+	 * Get the directory location for the import source
+	 * @return string
+	 */
+	function getImportPath() {
+		return $this->_baseImportPath;
 	}
 }
 

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -527,4 +527,5 @@
 	<message key="plugins.importexport.common.error.unknownEncoding">Unknown encoding {$param}</message>
 	<message key="plugins.importexport.common.error.unknownUserGroup">Unknown user group {$param}</message>
 	<message key="plugins.importexport.common.error.unknownUploader">Unknown uploader {$param}</message>
+	<message key="plugins.importexport.common.error.temporaryFileFailed">Temporary file {$dest} could not be created from {$source}</message>
 </locale>


### PR DESCRIPTION
Shared library component of #2500.