### PR TITLE
pkp/pkp-lib#2500: use FileManager to delete temporary file which was not actually created via TemporaryFileManager

### DIFF
--- a/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlSubmissionFileFilter.inc.php
@@ -332,7 +332,8 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 				}
 				if ($errorFlag) {
 					$deployment->addError(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.common.error.temporaryFileFailed', array('dest' => $temporaryFilename, 'source' => $filesrc)));
-					$temporaryFileManager->deleteFile($temporaryFilename);
+					$fileManager = new FileManager();
+					$fileManager->deleteFile($temporaryFilename);
 					$temporaryFilename = '';
 				}
 				return $temporaryFilename;
@@ -355,7 +356,8 @@ class NativeXmlSubmissionFileFilter extends NativeImportFilter {
 						$errorFlag = true;
 					}
 					if ($errorFlag) {
-						$temporaryFileManager->deleteFile($temporaryFilename);
+						$fileManager = new FileManager();
+						$fileManager->deleteFile($temporaryFilename);
 						$temporaryFilename = '';
 					}
 				}


### PR DESCRIPTION
The `TemporaryFileManager` class does not currently support creating new temporary files on demand, outside of the `handleUpload()` method.

Using `TemporaryFileManager::deleteFile()` on a file not actually indexed as a temporary file will cause a fatal error.

This is just a hotfix, pending better `TemporaryFileManager` functionality.
 