### PR TITLE
Move new reviews are in notification code outside default form else clause

### DIFF
--- a/classes/submission/reviewer/form/ReviewerReviewStep3Form.inc.php
+++ b/classes/submission/reviewer/form/ReviewerReviewStep3Form.inc.php
@@ -191,30 +191,32 @@ class ReviewerReviewStep3Form extends ReviewerReviewForm {
 			}
 			unset($comment);
 
-			$submissionDao = Application::getSubmissionDAO();
-			$submission = $submissionDao->getById($reviewAssignment->getSubmissionId());
+		}
 
-			$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO');
-			$stageAssignments = $stageAssignmentDao->getBySubmissionAndStageId($submission->getId(), $submission->getStageId());
-			$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
-			$router = $request->getRouter();
-			$context = $router->getContext($request);
-			$receivedList = array(); // Avoid sending twice to the same user.
+		// Send notification
+		$submissionDao = Application::getSubmissionDAO();
+		$submission = $submissionDao->getById($reviewAssignment->getSubmissionId());
 
-			while ($stageAssignment = $stageAssignments->next()) {
-				$userId = $stageAssignment->getUserId();
-				$userGroup = $userGroupDao->getById($stageAssignment->getUserGroupId(), $submission->getContextId());
+		$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO');
+		$stageAssignments = $stageAssignmentDao->getBySubmissionAndStageId($submission->getId(), $submission->getStageId());
+		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
+		$router = $request->getRouter();
+		$context = $router->getContext($request);
+		$receivedList = array(); // Avoid sending twice to the same user.
 
-				// Never send reviewer comment notification to users other than mangers and editors.
-				if (!in_array($userGroup->getRoleId(), array(ROLE_ID_MANAGER, ROLE_ID_SUB_EDITOR)) || in_array($userId, $receivedList)) continue;
+		while ($stageAssignment = $stageAssignments->next()) {
+			$userId = $stageAssignment->getUserId();
+			$userGroup = $userGroupDao->getById($stageAssignment->getUserGroupId(), $submission->getContextId());
 
-				$notificationMgr->createNotification(
-					$request, $userId, NOTIFICATION_TYPE_REVIEWER_COMMENT,
-					$submission->getContextId(), ASSOC_TYPE_REVIEW_ASSIGNMENT, $reviewAssignment->getId()
-				);
+			// Never send reviewer comment notification to users other than mangers and editors.
+			if (!in_array($userGroup->getRoleId(), array(ROLE_ID_MANAGER, ROLE_ID_SUB_EDITOR)) || in_array($userId, $receivedList)) continue;
 
-				$receivedList[] = $userId;
-			}
+			$notificationMgr->createNotification(
+				$request, $userId, NOTIFICATION_TYPE_REVIEWER_COMMENT,
+				$submission->getContextId(), ASSOC_TYPE_REVIEW_ASSIGNMENT, $reviewAssignment->getId()
+			);
+
+			$receivedList[] = $userId;
 		}
 
 		// Set review to next step.


### PR DESCRIPTION
At the moment the notification code for new reviews only works for journals that use the default form, because the code is inside the else clause here: https://github.com/pkp/pkp-lib/blob/ojs-3_1_0-1/classes/submission/reviewer/form/ReviewerReviewStep3Form.inc.php#L199-L212

This change moves the code outside the else clause so that the journals using the custom forms also get these notifications.

see https://github.com/pkp/pkp-lib/issues/3423#issuecomment-378945708
