### PR TITLE
Fix typo in Russian locale

### DIFF
--- a/locale/ru_RU/submission.xml
+++ b/locale/ru_RU/submission.xml
@@ -661,7 +661,7 @@
 
 	<!-- Запросы отправки -->
 	<message key="submission.queries.submission">Обсуждения до рецензирования</message>
-	<mцessage key="submission.queries.review">Обсуждения рецензирования</message>
+	<message key="submission.queries.review">Обсуждения рецензирования</message>
 	<message key="submission.queries.editorial">Обсуждения литературного редактирования</message>
 	<message key="submission.queries.production">Обсуждения публикации</message>
 	<message key="submission.query.subject">Тема</message>


### PR DESCRIPTION
Typo introduced in https://github.com/pkp/pkp-lib/commit/e2b1be8340b065bacd38f7c010e20791a1b6f9fa.