### PR TITLE
pkp/pkp-lib#3525 Give the possibility to choose language of template …

### DIFF
--- a/classes/controllers/grid/users/reviewer/PKPReviewerGridHandler.inc.php
+++ b/classes/controllers/grid/users/reviewer/PKPReviewerGridHandler.inc.php
@@ -651,46 +651,42 @@ class PKPReviewerGridHandler extends GridHandler {
 	 * @param $request PKPRequest
 	 * @return JSONMessage JSON object
 	 */
-	/**
-	 * @copydoc PKPReviewerGridHandler::fetchTemplateBody()
-	 */
 	function fetchTemplateBody($args, $request) {
-			$templateLocale = $request->getUserVar('templateLocale');
-			$templateId = $request->getUserVar('template_'.$templateLocale);
-			if (strlen($templateLocale) < 2 ) { 
-				$templateLocale = NULL;
-				}
-			import('lib.pkp.classes.mail.SubmissionMailTemplate');
-			$template = new SubmissionMailTemplate($this->getSubmission(), $templateId, $templateLocale);
-			if ($template) {
-				$user = $request->getUser();
-				$dispatcher = $request->getDispatcher();
-				$context = $request->getContext();
-				$template->assignParams(array(
-					'contextUrl' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath()),
-					'editorialContactSignature' => $user->getContactSignature(),
-					'signatureFullName' => $user->getFullname(),
-					'passwordResetUrl' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath(), 'login', 'lostPassword'),
-					'messageToReviewer' => __('reviewer.step1.requestBoilerplate'),
-					'abstractTermIfEnabled' => ($this->getSubmission()->getLocalizedAbstract() == '' ? '' : __('common.abstract')), // Deprecated; for OJS 2.x templates
+		$templateLocale = $request->getUserVar('templateLocale');
+		$templateId = $request->getUserVar('template_' . $templateLocale);
+		if (strlen($templateLocale) < 2) {
+			$templateLocale = NULL;
+		}
+		import('lib.pkp.classes.mail.SubmissionMailTemplate');
+		$template = new SubmissionMailTemplate($this->getSubmission(), $templateId, $templateLocale);
+		if ($template) {
+			$user = $request->getUser();
+			$dispatcher = $request->getDispatcher();
+			$context = $request->getContext();
+			$template->assignParams(array(
+				'contextUrl' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath()),
+				'editorialContactSignature' => $user->getContactSignature(),
+				'signatureFullName' => $user->getFullname(),
+				'passwordResetUrl' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath(), 'login', 'lostPassword'),
+				'messageToReviewer' => __('reviewer.step1.requestBoilerplate'),
+				'abstractTermIfEnabled' => ($this->getSubmission()->getLocalizedAbstract() == '' ? '' : __('common.abstract')), // Deprecated; for OJS 2.x templates
 					// submissionReviewUrl -> we can't prepopulate, it depends if oneclick is enabled
-				));
-				$template->replaceParams();
+			));
+			$template->replaceParams();
 
-				return new JSONMessage(
-					true,
-					array(
-						'body' => $template->getBody(),
-						'variables' => array(
-							'reviewerName' => __('user.name'),
-							'responseDueDate' => __('reviewer.submission.responseDueDate'),
-							'reviewDueDate' => __('reviewer.submission.reviewDueDate'),
-							'submissionReviewUrl' => __('common.url'),
-							'reviewerUserName' => __('user.username'),
-						)
+			return new JSONMessage(
+					true, array(
+				'body' => $template->getBody(),
+				'variables' => array(
+					'reviewerName' => __('user.name'),
+					'responseDueDate' => __('reviewer.submission.responseDueDate'),
+					'reviewDueDate' => __('reviewer.submission.reviewDueDate'),
+					'submissionReviewUrl' => __('common.url'),
+					'reviewerUserName' => __('user.username'),
+				)
 					)
-				);
-			}
+			);
+		}
 	}
 	
 	//

--- a/classes/mail/EmailTemplateDAO.inc.php
+++ b/classes/mail/EmailTemplateDAO.inc.php
@@ -118,6 +118,22 @@ class EmailTemplateDAO extends DAO {
 	function getEmailTemplate($emailKey, $locale, $contextId) {
 		$primaryLocale = AppLocale::getPrimaryLocale();
 
+//		$context = $request->getContext();
+//
+//		propose tous les templates si mail settings language est ok
+//		AIE, visiblement on ne peut retourner un seul mail settings
+//		
+//		$permittedSettings = array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales','supportedMailLocales');
+//		if (in_array($settingName, $permittedSettings) && $locale) {
+//			$currentSettingValue = (array) $context->getSetting($settingName);
+//			if (AppLocale::isLocaleValid($locale) && array_key_exists($locale, $availableLocales)) {
+//				if ($settingValue) {
+//					array_push($currentSettingValue, $locale);
+//					if ($settingName == 'supportedFormLocales') {
+//						// reload localized default context settings
+//		
+//		
+		
 		$result = $this->retrieve(
 			'SELECT	COALESCE(edl.subject, ddl.subject, edpl.subject, ddpl.subject) AS subject,
 				COALESCE(edl.body, ddl.body, edpl.body, ddpl.body) AS body,

--- a/classes/mail/EmailTemplateDAO.inc.php
+++ b/classes/mail/EmailTemplateDAO.inc.php
@@ -118,22 +118,6 @@ class EmailTemplateDAO extends DAO {
 	function getEmailTemplate($emailKey, $locale, $contextId) {
 		$primaryLocale = AppLocale::getPrimaryLocale();
 
-//		$context = $request->getContext();
-//
-//		propose tous les templates si mail settings language est ok
-//		AIE, visiblement on ne peut retourner un seul mail settings
-//		
-//		$permittedSettings = array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales','supportedMailLocales');
-//		if (in_array($settingName, $permittedSettings) && $locale) {
-//			$currentSettingValue = (array) $context->getSetting($settingName);
-//			if (AppLocale::isLocaleValid($locale) && array_key_exists($locale, $availableLocales)) {
-//				if ($settingValue) {
-//					array_push($currentSettingValue, $locale);
-//					if ($settingName == 'supportedFormLocales') {
-//						// reload localized default context settings
-//		
-//		
-		
 		$result = $this->retrieve(
 			'SELECT	COALESCE(edl.subject, ddl.subject, edpl.subject, ddpl.subject) AS subject,
 				COALESCE(edl.body, ddl.body, edpl.body, ddpl.body) AS body,

--- a/controllers/grid/languages/LanguageGridCellProvider.inc.php
+++ b/controllers/grid/languages/LanguageGridCellProvider.inc.php
@@ -50,6 +50,9 @@ class LanguageGridCellProvider extends GridCellProvider {
 			case 'formLocale';
 				return array('selected' => $element['supportedFormLocales'],
 					'disabled' => !$element['supported']);
+			case 'mailLocale';
+				return array('selected' => $element['supportedMailLocales'],
+					'disabled' => !$element['supported']);
 			default:
 				assert(false);
 				break;
@@ -117,6 +120,12 @@ class LanguageGridCellProvider extends GridCellProvider {
 				$action = 'setFormLocale-' . $row->getId();
 				$actionArgs['setting'] = 'supportedFormLocales';
 				$actionArgs['value'] = !$element['supportedFormLocales'];
+				$actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
+				break;
+			case 'mailLocale':
+				$action = 'setMailLocale-' . $row->getId();
+				$actionArgs['setting'] = 'supportedMailLocales';
+				$actionArgs['value'] = !$element['supportedMailLocales'];
 				$actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
 				break;
 		}

--- a/controllers/grid/languages/LanguageGridHandler.inc.php
+++ b/controllers/grid/languages/LanguageGridHandler.inc.php
@@ -65,7 +65,7 @@ class LanguageGridHandler extends GridHandler {
 		$availableLocales = $this->getGridDataElements($request);
 		$context = $request->getContext();
 
-		$permittedSettings = array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales');
+		$permittedSettings = array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales','supportedMailLocales');
 		if (in_array($settingName, $permittedSettings) && $locale) {
 			$currentSettingValue = (array) $context->getSetting($settingName);
 			if (AppLocale::isLocaleValid($locale) && array_key_exists($locale, $availableLocales)) {
@@ -209,6 +209,16 @@ class LanguageGridHandler extends GridHandler {
 				$cellProvider
 			)
 		);
+		
+		$this->addColumn(
+			new GridColumn(
+				'mailLocale',
+				'manager.language.mails',
+				null,
+				'controllers/grid/common/cell/selectStatusCell.tpl',
+				$cellProvider
+			)
+		);
 	}
 
 	/**
@@ -223,7 +233,7 @@ class LanguageGridHandler extends GridHandler {
 
 		if (is_array($data)) {
 			foreach ($data as $locale => $localeData) {
-				foreach (array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales') as $name) {
+				foreach (array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales','supportedMailLocales') as $name) {
 					$data[$locale][$name] = in_array($locale, (array) $context->getSetting($name));
 				}
 			}

--- a/controllers/grid/users/reviewer/form/ReviewerForm.inc.php
+++ b/controllers/grid/users/reviewer/form/ReviewerForm.inc.php
@@ -263,10 +263,21 @@ class ReviewerForm extends Form {
 			}
 		}
 
-		foreach ($templateKeys as $templateKey) {
-			$template = new SubmissionMailTemplate($submission, $templateKey, null, null, null, false);
-			$template->assignParams(array());
-			$templates[$templateKey] = $template->getSubject();
+		
+		$supportedMailLocales = $context->getSetting('supportedMailLocales');
+		if (empty($supportedMailLocales)) $supportedMailLocales = array($context->getPrimaryLocale());
+		$supportedMailLocaleNames = array_flip(array_intersect(
+							array_flip(AppLocale::getAllLocales()),				
+					$supportedMailLocales ));
+		$templateMgr->assign('supportedMailLocaleNames',$supportedMailLocaleNames);
+		
+		
+		foreach (array_keys($supportedMailLocaleNames) as $localeKey) {
+			foreach ($templateKeys as $templateKey) {
+				$template = new SubmissionMailTemplate($submission, $templateKey, $localeKey, null, null, false);
+				$template->assignParams(array());
+				$templates[$localeKey][$templateKey] = $template->getSubject();
+			}
 		}
 
 		$templateMgr->assign('templates', $templates);

--- a/js/controllers/grid/users/reviewer/AdvancedReviewerSearchHandler.js
+++ b/js/controllers/grid/users/reviewer/AdvancedReviewerSearchHandler.js
@@ -79,6 +79,18 @@
 			// Hide the grid now
 			$('#searchGridAndButton').hide();
 			$('#regularReviewerForm').show();
+
+			// Change the NAME placeholder in the mail editor
+			$('[name^="personalMessage"]').val()
+					.replace('<span class="" data-symbolic="reviewerName" contenteditable="false" data-mce-selected="1">{$reviewerName}</span>', reviewerName);
+			$("iframe[id^='personalMessage']")
+					.contents()
+					.find('[data-symbolic="reviewerName"]')
+					.each(function() {
+						$(this).html(reviewerName);
+						$(this).attr('class', '');
+						$(this).removeAttr('contenteditable');
+					});
 		}
 	};
 

--- a/js/controllers/grid/users/reviewer/AdvancedReviewerSearchHandler.js
+++ b/js/controllers/grid/users/reviewer/AdvancedReviewerSearchHandler.js
@@ -81,8 +81,10 @@
 			$('#regularReviewerForm').show();
 
 			// Change the NAME placeholder in the mail editor
-			$('[name^="personalMessage"]').val()
-					.replace('<span class="" data-symbolic="reviewerName" contenteditable="false" data-mce-selected="1">{$reviewerName}</span>', reviewerName);
+			$('[name^="personalMessage"]').val().replace(
+					'<span class="" data-symbolic="reviewerName" ' +
+					'contenteditable="false" data-mce-selected="1">{$reviewerName}</span>',
+					reviewerName);
 			$("iframe[id^='personalMessage']")
 					.contents()
 					.find('[data-symbolic="reviewerName"]')

--- a/js/controllers/grid/users/reviewer/form/AddReviewerFormHandler.js
+++ b/js/controllers/grid/users/reviewer/form/AddReviewerFormHandler.js
@@ -97,13 +97,13 @@
 			AddReviewerFormHandler.prototype.selectTemplateHandler_ =
 					function(sourceElement, event) {
 
-		var $form = this.getHtmlElement();
-		var localeSelected = $('#templateLocale').val();
-		var templateID = '#template_'+localeSelected;
-		var data = $form.find(templateID+', #templateLocale').serialize();
+		var $form = this.getHtmlElement(), localeSelected = $('#templateLocale')
+				.val(), templateID = '#template_' + localeSelected,
+				data = $form.find(templateID + ', #templateLocale').serialize();
 		$.post(this.templateUrl_, data,
 				this.callbackWrapper(this.updateTemplate), 'json');
 	};
+
 
 	/**
 	 * Respond to an "locale change" call by triggering a published event.
@@ -118,10 +118,11 @@
 					function(sourceElement, event) {
 		var localeSelected = sourceElement.value;
 		$('.template').hide();
-		$('#template_'+localeSelected).removeClass("pkp_helpers_display_none").show();
+		$('#template_' + localeSelected).removeClass('pkp_helpers_display_none')
+				.show();
 		this.selectTemplateHandler_(sourceElement, event);
 	};
-		
+
 
 	/**
 	 * Internal callback to replace the textarea with the contents of the
@@ -141,9 +142,9 @@
 				$textarea = $form.find('textarea[name="personalMessage"]'),
 				editor = tinyMCE.EditorManager.get($textarea.attr('id'));
 
-				$textarea.attr('data-variables', JSON.stringify(jsonDataContent.variables));
-				editor.setContent(jsonDataContent.body);
-				this.addReviewerNameToMailEditor();
+		$textarea.attr('data-variables', JSON.stringify(jsonDataContent.variables));
+		editor.setContent(jsonDataContent.body);
+		this.addReviewerNameToMailEditor();
 		return processedJsonData.status;
 	};
 
@@ -154,18 +155,20 @@
 	 */
 	$.pkp.controllers.grid.users.reviewer.form.AddReviewerFormHandler.
 			prototype.addReviewerNameToMailEditor = function() {
-			var reviewerName = $('[id^="selectedReviewerName"]').html();
-			$('[name^="personalMessage"]').val()
-					.replace('<span class="" data-symbolic="reviewerName" contenteditable="false" data-mce-selected="1">{$reviewerName}</span>', reviewerName);
+
+		var reviewerName = $('[id^="selectedReviewerName"]').html();
+		$('[name^="personalMessage"]').val().replace(
+				'<span class="" data-symbolic="reviewerName" ' +
+				'contenteditable="false" data-mce-selected="1">{$reviewerName}</span>',
+				reviewerName);
 	
-			$("iframe[id^='personalMessage']")
-					.contents()
-					.find('[data-symbolic="reviewerName"]')
-					.each(function() {
-						$(this).html(reviewerName);
-						$(this).attr('class', '');
-						$(this).removeAttr('contenteditable');
-					});
+		$("iframe[id^='personalMessage']").contents()
+				.find('[data-symbolic="reviewerName"]')
+				.each(function() {
+					$(this).html(reviewerName);
+					$(this).attr('class', '');
+					$(this).removeAttr('contenteditable');
+				});
 	};
 
 /** @param {jQuery} $ jQuery closure. */

--- a/js/controllers/grid/users/reviewer/form/AddReviewerFormHandler.js
+++ b/js/controllers/grid/users/reviewer/form/AddReviewerFormHandler.js
@@ -140,7 +140,8 @@
 				processedJsonData = this.handleJson(jsonData),
 				jsonDataContent = (jsonData.content),
 				$textarea = $form.find('textarea[name="personalMessage"]'),
-				editor = tinyMCE.EditorManager.get($textarea.attr('id'));
+				editor = 
+				tinyMCE.EditorManager.get(/** @type {string} */ $textarea.attr('id'));
 
 		$textarea.attr('data-variables', JSON.stringify(jsonDataContent.variables));
 		editor.setContent(jsonDataContent.body);

--- a/locale/en_US/common.xml
+++ b/locale/en_US/common.xml
@@ -371,6 +371,7 @@
 
 	<!-- Stage Participants -->
 	<message key="stageParticipants.history.messageSent">Notification sent to users.</message>
+	<message key="stageParticipants.notify.chooseLocale">Select language for predefined message.</message>
 	<message key="stageParticipants.notify.chooseMessage">Choose a predefined message to use, or fill out the form below.</message>
 	<message key="stageParticipants.notify.message">Message</message>
 	<message key="stageParticipants.notify.warning">Please ensure that you have filled out the message field and selected at least one recipient.</message>

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -112,6 +112,7 @@
 	<message key="manager.language.ui">UI</message>
 	<message key="manager.language.submissions">Submissions</message>
 	<message key="manager.language.forms">Forms</message>
+	<message key="manager.language.mails">Mails</message>
 	<message key="manager.language.reloadLocalizedDefaultSettings">Reload defaults</message>
 	<message key="manager.languages.alternateLocaleInstructions">This system optionally allows certain critical information to be entered in several additional languages. To use this feature, select alternate locales and choose from the options listed below.</message>
 	<message key="manager.languages.supportedLocalesInstructions">Select all locales to support on the site via a language select menu to appear on each page. The menu will only appear if more than one locale is selected.</message>

--- a/templates/controllers/grid/users/reviewer/form/reviewerFormFooter.tpl
+++ b/templates/controllers/grid/users/reviewer/form/reviewerFormFooter.tpl
@@ -9,16 +9,40 @@
  *
  *}
 <div id="reviewerFormFooter" class="reviewerFormFooterContainer">
-	<!--  message template choice -->
-	{if $templates|@count == 1}
-		{foreach from=$templates item=template key=templateKey}
-			<input type="hidden" name="template" value="{$templateKey|escape}"/>
+	<!--  message locale template choice -->
+			
+	{if $supportedMailLocaleNames|@count == 1}
+		{foreach from=$supportedMailLocaleNames item=localeName key=localeKey}
+			<input type="hidden" name="templateLocale" value="{$localeKey|escape}" id="templateLocale" />
 		{/foreach}
 	{else}
-		{fbvFormSection title="stageParticipants.notify.chooseMessage" for="template" size=$fbvStyles.size.medium}
-			{fbvElement type="select" from=$templates translate=false id="template"}
+		{fbvFormSection title="stageParticipants.notify.chooseLocale" for="templatelocale" size=$fbvStyles.size.medium}
+			{fbvElement type="select" from=$supportedMailLocaleNames translate=false id="templateLocale"}
 		{/fbvFormSection}
 	{/if}
+	
+	<!--  message template choice -->
+	
+	
+		{*{if $localizedTemplates|@count == 1}
+			{foreach from=$localizedTemplates item=template key=templateKey}
+					<input type="hidden" name="template" value="{$templateKey|escape}"/>
+			{/foreach}
+			{else}*}
+			
+				{fbvFormSection title="stageParticipants.notify.chooseMessage" for="template" size=$fbvStyles.size.medium}
+				{foreach from=$templates item=localizedTemplates key=localeKey name=foo}
+					{if $smarty.foreach.foo.first}
+						{fbvElement type="select" from=$localizedTemplates translate=false id="template_$localeKey" class="template"}
+					{else}
+						{fbvElement type="select" from=$localizedTemplates translate=false id="template_$localeKey" class="template pkp_helpers_display_none"}
+					{/if}
+				{/foreach}
+				{/fbvFormSection}
+			
+		{*{/if}*}
+	
+
 
 	<!--  Message to reviewer textarea -->
 	{fbvFormSection title="editor.review.personalMessageToReviewer" for="personalMessage"}


### PR DESCRIPTION
…messages in ReviewerForm

It's a first solution for #3525.
- this adds an option in Settings> Website> Languages: for each language, user can enable this language to be proposed for email templates.
- for the moment, this functionality is just for reviewerForm but I hope we can do something more generic for all forms where you can select a mail template.

And we replace some variables like {$title} server side before sending template.
I use #2180 for client side.

This PR also refers to #3523.