### PR TITLE
Fix editorial note action display

### DIFF
--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -68,8 +68,8 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 		assert(is_a($element, 'DataObject') && !empty($columnId));
 		switch ($columnId) {
 			case 'name':
-				$isAuthorBlind = in_array($element->getReviewMethod(), array(SUBMISSION_REVIEW_METHOD_BLIND, SUBMISSION_REVIEW_METHOD_DOUBLEBLIND));
-				if ($this->_isCurrentUserAssignedAuthor && $isAuthorBlind) {
+				$isReviewBlind = in_array($element->getReviewMethod(), array(SUBMISSION_REVIEW_METHOD_BLIND, SUBMISSION_REVIEW_METHOD_DOUBLEBLIND));
+				if ($this->_isCurrentUserAssignedAuthor && $isReviewBlind) {
 					return array('label' => __('editor.review.anonymousReviewer'));
 				}
 				return array('label' => $element->getReviewerFullName());

--- a/controllers/grid/users/reviewer/ReviewerGridRow.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridRow.inc.php
@@ -49,8 +49,8 @@ class ReviewerGridRow extends GridRow {
 
 		// Authors can't perform any actions on blind reviews
 		$reviewAssignment = $this->getData();
-		$isAuthorBlind = in_array($reviewAssignment->getReviewMethod(), array(SUBMISSION_REVIEW_METHOD_BLIND, SUBMISSION_REVIEW_METHOD_DOUBLEBLIND));
-		if ($this->_isCurrentUserAssignedAuthor && $isAuthorBlind) {
+		$isReviewBlind = in_array($reviewAssignment->getReviewMethod(), array(SUBMISSION_REVIEW_METHOD_BLIND, SUBMISSION_REVIEW_METHOD_DOUBLEBLIND));
+		if ($this->_isCurrentUserAssignedAuthor && $isReviewBlind) {
 			return;
 		}
 
@@ -145,7 +145,7 @@ class ReviewerGridRow extends GridRow {
 			$canCurrentUserGossip = ServicesContainer::instance()
 				->get('user')
 				->canCurrentUserGossip($reviewAssignment->getReviewerId());
-			if ($canCurrentUserGossip && !$isAuthorBlind) {
+			if ($canCurrentUserGossip) {
 				$this->addAction(
 					new LinkAction(
 						'gossip',

--- a/locale/en_US/user.xml
+++ b/locale/en_US/user.xml
@@ -1,4 +1,4 @@
-x<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE locale SYSTEM "../../dtd/locale.dtd">
 
 <!--

--- a/locale/en_US/user.xml
+++ b/locale/en_US/user.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+x<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE locale SYSTEM "../../dtd/locale.dtd">
 
 <!--
@@ -41,7 +41,7 @@
 	<message key="user.interests">Reviewing interests</message>
 	<message key="user.interests.description">(Separate interests by pressing the enter or comma key)</message>
 	<message key="user.gossip">Editorial Notes</message>
-	<message key="user.gossip.description">Notes entered here will only be visible to administrators, journal managers, editors, and subeditors.</message>
+	<message key="user.gossip.description">Record notes about this reviewer that you would like to make visible to other administrators, journal managers, editors, and subeditors. Notes will be visible for future review assignments.</message>
 	<message key="user.group">User Group</message>
 	<message key="user.lastName">Last Name</message>
 	<message key="user.profile.form.profileImageInvalid">Invalid profile image format or image too big. Accepted formats are .gif, .jpg, or .png, and the image must not exceed 150x150 pixels.</message>

--- a/locale/fi_FI/user.xml
+++ b/locale/fi_FI/user.xml
@@ -153,6 +153,6 @@
 	<message key="user.apiKey">API-avain</message>
 	<message key="user.apiKeyEnabled">Anna ulkoisten järjestelmien olla yhteydessä tähän tiliin API-avaimen avulla.</message>
 	<message key="user.apiKey.generate">Luo uusi API-avain</message>
-	<message key="user.gossip.description">Tähän annetut muistiinpanot näkyvät vain ylläpitäjille, julkaisun hallinnoijille, toimittajille ja osastotoimittajille.</message>
+	<message key="user.gossip.description">Tallenna arvioijaa koskevia muistiinpanoja, jotka haluat antaa muiden toimittajien, osastontoimittajien ja julkaisun hallinnoijien tiedoksi. Merkinnät näkyvät myös arvioijan tulevien arviointipyyntöjen yhteydessä.</message>
 	<message key="user.role.assistant">Avustaja</message>
 </locale>


### PR DESCRIPTION
Hi @NateWr 

This is the pr for https://github.com/pkp/pkp-lib/issues/3130#issuecomment-379749944

Note that I removed the whole check from row 148 because I realized that already on row 54 **all** the actions get hidden if the user is editor/author && the review is blind. So no need to control that again only for editorial notes action, right?
