### PR TITLE
verify if $this->settingsForm is defined or not null

### DIFF
--- a/controllers/tab/settings/paymentMethod/form/PaymentMethodForm.inc.php
+++ b/controllers/tab/settings/paymentMethod/form/PaymentMethodForm.inc.php
@@ -108,7 +108,7 @@ class PaymentMethodForm extends ContextSettingsForm {
 	 */
 	function validate() {
 		if (!$this->settingsForm->validate()) {
-			foreach ($this->settingsForm->getErrorsArray() as $field => $message) {
+			foreach (isset($this->settingsForm) && $this->settingsForm->getErrorsArray() as $field => $message) {
 				$this->addError($field, $message);
 			}
 		}


### PR DESCRIPTION
fix PHP Fatal error:  Call to a member function validate() on null in /ojs/ojs-3.1.1/lib/pkp/controllers/tab/settings/paymentMethod/form/PaymentMethodForm.inc.php on line 110, referer: http://example.com/index.php/sarc-test/management/settings/distribution