### PR TITLE
Prevent ErrorMsg to spread to other text inputs

### DIFF
--- a/classes/form/FormBuilderVocabulary.inc.php
+++ b/classes/form/FormBuilderVocabulary.inc.php
@@ -382,7 +382,7 @@ class FormBuilderVocabulary {
 		$smarty->assign('FBV_isTypeURL', ($params['type'] === 'url') ? true : false);
 
 		$textInputParams = '';
-		$smarty->clear_assign(array('FBV_disabled', 'FBV_readonly', 'FBV_multilingual', 'FBV_name', 'FBV_value', 'FBV_label_content', 'FBV_uniqId'));
+		$smarty->clear_assign(array('FBV_disabled', 'FBV_readonly', 'FBV_multilingual', 'FBV_name', 'FBV_value', 'FBV_label_content', 'FBV_uniqId', 'FBV_urlValidationErrorMessage'));
 		foreach ($params as $key => $value) {
 			switch ($key) {
 				case 'label': $smarty->assign('FBV_label_content', $this->_smartyFBVSubLabel($params, $smarty)); break;


### PR DESCRIPTION
The `FBV_urlValidationErrorMessage` has to be cleared from the templateManager. Otherwise every following text input (without urlValidationErrorMsg) get's this error message applied.