### PR TITLE
pkp/pkp-lib#3049: Backport pkp_page and pkp_op body classes from 3.x to 2.x template header

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -100,6 +100,8 @@ class PKPTemplateManager extends Smarty {
 		$this->assign('defaultCharset', Config::getVar('i18n', 'client_charset'));
 		$this->assign('basePath', $this->request->getBasePath());
 		$this->assign('baseUrl', $this->request->getBaseUrl());
+		$this->assign('requestedPage', $this->request->getRequestedPage());
+		$this->assign('requestedOp', $this->request->getRequestedOp());
 		$this->assign('requiresFormRequest', $this->request->isPost());
 		if (is_a($router, 'PKPPageRouter')) $this->assign('requestedPage', $router->getRequestedPage($this->request));
 		$this->assign('currentUrl', $this->request->getCompleteUrl());

--- a/templates/common/header.tpl
+++ b/templates/common/header.tpl
@@ -120,7 +120,7 @@
 
 	{$additionalHeadData}
 </head>
-<body id="pkp-{$pageTitle|replace:'.':'-'}">
+<body id="pkp-{$pageTitle|replace:'.':'-'}" class="pkp_page_{$requestedPage|escape|default:"index"} pkp_op_{$requestedOp|escape|default:"index"}">
 <div id="container">
 
 <div id="header">


### PR DESCRIPTION
Resolves pkp/pkp-lib#3049 for shared library.