### PR TITLE
bug fix: emailTemplates from plugins are not getting installed when u…

### DIFF
--- a/classes/plugins/PluginHelper.inc.php
+++ b/classes/plugins/PluginHelper.inc.php
@@ -122,6 +122,7 @@ class PluginHelper {
 			if(!is_file($installFile)) $installFile = Core::getBaseDir() . '/' . PKP_LIB_PATH . '/xml/defaultPluginInstall.xml';
 			assert(is_file($installFile));
 			$params = $this->_getConnectionParams();
+			$params['locale'] = LOCALE_DEFAULT;
 			$installer = new Install($params, $installFile, true);
 			$installer->setCurrentVersion($pluginVersion);
 			if (!$installer->execute()) {

--- a/classes/plugins/PluginHelper.inc.php
+++ b/classes/plugins/PluginHelper.inc.php
@@ -121,11 +121,11 @@ class PluginHelper {
 			$installFile = $pluginDest . '/' . PLUGIN_INSTALL_FILE;
 			if(!is_file($installFile)) $installFile = Core::getBaseDir() . '/' . PKP_LIB_PATH . '/xml/defaultPluginInstall.xml';
 			assert(is_file($installFile));
-                        $request = Application::getRequest();
-                        $site = $request->getSite();
-                        $params = $this->_getConnectionParams();
+			$siteDao = DAORegistry::getDAO('SiteDAO');
+			$site = $siteDao->getSite();
+			$params = $this->_getConnectionParams();
 			$params['locale'] = $site->getPrimaryLocale();
-                        $params['additionalLocales'] = $site->getSupportedLocales();
+			$params['additionalLocales'] = $site->getSupportedLocales();
 			$installer = new Install($params, $installFile, true);
 			$installer->setCurrentVersion($pluginVersion);
 			if (!$installer->execute()) {
@@ -244,11 +244,11 @@ class PluginHelper {
 
 			$upgradeFile = $pluginDest . '/' . PLUGIN_UPGRADE_FILE;
 			if($fileManager->fileExists($upgradeFile)) {
-                                $request = Application::getRequest();
-                                $site = $request->getSite();
+				$siteDao = DAORegistry::getDAO('SiteDAO');
+				$site = $siteDao->getSite();
 				$params = $this->_getConnectionParams();
-                                $params['locale'] = $site->getPrimaryLocale();
-                                $params['additionalLocales'] = $site->getSupportedLocales();
+				$params['locale'] = $site->getPrimaryLocale();
+				$params['additionalLocales'] = $site->getSupportedLocales();
 				$installer = new Upgrade($params, $upgradeFile, true);
 
 				if (!$installer->execute()) {

--- a/classes/plugins/PluginHelper.inc.php
+++ b/classes/plugins/PluginHelper.inc.php
@@ -121,8 +121,11 @@ class PluginHelper {
 			$installFile = $pluginDest . '/' . PLUGIN_INSTALL_FILE;
 			if(!is_file($installFile)) $installFile = Core::getBaseDir() . '/' . PKP_LIB_PATH . '/xml/defaultPluginInstall.xml';
 			assert(is_file($installFile));
-			$params = $this->_getConnectionParams();
-			$params['locale'] = LOCALE_DEFAULT;
+                        $request = Application::getRequest();
+                        $site = $request->getSite();
+                        $params = $this->_getConnectionParams();
+			$params['locale'] = $site->getPrimaryLocale();
+                        $params['additionalLocales'] = $site->getSupportedLocales();
 			$installer = new Install($params, $installFile, true);
 			$installer->setCurrentVersion($pluginVersion);
 			if (!$installer->execute()) {
@@ -241,7 +244,11 @@ class PluginHelper {
 
 			$upgradeFile = $pluginDest . '/' . PLUGIN_UPGRADE_FILE;
 			if($fileManager->fileExists($upgradeFile)) {
+                                $request = Application::getRequest();
+                                $site = $request->getSite();
 				$params = $this->_getConnectionParams();
+                                $params['locale'] = $site->getPrimaryLocale();
+                                $params['additionalLocales'] = $site->getSupportedLocales();
 				$installer = new Upgrade($params, $upgradeFile, true);
 
 				if (!$installer->execute()) {


### PR DESCRIPTION
…sing the webinterface of OJS 3.1 to install a plugin and only the default language is in installed.

Hi, 

there seems to be a small bug in pkp-lib:`/classes/plugins/PluginHelper.inc.php`.
The `$params` array seems to be missing the default/current locale.
This causes `Plugin->installEmailTemplateData()` to iterate over an empty array `$installer->installedLocales`, which results in no emailTemplate of the plugin getting installed.

Tested with OJS 3.1.0, PHP 5.6 and only one language in OJS installed (`en_US`), using the webinterface  
`Settings->Website->Plugins->Installed Plugins->Upload A New Plugin`