### PR TITLE
Show task bubble only if there are active tasks

### DIFF
--- a/templates/frontend/components/navigationMenus/dashboardMenuItem.tpl
+++ b/templates/frontend/components/navigationMenus/dashboardMenuItem.tpl
@@ -10,6 +10,8 @@
  *}
 
 {$navigationMenuItem->getLocalizedTitle()|escape}
-<span class="task_count">
-	{$unreadNotificationCount}
-</span>
+{if $unreadNotificationCount}
+	<span class="task_count">
+		{$unreadNotificationCount}
+	</span>
+{/if}


### PR DESCRIPTION
@NateWr  
Does it make sense for the default template? For our new themes, we prefer to use this approach. 