### PR TITLE
pkp/pkp-lib#3578: harmonizing GridCellProvider::getCellActions() signatures

### DIFF
--- a/controllers/grid/languages/LanguageGridCellProvider.inc.php
+++ b/controllers/grid/languages/LanguageGridCellProvider.inc.php
@@ -59,7 +59,7 @@ class LanguageGridCellProvider extends GridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		import('lib.pkp.classes.linkAction.request.RemoteActionConfirmationModal');
 		import('lib.pkp.classes.linkAction.request.AjaxAction');
 

--- a/controllers/grid/queries/QueriesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueriesGridCellProvider.inc.php
@@ -82,7 +82,7 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		import('lib.pkp.classes.linkAction.request.RemoteActionConfirmationModal');
 		import('lib.pkp.classes.linkAction.request.AjaxAction');
 
@@ -109,7 +109,7 @@ class QueriesGridCellProvider extends DataObjectGridCellProvider {
 				}
 				break;
 		}
-		return parent::getCellActions($request, $row, $column);
+		return parent::getCellActions($request, $row, $column, $position);
 	}
 
 	/**

--- a/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
@@ -73,7 +73,7 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 				}
 				return $actions;
 		}
-		return parent::getCellActions($request, $row,, $column, $position);
+		return parent::getCellActions($request, $row, $column, $position);
 	}
 }
 

--- a/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
+++ b/controllers/grid/queries/QueryNotesGridCellProvider.inc.php
@@ -55,7 +55,7 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		switch ($column->getId()) {
 			case 'contents':
 				$element = $row->getData();
@@ -73,7 +73,7 @@ class QueryNotesGridCellProvider extends DataObjectGridCellProvider {
 				}
 				return $actions;
 		}
-		return parent::getCellActions($request, $row, $column);
+		return parent::getCellActions($request, $row,, $column, $position);
 	}
 }
 


### PR DESCRIPTION
Fixes part of #3578; may break some plugins.