### PR TITLE
pkp/pkp-lib#1807 b) a fix for locale placeholder for keyword form inp…

### DIFF
--- a/templates/form/keywordInput.tpl
+++ b/templates/form/keywordInput.tpl
@@ -14,7 +14,7 @@
 			$(document).ready(function(){ldelim}
 				$("#{$thisFormLocale|escape:jqselector}-{$FBV_id}{$uniqId}").tagit({ldelim}
 					fieldName: "keywords[{$thisFormLocale|escape}-{$FBV_id|escape}][]",
-					{if !$smarty.foreach.formLocales.first && empty($FBV_currentKeywords.$thisFormLocale)}placeholderText: "{$thisFormLocaleName|escape}",{/if}
+					{if $thisFormLocale != $formLocale && empty($FBV_currentKeywords.$thisFormLocale)}placeholderText: "{$thisFormLocaleName|escape}",{/if}
 					allowSpaces: true,
 					{if $FBV_sourceUrl && !$FBV_disabled}
 						tagSource: function(search, showChoices) {ldelim}


### PR DESCRIPTION
…ut fields

For some reason, in the QuickSubmit plugin, the first `formLocales` iteration value was not the `formLocale`... thus the comparison `$thisFormLocale != $formLocale` seems to be better...