### PR TITLE
Making disabled themes not visible in the appearance menu

### DIFF
--- a/controllers/tab/settings/appearance/form/PKPAppearanceForm.inc.php
+++ b/controllers/tab/settings/appearance/form/PKPAppearanceForm.inc.php
@@ -107,7 +107,9 @@ class PKPAppearanceForm extends ContextSettingsForm {
 		$enabledThemes = array();
 		$activeThemeOptions = array();
 		foreach ($themePlugins as $themePlugin) {
-			$enabledThemes[basename($themePlugin->getPluginPath())] = $themePlugin->getDisplayName();
+			if ($themePlugin->getEnabled()) {
+  				$enabledThemes[basename($themePlugin->getPluginPath())] = $themePlugin->getDisplayName();
+			}
 			if ($themePlugin->isActive()) {
 				$activeThemeOptions = $themePlugin->getOptionsConfig();
 				$activeThemeOptionsValues = $themePlugin->getOptionValues();


### PR DESCRIPTION
Writing only enabled themes into the array #3476