### PR TITLE
pkp/pkp-lib#2612 Prevent overdue filter from including incorrect matc…

### DIFF
--- a/classes/services/queryBuilders/PKPSubmissionListQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionListQueryBuilder.inc.php
@@ -225,8 +225,17 @@ abstract class PKPSubmissionListQueryBuilder extends BaseQueryBuilder {
 			$q->where('rr.status', '!=', REVIEW_ROUND_STATUS_SENT_TO_EXTERNAL);
 			$q->where('rr.status', '!=', REVIEW_ROUND_STATUS_ACCEPTED);
 			$q->where('rr.status', '!=', REVIEW_ROUND_STATUS_DECLINED);
-			$q->where('raod.date_due', '<', \Core::getCurrentDate(strtotime('tomorrow')));
-			$q->where('raod.date_response_due', '<', \Core::getCurrentDate(strtotime('tomorrow')));
+			$q->where(function ($q) {
+				$q->where('raod.declined', '<>', 1);
+				$q->where(function ($q) {
+					$q->where('raod.date_due', '<', \Core::getCurrentDate(strtotime('tomorrow')));
+					$q->whereNull('raod.date_completed');
+				});
+				$q->orWhere(function ($q) {
+					$q->where('raod.date_response_due', '<', \Core::getCurrentDate(strtotime('tomorrow')));
+					$q->whereNull('raod.date_confirmed');
+				});
+			});
 		}
 
 		// assigned to


### PR DESCRIPTION
…hes.

This commit fixes the overdue submission filter checks to prevent
false positives in a couple cases:

- Tests to make sure review has not been declined.
- Tests to make sure review has not been submitted/responded.