### PR TITLE
Adding help link to the Archiving settings tabs

### DIFF
--- a/templates/controllers/tab/settings/archiving/form/archivingForm.tpl
+++ b/templates/controllers/tab/settings/archiving/form/archivingForm.tpl
@@ -9,6 +9,9 @@
  *
  *}
 
+{* Help Link *}
+{help file="settings.md" section="website" class="pkp_help_tab"}
+
 <script type="text/javascript">
 	$(function() {ldelim}
 		// Attach the form handler.


### PR DESCRIPTION
Added the help link to the tab so that the Archiving tab matches the other Website Settings tabs.