### PR TITLE
fix null $image[$key] value

### DIFF
--- a/controllers/tab/settings/siteSetup/form/NewSiteImageFileForm.inc.php
+++ b/controllers/tab/settings/siteSetup/form/NewSiteImageFileForm.inc.php
@@ -42,7 +42,9 @@ class NewSiteImageFileForm extends SettingsFileUploadForm {
 
 		$supportedLocales = AppLocale::getSupportedLocales();
 		foreach ($supportedLocales as $key => $locale) {
-			$imageAltText[$key] = $image[$key]['altText'];
+			if (isset($image[$key])) {
+				$imageAltText[$key] = $image[$key]['altText'];
+			}
 		}
 
 		$this->setData('imageAltText', $imageAltText);


### PR DESCRIPTION
To avoid PHP notices in JSON responses, making it invalid, like:
Notice: Undefined index: es_ES in /ojs/ojs-3.1.1/lib/pkp/controllers/tab/settings/siteSetup/form/NewSiteImageFileForm.inc.php on line 45

Notice: Undefined index: fr_CA in /ojs/ojs-3.1.1/lib/pkp/controllers/tab/settings/siteSetup/form/NewSiteImageFileForm.inc.php on line 45

Notice: Undefined index: fr_FR in /ojs/ojs-3.1.1/lib/pkp/controllers/tab/settings/siteSetup/form/NewSiteImageFileForm.inc.php on line 45

Notice: Undefined index: it_IT in /ojs/ojs-3.1.1/lib/pkp/controllers/tab/settings/siteSetup/form/NewSiteImageFileForm.inc.php on line 45

Notice: Undefined index: pt_BR in /ojs/ojs-3.1.1/lib/pkp/controllers/tab/settings/siteSetup/form/NewSiteImageFileForm.inc.php on line 45
{"status":true,"content":"\n