### PR TITLE
pkp/pkp-lib#2592 Clearing template cache clears compiled .css files

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -768,6 +768,7 @@ class PKPTemplateManager extends Smarty {
 	 * Clear template compile and cache directories.
 	 */
 	function clearTemplateCache() {
+		$this->clearCssCache();
 		$this->clear_compiled_tpl();
 		$this->clear_all_cache();
 	}


### PR DESCRIPTION
Hi @NateWr, after adding this line to the clearTemplateCache() method and testing it frequently, I believe it successfully deletes any compiled .css files in the cache folder and reloads the page with the original .css file(s). Is this what you wanted or did I misinterpret your issue description? Thanks