### PR TITLE
Add tinymce link list using the public library files

### DIFF
--- a/js/controllers/SiteHandler.js
+++ b/js/controllers/SiteHandler.js
@@ -137,12 +137,26 @@
 			tinyMCE.PluginManager.load('pkpwordcount', $.pkp.app.baseUrl +
 					'/plugins/generic/tinymce/plugins/pkpWordcount/plugin.js');
 
+			var linkListUrl;
+			var indexFile = $.pkp.app.restfulUrlsEnabled ? '' : 'index.php';
+
+			if ($.pkp.app.contextPath) {
+				if (!$.pkp.app.pathInfoEnabled) {
+					linkListUrl = $.pkp.app.baseUrl + '/' + indexFile  + '?journal=' + encodeURIComponent($.pkp.app.contextPath) + '/libraryFiles/jsonListPublic';
+				} else {
+					linkListUrl = $.pkp.app.baseUrl + '/' + indexFile  + '/' + $.pkp.app.contextPath + '/libraryFiles/jsonListPublic';
+				}
+			} else {
+				linkListUrl = $.pkp.app.baseUrl + '/libraryFiles/jsonListPublic';
+			}
+
 			var tinymceParams, tinymceParamDefaults = {
 				width: '100%',
 				resize: 'both',
 				entity_encoding: 'raw',
 				plugins: 'paste,fullscreen,link,lists,code,' +
 						'-jbimages,-pkpTags,noneditable',
+				link_list: linkListUrl,
 				convert_urls: false,
 				forced_root_block: 'p',
 				paste_auto_cleanup_on_paste: true,

--- a/pages/libraryFiles/LibraryFileHandler.inc.php
+++ b/pages/libraryFiles/LibraryFileHandler.inc.php
@@ -106,4 +106,29 @@ class LibraryFileHandler extends Handler {
 			}
 		}
 	}
+
+	/**
+	 * Public JSON list of all public files. Used in Tinymce link list.
+	 * @param $args array
+	 * @param $request Request
+	 */
+	function jsonListPublic($args, $request) {
+		import('classes.file.LibraryFileManager');
+		$dispatcher = $request->getDispatcher();
+		$context = $request->getContext();
+		$jsonList = array();
+
+		$libraryFileDao = DAORegistry::getDAO('LibraryFileDAO');
+		$libraryFiles = $libraryFileDao->getByContextId($context->getId());
+
+		if ($libraryFiles) {
+			while ($libraryFile = $libraryFiles->next()) {
+				if ($libraryFile->getPublicAccess()){
+					$jsonList[] = array('title' => $libraryFile->getLocalizedName(), 'value' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath(), 'libraryFiles', 'downloadPublic', $libraryFile->getId()));
+				}
+			}
+		}
+		return json_encode($jsonList);
+	}
+
 }

--- a/pages/libraryFiles/index.php
+++ b/pages/libraryFiles/index.php
@@ -15,6 +15,7 @@
 switch ($op) {
 	case 'downloadPublic':
 	case 'downloadLibraryFile':
+	case 'jsonListPublic':
 		define('HANDLER_CLASS', 'LibraryFileHandler');
 		import('lib.pkp.pages.libraryFiles.LibraryFileHandler');
 		break;


### PR DESCRIPTION
Hi @NateWr and @asmecher 

This something that was not asked anywhere, but would be a nice feature in my opinion.

Tinymce has a link_list variable that you can use the create a pull down list of preset links. These changes use that feature and list the public library files as preset options there.

So basically when you go on and edit something with tinymce and create a link, you can see all the public library files there in a pull down and choose from the list. No need to remember the url of a file!

This is just a proof on concept code. Probably the handler I use and the way it is called is something that should be revised? But if this is something you would consider to the core, I am happy to do changes...

<img width="651" alt="screen shot 2018-08-02 at 20 57 11" src="https://user-images.githubusercontent.com/16347527/43601753-abb43210-9696-11e8-858d-bd8271588176.png">

edit: also this could be extended with the url's of the different pages available. It supports submenus you could use for grouping: http://archive.tinymce.com/wiki.php/Configuration:link_list 'Files', 'Pages'