### PR TITLE
pkp/pkp-lib#3456 Open the Help menu to plugins 

### DIFF
--- a/classes/plugins/Plugin.inc.php
+++ b/classes/plugins/Plugin.inc.php
@@ -823,6 +823,35 @@ abstract class Plugin {
 	function getJavascriptNameSpace() {
 		return '$.pkp.plugins.' . strtolower(get_class($this));
 	}
+
+	/**
+	 * Register the help index file
+	 *
+	 * @param indexFile
+	 */
+	function registerHelp($index = "index.md") {
+		$this->helpIndex = $index;
+		HookRegistry::register ('Help::Plugins', array($this, 'pluginHelp'));
+	}
+
+	/**
+	 * Callback to return the help index
+	 *
+	 * @param $hookName string
+	 * @param $args array
+	 *
+	 * @return boolean
+	 */
+	function pluginHelp($hookName, $args) {
+		$pluginHelpChapters =& $args[0];
+		$pluginHelpChapters[] = array(
+			'label' => $this->getDisplayName(),
+			'file' => $this->helpIndex,
+			'path' => $this->getPluginPath() . DIRECTORY_SEPARATOR . 'help'
+		);
+
+		return false;
+	}
 }
 
 ?>

--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -988,14 +988,29 @@ class PKPTemplateManager extends Smarty {
 	}
 
 	/**
-	 * Smarty usage: {help file="someFile.md" section="someSection" textKey="some.text.key"}
+	 * Smarty usage: {help file="someFile.md" plugin="pluginPath" section="someSection" textKey="some.text.key"}
 	 *
 	 * Custom Smarty function for displaying a context-sensitive help link.
 	 * @param $smarty Smarty
 	 * @return string the HTML for the generated link action
 	 */
 	function smartyHelp($params, $smarty) {
-		assert(isset($params['file']));
+		$plugin = (isset($params['plugin'])) ? $params['plugin'] : null;
+
+		if ($plugin != null) {
+			$file = join(DIRECTORY_SEPARATOR, array("plugins", $plugin, "help", AppLocale::getIso1FromLocale(AppLocale::getLocale()), ""));
+
+			// When no file name was passed fall back to the default index.md
+			if (!isset($params['file'])) {
+				$file .= "index.md";
+			} else{
+				$file .= $params['file'];
+			}
+		} else {
+			$file = $params['file'];
+		}
+
+		assert(isset($file));
 
 		$params = array_merge(
 			array(
@@ -1009,7 +1024,7 @@ class PKPTemplateManager extends Smarty {
 		);
 
 		$this->assign(array(
-			'helpFile' => $params['file'],
+			'helpFile' => $file,
 			'helpSection' => $params['section'],
 			'helpTextKey' => $params['textKey'],
 			'helpText' => $params['text'],


### PR DESCRIPTION
Added the possibility for plugins to provide their own help files.

The plugin base class was extended to register a plugins help index file
to the `Help::Plugins` hook.

The PKPTemplateManager smartyHelp method was extended to support the
parameter plugin, to create a plugin help link, defaulting to index.md
as filename.

The HelpHandler now handles plugin help chapters as well.

Adapted the feedback to the [pr](https://github.com/pkp/pkp-lib/pull/3496) from @NateWr.