### PR TITLE
pkp/pkp-lib#2500: various Native Import filehandling fixes

### DIFF
--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -526,7 +526,11 @@
 	<message key="plugins.importexport.common.error.unknownElement">Unknown element {$param}</message>
 	<message key="plugins.importexport.common.error.unknownGenre">Unknown genre {$param}</message>
 	<message key="plugins.importexport.common.error.unknownEncoding">Unknown encoding {$param}</message>
+	<message key="plugins.importexport.common.error.encodingError">The content is not encoded as {$param}</message>
 	<message key="plugins.importexport.common.error.unknownUserGroup">Unknown user group {$param}</message>
 	<message key="plugins.importexport.common.error.unknownUploader">Unknown uploader {$param}</message>
 	<message key="plugins.importexport.common.error.temporaryFileFailed">Temporary file {$dest} could not be created from {$source}</message>
+	<message key="plugins.importexport.common.error.filesizeMismatch">The provided filesize "{$expected}" and the actual filesize "{$actual}" do not match</message>
+	<!-- native importexport keys -->
+	<message key="plugins.importexport.native.error.submissionFileImportFailed">The submission file could not be imported</message>
 </locale>


### PR DESCRIPTION
* clear file statcache before checking for success of SubmissionFile import
* allow handleRevisionChildElement to delete a failed temporary file
* warn if actual filesize differs from provided filesize
* error if encoded data is invalid

Addresses a problem with pkp/pkp-lib#2500
