### PR TITLE
Control maxIdentifiers using a config setting

### DIFF
--- a/classes/oai/OAIStruct.inc.php
+++ b/classes/oai/OAIStruct.inc.php
@@ -36,7 +36,7 @@ class OAIConfig {
 	var $tokenLifetime = 86400;
 
 	/** @var int maximum identifiers returned per request */
-	var $maxIdentifiers = 500;
+	var $maxIdentifiers;
 
 	/** @var int maximum records returned per request */
 	var $maxRecords;
@@ -54,6 +54,9 @@ class OAIConfig {
 
 		$this->maxRecords = Config::getVar('oai', 'oai_max_records');
 		if (!$this->maxRecords) $this->maxRecords = 100;
+		
+		$this->maxIdentifiers = Config::getVar('oai', 'oai_max_identifiers');
+		if (!$this->maxIdentifiers) $this->maxIdentifiers = 500;		
 	}
 }
 


### PR DESCRIPTION
500 is a large number for a listing. In our case, without any caching mechanism, the page takes about 9sec to display 500 identifiers. We need to control the number of displayed identifiers.