### PR TITLE
when disable_path_info is On, modify _SERVER['REQUEST_URI'] to match Slim expectations 

### DIFF
--- a/classes/handler/APIHandler.inc.php
+++ b/classes/handler/APIHandler.inc.php
@@ -57,8 +57,6 @@ class APIHandler extends PKPHandler {
 			'settings' => array(
 				// we need access to route within middleware
 				'determineRouteBeforeAppMiddleware' => true,
-				'displayErrorDetails' => true,
-				'error' => true,
 			)
 		));
 		$this->_app->add(new ApiAuthorizationMiddleware($this));


### PR DESCRIPTION
@asmecher 

This code is modifying `$_SERVER['REQUEST_URI']` before Slim object is created as opposed to previously where I was attempting to proceed from the middleware. 

Moreover I have removed the middleware used initially to intercept the request since Slim `Request` object is already initialized by the time middlewares are executed. Also POST requests no longer need special treatment because the REST API only has GET endpoints at this stage. 