### PR TITLE
pkp/pkp-lib#3836 Privacy consent statement for registrationFormContexts

### DIFF
--- a/locale/en_US/user.xml
+++ b/locale/en_US/user.xml
@@ -109,6 +109,8 @@
 	<message key="user.login.resetPasswordInstructions">Enter your account email address below and an email will be sent with instructions on how to reset your password.</message>
 
 	<message key="user.register.form.privacyConsent"><![CDATA[Yes, I agree to have my data collected and stored according to the <a href="{$privacyUrl}" target="_blank">privacy statement</a>.]]></message>
+	<message key="user.register.form.privacyConsentContext">Yes, I agree to have my data collected and stored according to the journal's Policy Statement:</message>
+	<message key="user.register.form.privacyConsentContextData"><![CDATA[The <a href="{$privacyUrl}" target="_blank">Policy Statement</a> of {$privacyContextName}.]]></message>
 	<message key="user.register.form.emailConsent">Yes, I would like to be notified of new publications and announcements.</message>
 	<message key="user.register.form.emailExists">The selected email address is already in use by another user.</message>
 	<message key="user.register.form.passwordsDoNotMatch">The passwords do not match.</message>

--- a/templates/frontend/components/navigationMenus/dashboardMenuItem.tpl
+++ b/templates/frontend/components/navigationMenus/dashboardMenuItem.tpl
@@ -10,8 +10,6 @@
  *}
 
 {$navigationMenuItem->getLocalizedTitle()|escape}
-{if $unreadNotificationCount}
-	<span class="task_count">
-		{$unreadNotificationCount}
-	</span>
-{/if}
+<span class="task_count">
+	{$unreadNotificationCount}
+</span>

--- a/templates/frontend/components/navigationMenus/dashboardMenuItem.tpl
+++ b/templates/frontend/components/navigationMenus/dashboardMenuItem.tpl
@@ -10,6 +10,8 @@
  *}
 
 {$navigationMenuItem->getLocalizedTitle()|escape}
-<span class="task_count">
-	{$unreadNotificationCount}
-</span>
+{if $unreadNotificationCount}
+	<span class="task_count">
+		{$unreadNotificationCount}
+	</span>
+{/if}

--- a/templates/frontend/components/registrationFormContexts.tpl
+++ b/templates/frontend/components/registrationFormContexts.tpl
@@ -21,6 +21,33 @@
    outside of the context of any one journal/press. *}
 {if !$currentContext}
 
+	<fieldset class="consent">
+		<div class="fields">
+			<div class="optin optin-privacy">
+				<label>
+					<input type="checkbox" name="privacyConsent" value="1"{if $privacyConsent} checked="checked"{/if}>
+					{translate key="user.register.form.privacyConsentContext"}
+				</label>
+				{foreach from=$contexts item=context}
+					{assign var=contextPath value=$context->getPath()|escape}
+					{assign var=privacyContextName value=$context->getLocalizedName()|escape}
+					{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE context=$contextPath page="about" op="privacy"}{/capture}
+					<div class="context_consent_policy">
+						{translate key="user.register.form.privacyConsentContextData" privacyUrl=$privacyUrl privacyContextName=$privacyContextName}
+					</div>
+				{/foreach}
+			</div>
+		</div>
+		<div class="fields">
+			<div class="optin optin-email">
+				<label>
+					<input type="checkbox" name="emailConsent" value="1"{if $emailConsent} checked="checked"{/if}>
+					{translate key="user.register.form.emailConsent"}
+				</label>
+			</div>
+		</div>
+	</fieldset>
+
 	{* Allow users to register for any journal/press on this site *}
 	<fieldset name="contexts">
 		<legend>


### PR DESCRIPTION
As I encountered with this issue while testing a new theme, some thoughts on managing of Privacy Statement for registration from the site-wide registration page. Also, should the term `Privacy Statement` be consistent for all cases? Because for default theme `Policy Statement` is used instead.