### PR TITLE
Move submission status check outside if clause

### DIFF
--- a/classes/task/ReviewReminder.inc.php
+++ b/classes/task/ReviewReminder.inc.php
@@ -144,9 +144,9 @@ class ReviewReminder extends ScheduledTask {
 				// Avoid review assignments without submission in database.
 				if (!$submission) continue;
 
-				if ($submission->getStatus() != STATUS_QUEUED) continue;
-
 			}
+
+			if ($submission->getStatus() != STATUS_QUEUED) continue;
 
 			// Fetch the context
 			if ($context == null || $context->getId() != $submission->getContextId()) {


### PR DESCRIPTION
@bozana @asmecher 

See https://forum.pkp.sfu.ca/t/automated-reminders-being-sent-for-archived-articles/39998/12 for details. Would be good to have in 3.1.1. because this seems to be a clear bug with an easy fix...