### PR TITLE
Fix queryid call in getCanOpenClose

### DIFF
--- a/controllers/grid/queries/QueriesAccessHelper.inc.php
+++ b/controllers/grid/queries/QueriesAccessHelper.inc.php
@@ -59,7 +59,7 @@ class QueriesAccessHelper {
 		if ($this->hasStageRole($query->getStageId(), array(ROLE_ID_MANAGER, ROLE_ID_SUB_EDITOR))) return true;
 
 		// Assigned assistants are allowed
-		if ($this->hasStageRole($query->getStageId(), array(ROLE_ID_ASSISTANT)) && $this->isAssigned($this->_user->getId(), $queryId)) return true;
+		if ($this->hasStageRole($query->getStageId(), array(ROLE_ID_ASSISTANT)) && $this->isAssigned($this->_user->getId(), $query->getId())) return true;
 
 		// Otherwise, not allowed.
 		return false;


### PR DESCRIPTION
Causes PHP Notice:  Undefined variable: queryId in /lib/pkp/controllers/grid/queries/QueriesAccessHelper.inc.php on line 62