### PR TITLE
Fix text for required API key

### DIFF
--- a/locale/de_DE/user.xml
+++ b/locale/de_DE/user.xml
@@ -156,5 +156,5 @@
 	<message key="user.apiKeyEnabled">Externen Anwendungen mittels des API-Keys ermöglichen, auf diesen Account zuzugreifen</message>
 	<message key="user.apiKey.generate">Neuen API-Key erzeugen</message>
 	<message key="user.apiKey.generateWarning">Das Erzeugen eines neuen API-Keys wird alle existierenden Keys für diese/n Nutzer/in ungültig machen.</message>
-	<message key="user.apiKey.secretRequired">Bevor Sie einen API-Key erzeugen, müssen Sie ein Geheimnis (secret) in der Konfigurationsdatei festlegen ("api_key_secret")</message>
+	<message key="user.apiKey.secretRequired">Bevor Sie einen API-Key erzeugen, muss Ihr Website-Administrator/Ihre Website-Administratorin die Einstellung "api_key_secret" in der Konfigurationsdatei festlegen.</message>
 </locale>

--- a/locale/en_US/user.xml
+++ b/locale/en_US/user.xml
@@ -156,5 +156,5 @@
 	<message key="user.apiKeyEnabled">Enable external applications with the API key to access this account</message>
 	<message key="user.apiKey.generate">Generate new API key</message>
 	<message key="user.apiKey.generateWarning">Generating a new API key will invalidate any existing key for this user.</message>
-	<message key="user.apiKey.secretRequired">Before generating an API key, you must set a secret in the config file ("api_key_secret")</message>
+	<message key="user.apiKey.secretRequired">Before generating an API key, your site administrator must set a secret in the config file ("api_key_secret").</message>
 </locale>


### PR DESCRIPTION
Only a system administrator can set api_key_secret in the
configuration file config.inc.php, so "you" is typically wrong.

Fix the English and German texts accordingly.

Add also the missing full stop.

Signed-off-by: Stefan Weil <sw@weilnetz.de>