### PR TITLE
pkp/pkp-lib#3188 Fix unexpected title on message for a declined submission

### DIFF
--- a/controllers/modals/editorDecision/form/SendReviewsForm.inc.php
+++ b/controllers/modals/editorDecision/form/SendReviewsForm.inc.php
@@ -123,7 +123,7 @@ class SendReviewsForm extends EditorDecisionWithEmailForm {
 				break;
 
 			case SUBMISSION_EDITOR_DECISION_DECLINE:
-				$emailKey = 'SUBMISSION_UNSUITABLE';
+				$emailKey = 'EDITOR_DECISION_DECLINE';
 				$status = REVIEW_ROUND_STATUS_DECLINED;
 				break;
 


### PR DESCRIPTION
The subject of the message an author receives for a declined submission ('Unsuitable submission') was not the subject of the template used in the 'Decline Submission' dialog ('Editor Decision') due to the use of different templates during message preparation (`EDITOR_DECISION_DECLINE`) and form execution (`SUBMISSION_UNSUITABLE`).