### PR TITLE
Use correct id in login as check

### DIFF
--- a/controllers/grid/users/stageParticipant/StageParticipantGridRow.inc.php
+++ b/controllers/grid/users/stageParticipant/StageParticipantGridRow.inc.php
@@ -79,8 +79,8 @@ class StageParticipantGridRow extends GridRow {
 			$user = $request->getUser();
 			if (
 				!Validation::isLoggedInAs() &&
-				$user->getId() != $rowId &&
-				Validation::canAdminister($rowId, $user->getId())
+				$user->getId() != $userId &&
+				Validation::canAdminister($userId, $user->getId())
 			) {
 				$dispatcher = $router->getDispatcher();
 				import('lib.pkp.classes.linkAction.request.RedirectConfirmationModal');


### PR DESCRIPTION
Hi @NateWr / @asmecher 

I noticed that in some cases the login as action is not visible in the stage participants grid. The reason seems to be, I think, that the check in the gridrow uses the wrong id.