### PR TITLE
If author role is missing when doing a submission, let user enroll

### DIFF
--- a/classes/submission/form/PKPSubmissionSubmitStep1Form.inc.php
+++ b/classes/submission/form/PKPSubmissionSubmitStep1Form.inc.php
@@ -259,7 +259,6 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 	 */
 	function execute($args, $request) {
 		$submissionDao = Application::getSubmissionDAO();
-		$context = $request->getContext();
 		$user = $request->getUser();
 		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
 

--- a/classes/submission/form/PKPSubmissionSubmitStep1Form.inc.php
+++ b/classes/submission/form/PKPSubmissionSubmitStep1Form.inc.php
@@ -102,6 +102,7 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 		// Set default group to default author group
 		$defaultGroup = $userGroupDao->getDefaultByRoleId($this->context->getId(), ROLE_ID_AUTHOR);
 		$noExistingRoles = false;
+		$managerGroups = false;
 
 		// If the user has manager roles, add manager roles and available author roles to selection
 		if (!$managerUserGroupAssignments->wasEmpty()) {
@@ -109,6 +110,7 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 				$managerUserGroup = $userGroupDao->getById($managerUserGroupAssignment->getUserGroupId());
 				$userGroupNames[$managerUserGroup->getId()] = $managerUserGroup->getLocalizedName();
 			}
+			$managerGroups = join(__('common.listSeparator'), $userGroupNames);
 			$userGroupNames = array_replace($userGroupNames, $availableUserGroupNames); 
 
 			// Set default group to default manager group
@@ -127,6 +129,7 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 			$noExistingRoles = true;
 		}
 
+		$templateMgr->assign('managerGroups', $managerGroups);
 		$templateMgr->assign('userGroupOptions', $userGroupNames);
 		$templateMgr->assign('defaultGroup', $defaultGroup);
 		$templateMgr->assign('noExistingRoles', $noExistingRoles);

--- a/locale/en_US/submission.xml
+++ b/locale/en_US/submission.xml
@@ -18,6 +18,7 @@
 	<message key="submission.confirm.message">Your submission has been uploaded and is ready to be sent. You may go back to review and adjust any of the information you have entered before continuing. When you are ready, click "Finish Submission".</message>
 	<message key="submission.submit.availableUserGroups">Select a role</message>
 	<message key="submission.submit.availableUserGroupsDescription">Your account does not currently have a role permitting new submissions, such as Author. Please select the role you wish to be enrolled as.</message>
+	<message key="submission.submit.userGroupDescriptionManagers">Submit in any of the following roles if you would like to publish this submission yourself without assistance from another editor: {$managerGroups}</message>
 	<message key="submission.submit.submissionChecklist">Submission Requirements</message>
 	<message key="submission.submit.submissionChecklistDescription">You must read and acknowledge that you've completed the requirements below before proceeding.</message>
 	<message key="submission.submit.submissionComplete">Submission complete</message>

--- a/locale/en_US/submission.xml
+++ b/locale/en_US/submission.xml
@@ -13,10 +13,11 @@
 
 <locale name="en_US" full_name="U.S. English">
 	<!-- Author Submission -->
-	<message key="author.submit.userGroupRequired">Your account does not currently have a role permitting new submissions, such as Author. Please double-check your account; you may be able to add a suitable role yourself by editing your profile.</message>
 	<message key="author.submit.submissionCitations">Provide a formatted list of references for works cited in this submission. Please separate individual references with a blank line.</message>
 	<message key="author.submission.roundStatus.reviewsReady">New reviews have been submitted and are being considered by the editor.</message>
 	<message key="submission.confirm.message">Your submission has been uploaded and is ready to be sent. You may go back to review and adjust any of the information you have entered before continuing. When you are ready, click "Finish Submission".</message>
+	<message key="submission.submit.availableUserGroups">Select a role</message>
+	<message key="submission.submit.availableUserGroupsDescription">Your account does not currently have a role permitting new submissions, such as Author. Please select the role you wish to be enrolled as.</message>
 	<message key="submission.submit.submissionChecklist">Submission Requirements</message>
 	<message key="submission.submit.submissionChecklistDescription">You must read and acknowledge that you've completed the requirements below before proceeding.</message>
 	<message key="submission.submit.submissionComplete">Submission complete</message>

--- a/pages/submission/PKPSubmissionHandler.inc.php
+++ b/pages/submission/PKPSubmissionHandler.inc.php
@@ -32,9 +32,9 @@ abstract class PKPSubmissionHandler extends Handler {
 
 		// Are we in step one without a submission present?
 		if ($step === 1 && $submissionId === 0) {
-			// Authorize submission creation.
-			import('lib.pkp.classes.security.authorization.ContextAccessPolicy');
-			$this->addPolicy(new ContextAccessPolicy($request, $roleAssignments));
+			// Authorize submission creation. Author role not required.
+			import('lib.pkp.classes.security.authorization.UserRequiredPolicy');
+			$this->addPolicy(new UserRequiredPolicy($request));
 		} else {
 			// Authorize editing of incomplete submissions.
 			import('lib.pkp.classes.security.authorization.SubmissionAccessPolicy');

--- a/templates/submission/form/step1.tpl
+++ b/templates/submission/form/step1.tpl
@@ -33,7 +33,12 @@
 	<!-- If user has existing roles, show available roles or automatically select single role -->	
 	{else}
 		{if count($userGroupOptions) > 1}
-			{fbvFormSection label="submission.submit.userGroup" description="submission.submit.userGroupDescription" list=true required=true}
+				{fbvFormSection label="submission.submit.availableUserGroups" list=true required=true}
+				{if $managerGroups}
+					{translate key='submission.submit.userGroupDescriptionManagers' managerGroups=$managerGroups}
+				{else}
+					{translate key='submission.submit.userGroupDescription'}
+				{/if}
 				{foreach from=$userGroupOptions key="userGroupId" item="userGroupName"}
 					{if $defaultGroup->getId() == $userGroupId}{assign var="checked" value=true}{else}{assign var="checked" value=false}{/if}
 					{fbvElement type="radio" id="userGroup"|concat:$userGroupId name="userGroupId" value=$userGroupId checked=$checked label=$userGroupName translate=false}

--- a/templates/submission/form/step1.tpl
+++ b/templates/submission/form/step1.tpl
@@ -22,14 +22,27 @@
 {include file="controllers/notification/inPlaceNotification.tpl" notificationId="submitStep1FormNotification"}
 
 {fbvFormArea id="submissionStep1"}
-	<!-- Author user group selection (only appears if user has > 1 author user groups) -->
-	{if count($authorUserGroupOptions) > 1}
-		{fbvFormSection label="submission.submit.userGroup" description="submission.submit.userGroupDescription"}
-			{fbvElement type="select" id="authorUserGroupId" from=$authorUserGroupOptions translate=false size=$fbvStyles.size.SMALL}
+	<!-- If no existing roles, show available author roles to choose from -->
+	{if $noExistingRoles}
+		{fbvFormSection label="submission.submit.availableUserGroups" description="submission.submit.availableUserGroupsDescription" list=true required=true}
+			{foreach from=$userGroupOptions key="userGroupId" item="userGroupName"}
+				{if $defaultGroup->getId() == $userGroupId}{assign var="checked" value=true}{else}{assign var="checked" value=false}{/if}
+				{fbvElement type="radio" id="userGroup"|concat:$userGroupId name="userGroupId" value=$userGroupId checked=$checked label=$userGroupName translate=false}
+			{/foreach}
 		{/fbvFormSection}
-	{elseif count($authorUserGroupOptions) == 1}
-		{foreach from=$authorUserGroupOptions key="key" item="authorUserGroupName"}{assign var=authorUserGroupId value=$key}{/foreach}
-		{fbvElement type="hidden" id="authorUserGroupId" value=$authorUserGroupId}
+	<!-- If user has existing roles, show available roles or automatically select single role -->	
+	{else}
+		{if count($userGroupOptions) > 1}
+			{fbvFormSection label="submission.submit.userGroup" description="submission.submit.userGroupDescription" list=true required=true}
+				{foreach from=$userGroupOptions key="userGroupId" item="userGroupName"}
+					{if $defaultGroup->getId() == $userGroupId}{assign var="checked" value=true}{else}{assign var="checked" value=false}{/if}
+					{fbvElement type="radio" id="userGroup"|concat:$userGroupId name="userGroupId" value=$userGroupId checked=$checked label=$userGroupName translate=false}
+				{/foreach}
+			{/fbvFormSection}
+		{elseif count($userGroupOptions) == 1}
+			{foreach from=$userGroupOptions key="userGroupId" item="authorUserGroupName"}{assign var=userGroupId value=$userGroupId}{/foreach}
+			{fbvElement type="hidden" id="userGroupId" value=$userGroupId}
+		{/if}
 	{/if}
 
 	{if $copyrightNoticeAgree}

--- a/templates/submission/form/step1.tpl
+++ b/templates/submission/form/step1.tpl
@@ -33,7 +33,7 @@
 	<!-- If user has existing roles, show available roles or automatically select single role -->	
 	{else}
 		{if count($userGroupOptions) > 1}
-				{fbvFormSection label="submission.submit.availableUserGroups" list=true required=true}
+			{fbvFormSection label="submission.submit.availableUserGroups" list=true required=true}
 				{if $managerGroups}
 					{translate key='submission.submit.userGroupDescriptionManagers' managerGroups=$managerGroups}
 				{else}

--- a/templates/submission/form/step1.tpl
+++ b/templates/submission/form/step1.tpl
@@ -30,10 +30,6 @@
 	{elseif count($authorUserGroupOptions) == 1}
 		{foreach from=$authorUserGroupOptions key="key" item="authorUserGroupName"}{assign var=authorUserGroupId value=$key}{/foreach}
 		{fbvElement type="hidden" id="authorUserGroupId" value=$authorUserGroupId}
-	{else}
-		<div class="pkp_notification">
-			{include file="controllers/notification/inPlaceNotificationContent.tpl" notificationId=submit notificationStyleClass=notifyError notificationTitle="common.warning"|translate notificationContents="author.submit.userGroupRequired"|translate}
-		</div>
 	{/if}
 
 	{if $copyrightNoticeAgree}


### PR DESCRIPTION
Fix for https://github.com/pkp/pkp-lib/issues/2297

- Relax the context access policy when doing a submission

The pr will support the following scenarios:
- Case 1: users without any roles: show selection of available author roles to choose from. Tell the user she has to enroll.
- Case 2: user with existing author role: if one existing author role, add hidden variable for the userGroupId, if several existing author roles add a selection to choose from.
- Case 3: manager users with existing author roles: show selection of both existing manager roles and available author roles and let the editor choose.
- Case 4: manager users without existing author roles: show selection of both existing manager roles and available author roles and let editor choose. If she chooses an author role, enroll the manager also as an author.

In all above cases use $userGroupDao->getDefaultByRoleId to pre-select an option.

This would solve the situations where editors want to submit to their own journal and receive a peer-review for their paper. In these situations they of course choose an author role. In other cases, like when sending in editorials etc. they can choose a managerial role.



