### PR TITLE
pkp/pkp-lib#2064 Fix selector bug - because the "selector" parameter …

### DIFF
--- a/js/classes/TinyMCEHelper.js
+++ b/js/classes/TinyMCEHelper.js
@@ -79,7 +79,7 @@
 	 * @return {jQueryObject} JQuery DOM representing the PKP variable.
 	 */
 	$.pkp.classes.TinyMCEHelper.prototype.getVariableElement =
-			function(selector, variableSymbolic, variableName) {
+			function(variableSymbolic, variableName, selector) {
 		var variableType, variableTypes =
 				$.pkp.classes.TinyMCEHelper.prototype.getVariableTypesMap(selector);
 

--- a/js/controllers/SiteHandler.js
+++ b/js/controllers/SiteHandler.js
@@ -263,7 +263,7 @@
 					/\{\$([a-zA-Z]+)\}(?![^<]*>)/g, function(match, contents, offset, s) {
 						if (variablesParsed[contents] !== undefined) {
 							return $.pkp.classes.TinyMCEHelper.prototype.getVariableElement(
-									'#' + tinyMCEObject.id, contents, variablesParsed[contents])
+									contents, variablesParsed[contents], '#' + tinyMCEObject.id)
 									.html();
 						}
 						return match;


### PR DESCRIPTION
…is not mandatory, should be at the end of the parameter list of getVariableElement function