### PR TITLE
pkp/pkp-lib#2526: Create dedicated error and warning functions for PKPNativeImportExportDeployment

### DIFF
--- a/classes/plugins/importexport/PKPImportExportDeployment.inc.php
+++ b/classes/plugins/importexport/PKPImportExportDeployment.inc.php
@@ -28,7 +28,13 @@ class PKPImportExportDeployment {
 	var $_submission;
 
 	/** @var array The processed import objects IDs */
-	var $_processedObjectsIds;
+	var $_processedObjectsIds = array();
+
+	/** @var array Warnings keyed by object IDs */
+	var $_processedObjectsErrors = array();
+
+	/** @var array Errors keyed by object IDs */
+	var $_processedObjectsWarnings = array();
 
 	/** @var array Connection between the file and revision IDs from the XML import file and the DB file IDs */
 	var $_fileDBIds;
@@ -134,7 +140,7 @@ class PKPImportExportDeployment {
 	 * @param $assocId integer
 	 */
 	function addProcessedObjectId($assocType, $assocId) {
-		$this->_processedObjectsIds[$assocType][$assocId] = array();
+		$this->_processedObjectsIds[$assocType][] = $assocId;
 	}
 
 	/**
@@ -144,17 +150,51 @@ class PKPImportExportDeployment {
 	 * @param $errorMsg string
 	 */
 	function addError($assocType, $assocId, $errorMsg) {
-		$this->_processedObjectsIds[$assocType][$assocId][] = $errorMsg;
+		$this->_processedObjectsErrors[$assocType][$assocId][] = $errorMsg;
+	}
+
+	/**
+	 * Add the warning message to the processed object ID.
+	 * @param $assocType integer ASSOC_TYPE_...
+	 * @param $assocId integer
+	 * @param $warningMsg string
+	 */
+	function addWarning($assocType, $assocId, $warningMsg) {
+		$this->_processedObjectsWarnings[$assocType][$assocId][] = $warningMsg;
 	}
 
 	/**
 	 * Get the processed objects IDs.
 	 * @param $assocType integer ASSOC_TYPE_...
-	 * @return array Associative array (assoc object Id => array of errors)
+	 * @return array
 	 */
 	function getProcessedObjectsIds($assocType) {
 		if (array_key_exists($assocType, $this->_processedObjectsIds)) {
 			return $this->_processedObjectsIds[$assocType];
+		}
+		return null;
+	}
+
+	/**
+	 * Get the processed objects errors.
+	 * @param $assocType integer ASSOC_TYPE_...
+	 * @return array
+	 */
+	function getProcessedObjectsErrors($assocType) {
+		if (array_key_exists($assocType, $this->_processedObjectsErrors)) {
+			return $this->_processedObjectsErrors[$assocType];
+		}
+		return null;
+	}
+	/**
+	 * Get the processed objects errors.
+	 * @param $assocType integer ASSOC_TYPE_...
+	 * @return array
+	 */
+
+	function getProcessedObjectsWarnings($assocType) {
+		if (array_key_exists($assocType, $this->_processedObjectsWarnings)) {
+			return $this->_processedObjectsWarnings[$assocType];
 		}
 		return null;
 	}
@@ -169,7 +209,7 @@ class PKPImportExportDeployment {
 				$processedSubmisssionsIds = $this->getProcessedObjectsIds(ASSOC_TYPE_SUBMISSION);
 				if (!empty($processedSubmisssionsIds)) {
 					$submissionDao = Application::getSubmissionDAO();
-					foreach ($processedSubmisssionsIds as $submissionId => $errorMessages) {
+					foreach ($processedSubmisssionsIds as $submissionId) {
 						if ($submissionId) {
 							$submissionDao->deleteById($submissionId);
 						}

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -521,6 +521,7 @@
 	<message key="manager.setup.metadata.submission">Submission Form</message>
 	<!--  common importexport keys -->
 	<message key="plugins.importexport.common.validationErrors">Validation errors:</message>
+	<message key="plugins.importexport.common.warningsEncountered">Warnings encountered:</message>
 	<message key="plugins.importexport.common.errorsOccured">Errors occured:</message>
 	<message key="plugins.importexport.common.error.unknownElement">Unknown element {$param}</message>
 	<message key="plugins.importexport.common.error.unknownGenre">Unknown genre {$param}</message>

--- a/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
@@ -95,7 +95,7 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 				if ($submissionFile) $submissionFiles[] = $submissionFile;
 				break;
 			default:
-				$deployment->addError(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.common.error.unknownElement', array('param' => $node->tagName)));
+				$deployment->addWarning(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.common.error.unknownElement', array('param' => $node->tagName)));
 		}
 	}
 

--- a/plugins/importexport/native/filter/NativeXmlSubmissionFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlSubmissionFilter.inc.php
@@ -171,7 +171,7 @@ class NativeXmlSubmissionFilter extends NativeImportFilter {
 				break;
 			default:
 				$deployment = $this->getDeployment();
-				$deployment->addError(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.common.error.unknownElement', array('param' => $n->tagName)));
+				$deployment->addWarning(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.common.error.unknownElement', array('param' => $n->tagName)));
 		}
 	}
 


### PR DESCRIPTION
Foundation for resolving pkp/pkp-lib#2526; requires changes in each application because the `PKPNativeImportExportDeployment::getProcessedObjectsIds()` return changes.