### PR TITLE
update es_ES translation in context

### DIFF
--- a/locale/es_ES/submission.xml
+++ b/locale/es_ES/submission.xml
@@ -486,7 +486,7 @@
 	<message key="editor.submission.roundStatus.sentToExternal">Enviado para revisión externa.</message>
 	<message key="editor.submission.roundStatus.accepted">Envío aceptado.</message>
 	<message key="editor.submission.roundStatus.declined">Envío rechazado.</message>
-	<message key="editor.submission.roundStatus.pendingReviewers">Esperando a los revisores/as.</message>
+	<message key="editor.submission.roundStatus.pendingReviewers">Esperando asignar a los  revisores/as.</message>
 	<message key="editor.submission.roundStatus.pendingReviews">Esperando las respuestas de los revisores/as.</message>
 	<message key="editor.submission.roundStatus.reviewsReady">Los revisores/as nuevos están listos.</message>
 	<message key="editor.submission.roundStatus.reviewsCompleted">Revisiones completadas.</message>


### PR DESCRIPTION
this line is not correct, @marcbria in this moment of the process the manuscript does not have reviewers, and the editors need to assign some reviewers.

If you prefer another sentence just tell me, and I can change it