### PR TITLE
pkp/pkp-lib#3578: renaming PKPUserSettingsDAO methods

### DIFF
--- a/classes/user/PKPUserSettingsDAO.inc.php
+++ b/classes/user/PKPUserSettingsDAO.inc.php
@@ -18,14 +18,14 @@
 class PKPUserSettingsDAO extends DAO {
 
 	/**
-	 * Retrieve a user setting value.
+	 * Retrieve a user setting value by association.
 	 * @param $userId int
 	 * @param $name
 	 * @param $assocType int
 	 * @param $assocId int
 	 * @return mixed
 	 */
-	function &getSetting($userId, $name, $assocType = null, $assocId = null) {
+	function &getByAssoc($userId, $name, $assocType = null, $assocId = null) {
 		$result = $this->retrieve(
 			'SELECT	setting_value,
 				setting_type
@@ -53,7 +53,7 @@ class PKPUserSettingsDAO extends DAO {
 	}
 
 	/**
-	 * Retrieve all users by setting name and value.
+	 * Retrieve all users by association, setting name, and value.
 	 * @param $name string
 	 * @param $value mixed
 	 * @param $type string
@@ -61,7 +61,7 @@ class PKPUserSettingsDAO extends DAO {
 	 * @param $assocId int
 	 * @return DAOResultFactory matching Users
 	 */
-	function &getUsersBySetting($name, $value, $type = null, $assocType = null, $assocId = null) {
+	function &getUsersByAssocSetting($name, $value, $type = null, $assocType = null, $assocId = null) {
 		$userDao = DAORegistry::getDAO('UserDAO');
 
 		$value = $this->convertToDB($value, $type);
@@ -113,7 +113,7 @@ class PKPUserSettingsDAO extends DAO {
 	}
 
 	/**
-	 * Add/update a user setting.
+	 * Add/update a user setting by association.
 	 * @param $userId int
 	 * @param $name string
 	 * @param $value mixed
@@ -121,7 +121,7 @@ class PKPUserSettingsDAO extends DAO {
 	 * @param $assocType int
 	 * @param $assocId int
 	 */
-	function updateSetting($userId, $name, $value, $type = null, $assocType = null, $assocId = null) {
+	function updateByAssoc($userId, $name, $value, $type = null, $assocType = null, $assocId = null) {
 		$result = $this->retrieve(
 			'SELECT	COUNT(*)
 			FROM	user_settings
@@ -173,13 +173,13 @@ class PKPUserSettingsDAO extends DAO {
 	}
 
 	/**
-	 * Delete a user setting.
+	 * Delete a user setting by association.
 	 * @param $userId int
 	 * @param $name string
 	 * @param $assocType int
 	 * @param $assocId int
 	 */
-	function deleteSetting($userId, $name, $assocType = null, $assocId = null) {
+	function deleteByAssoc($userId, $name, $assocType = null, $assocId = null) {
 		return $this->update(
 			'DELETE FROM user_settings WHERE user_id = ? AND setting_name = ? AND assoc_type = ? AND assoc_id = ?',
 			array((int) $userId, $name, (int) $assocType, (int) $assocId)


### PR DESCRIPTION
Better partial fix for #3578, per @asmecher’s suggestion.