### PR TITLE
Corrected information and importing unnecessary

### DIFF
--- a/classes/handler/PKPHandler.inc.php
+++ b/classes/handler/PKPHandler.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @file classes/core/PKPHandler.inc.php
+ * @file classes/handler/PKPHandler.inc.php
  *
  * Copyright (c) 2000-2012 John Willinsky
  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
@@ -13,7 +13,6 @@
  *
  */
 
-import('handler.validation.HandlerValidator');
 import('handler.validation.HandlerValidatorCustom');
 
 class PKPHandler {


### PR DESCRIPTION
The annotation 'file' was wrong.
The class 'handler.validation.HandlerValidator' is imported in 'handler.validation.HandlerValidatorCustom', so it's not necessary to import 2 times.