### PR TITLE
pkp/pkp-lib#3754: Prevent malformed SQL on malformed sort input for user query.

### DIFF
--- a/classes/user/PKPUserDAO.inc.php
+++ b/classes/user/PKPUserDAO.inc.php
@@ -576,7 +576,7 @@ class PKPUserDAO extends DAO {
 		}
 
 		$roleDao = DAORegistry::getDAO('RoleDAO');
-		$orderSql = ($sortBy?(' ORDER BY ' . $roleDao->getSortMapping($sortBy) . ' ' . $this->getDirectionMapping($sortDirection)) : '');
+		$orderSql = ($sortBy && $roleDao->getSortMapping($sortBy)?(' ORDER BY ' . $roleDao->getSortMapping($sortBy) . ' ' . $this->getDirectionMapping($sortDirection)) : '');
 		if ($field != USER_FIELD_NONE) $result = $this->retrieveRange($sql . ($allowDisabled?'':' AND u.disabled = 0') . $orderSql, $var, $dbResultRange);
 		else $result = $this->retrieveRange($sql . ($allowDisabled?'':' WHERE u.disabled = 0') . $orderSql, false, $dbResultRange);
 


### PR DESCRIPTION
Prevents the issue described in pkp/pkp-lib#3754, though the function `PKPUserDAO::getUsersByField()` appears unused in the OJS 3.x codebase (via `grep -r getUsersByField *`).