### PR TITLE
Set  all stages as always active for journal manager level roles and show permission level in the roles grid

### DIFF
--- a/classes/security/RoleDAO.inc.php
+++ b/classes/security/RoleDAO.inc.php
@@ -199,6 +199,10 @@ class RoleDAO extends DAO {
 	 */
 	function getForbiddenStages($roleId = null) {
 		$forbiddenStages = array(
+			ROLE_ID_MANAGER => array(
+				// Journal managers should always have all stage selections locked by default.
+				WORKFLOW_STAGE_ID_SUBMISSION, WORKFLOW_STAGE_ID_INTERNAL_REVIEW, WORKFLOW_STAGE_ID_EXTERNAL_REVIEW, WORKFLOW_STAGE_ID_EDITING, WORKFLOW_STAGE_ID_PRODUCTION,
+			),		
 			ROLE_ID_REVIEWER => array(
 				// Reviewer user groups should only have review stage assignments.
 				WORKFLOW_STAGE_ID_SUBMISSION, WORKFLOW_STAGE_ID_EDITING, WORKFLOW_STAGE_ID_PRODUCTION,
@@ -218,6 +222,15 @@ class RoleDAO extends DAO {
 		} else {
 			return $forbiddenStages;
 		}
+	}
+
+	/**
+	 *  All stages are always active for these permission levels.
+	 * @return array array(ROLE_ID_MANAGER...);
+	 */
+	function getAlwaysActiveStages() {
+		$alwaysActiveStages = array(ROLE_ID_MANAGER);
+		return $alwaysActiveStages;
 	}
 }
 

--- a/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
+++ b/controllers/grid/settings/roles/UserGroupGridCellProvider.inc.php
@@ -35,8 +35,8 @@ class UserGroupGridCellProvider extends GridCellProvider {
 		switch ($columnId) {
 			case 'name':
 				return array('label' => $userGroup->getLocalizedName());
-			case 'abbrev':
-				return array('label' => $userGroup->getLocalizedAbbrev());
+			case 'roleId':
+				return array('label' => __(array_shift(Application::getRoleNames(false, array($userGroup->getRoleId())))));
 			case in_array($columnId, $workflowStages):
 				// Set the state of the select element that will
 				// be used to assign the stage to the user group.
@@ -45,7 +45,6 @@ class UserGroupGridCellProvider extends GridCellProvider {
 					// This stage should not be assigned to the user group.
 					$selectDisabled = true;
 				}
-				if ($userGroup->getRoleId() == ROLE_ID_MANAGER) $selectDisabled = true;
 
 				return array('selected' => in_array($columnId, array_keys($assignedStages)),
 					'disabled' => $selectDisabled);

--- a/controllers/grid/settings/roles/UserGroupGridHandler.inc.php
+++ b/controllers/grid/settings/roles/UserGroupGridHandler.inc.php
@@ -129,7 +129,7 @@ class UserGroupGridHandler extends GridHandler {
 		// Set array containing the columns info with the same cell provider.
 		$columnsInfo = array(
 			1 => array('id' => 'name', 'title' => 'settings.roles.roleName', 'template' => null),
-			2 => array('id' => 'abbrev', 'title' => 'settings.roles.roleAbbrev', 'template' => null)
+			2 => array('id' => 'roleId', 'title' => 'settings.roles.from', 'template' => null)
 		);
 
 		foreach ($workflowStagesLocales as $stageId => $stageTitleKey) {

--- a/controllers/grid/settings/roles/form/UserGroupForm.inc.php
+++ b/controllers/grid/settings/roles/form/UserGroupForm.inc.php
@@ -152,12 +152,13 @@ class UserGroupForm extends Form {
 		return array(ROLE_ID_MANAGER, ROLE_ID_SUB_EDITOR);
 	}
 
-/**
+	/**
 	 * @copydoc Form::execute()
 	 */
 	function execute($request) {
 		$userGroupId = $this->getUserGroupId();
 		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
+		$roleDao = DAORegistry::getDAO('RoleDAO');
 
 		// Check if we are editing an existing user group or creating another one.
 		if ($userGroupId == null) {
@@ -180,8 +181,11 @@ class UserGroupForm extends Form {
 		}
 
 		// After we have created/edited the user group, we assign/update its stages.
-		if ($this->getData('assignedStages')) {
-			$this->_assignStagesToUserGroup($userGroupId, $this->getData('assignedStages'));
+		$assignedStages = $this->getData('assignedStages');
+		// Always set all stages active for some permission levels.
+		if (in_array($userGroup->getRoleId(), $roleDao->getAlwaysActiveStages())) $assignedStages = array_keys(WorkflowStageDAO::getWorkflowStageTranslationKeys());
+		if ($assignedStages) {
+			$this->_assignStagesToUserGroup($userGroupId, $assignedStages);
 		}
 	}
 
@@ -208,11 +212,11 @@ class UserGroupForm extends Form {
 		foreach ($userAssignedStages as $stageId) {
 
 			// Make sure we don't assign forbidden stages based on
-			// user groups role id.
+			// user groups role id. Override in case of some permission levels.
 			$roleId = $this->getData('roleId');
 			$roleDao = DAORegistry::getDAO('RoleDAO'); /* @var $roleDao RoleDAO */
 			$forbiddenStages = $roleDao->getForbiddenStages($roleId);
-			if (in_array($stageId, $forbiddenStages)) {
+			if (in_array($stageId, $forbiddenStages) && !in_array($roleId, $roleDao->getAlwaysActiveStages())) {
 				continue;
 			}
 


### PR DESCRIPTION
@asmecher Fix for https://github.com/pkp/pkp-lib/issues/2849 for OJS3.1.0

Not sure if the getAlwaysActiveStages solution is ok for you. 

Note that I removed the abbreviation from the listing to save some space. I think that the permission level is far more important to see from the listing than the abbreviation. If abbrev is needed, then it is of course easy to add back
