### PR TITLE
Review form elements grid, fixed broken order feature

### DIFF
--- a/controllers/grid/settings/reviewForms/ReviewFormElementsGridHandler.inc.php
+++ b/controllers/grid/settings/reviewForms/ReviewFormElementsGridHandler.inc.php
@@ -155,6 +155,13 @@ class ReviewFormElementsGridHandler extends GridHandler {
 	}
 
 	/**
+	 * @copydoc GridHandler::getDataElementSequence()
+	 */
+	function getDataElementSequence($gridDataElement) {
+		return $gridDataElement->getSequence();
+	}
+
+	/**
 	 * @copydoc GridHandler::setDataElementSequence()
 	 */
 	function setDataElementSequence($request, $rowId, $gridDataElement, $newSequence) {


### PR DESCRIPTION
... by adding missing getDataElementSequence() override, see issue #3926