### PR TITLE
FileDateGridColumn added, display SubmissionFile modification date

### DIFF
--- a/controllers/grid/files/FileDateGridColumn.inc.php
+++ b/controllers/grid/files/FileDateGridColumn.inc.php
@@ -49,20 +49,21 @@ class FileDateGridColumn extends GridColumn {
 		$submissionFileData = $row->getData();
 		$submissionFile = $submissionFileData['submissionFile'];
 		assert(is_a($submissionFile, 'SubmissionFile'));
-        $mtimestamp = strtotime($submissionFile->getDateModified());
-        $dateFormatShort = \Config::getVar('general', 'date_format_long');
-        $date = strftime($dateFormatShort, $mtimestamp);
-        // File age
-        $age = (int)floor((date('U') - $mtimestamp) / 86400);
-        switch( true ) {
-            case $age <= 7:
-                $cls = " pkp_helpers_text_warn"; break;
-            case $age <= 28:
-                $cls = " pkp_helpers_text_primary"; break;
-            default:
-                $cls = ""; break;
-        }
-        return array('label' => sprintf("<span class='label%s'>%s</span>", $cls, $date));
+		$mtimestamp = strtotime($submissionFile->getDateModified());
+		$dateFormatShort = \Config::getVar('general', 'date_format_long');
+		$date = strftime($dateFormatShort, $mtimestamp);
+		// File age
+		$age = (int)floor((date('U') - $mtimestamp) / 86400);
+		switch( true ) {
+			case $age <= 7:
+				$cls = " pkp_helpers_text_warn"; break;
+			case $age <= 28:
+				$cls = " pkp_helpers_text_primary"; break;
+			default:
+				$cls = ""; break;
+		}
+		return array('label' => sprintf("<span class='label%s'>%s</span>",
+										$cls, htmlspecialchars($date)));
 	}
 
 	//
@@ -84,4 +85,3 @@ class FileDateGridColumn extends GridColumn {
 	}
 }
 
-?>

--- a/controllers/grid/files/FileDateGridColumn.inc.php
+++ b/controllers/grid/files/FileDateGridColumn.inc.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @file controllers/grid/files/FileDateGridColumn.inc.php
+ *
+ * Copyright (c) 2014-2018 Simon Fraser University
+ * Copyright (c) 2000-2018 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ * Borrowed from FileDateGridColumn.inc.php
+ *
+ * @class FileDateGridColumn
+ * @ingroup controllers_grid_files
+ *
+ * @brief Implements a file name column.
+ */
+
+import('lib.pkp.classes.controllers.grid.GridColumn');
+
+class FileDateGridColumn extends GridColumn {
+	/** @var boolean */
+	var $_includeNotes;
+
+	/**
+	 * Constructor
+	 * @param $includeNotes boolean
+	 * without the history tab.
+	 */
+	function __construct($includeNotes = true) {
+		$this->_includeNotes = $includeNotes;
+
+		import('lib.pkp.classes.controllers.grid.ColumnBasedGridCellProvider');
+		$cellProvider = new ColumnBasedGridCellProvider();
+
+		parent::__construct('date', 'common.date', null, null, $cellProvider,
+			array('width' => 10, 'alignment' => COLUMN_ALIGNMENT_LEFT, 'anyhtml' => true));
+	}
+
+
+	//
+	// Public methods
+	//
+	/**
+	 * Method expected by ColumnBasedGridCellProvider
+	 * to render a cell in this column.
+	 *
+	 * @copydoc ColumnBasedGridCellProvider::getTemplateVarsFromRowColumn()
+	 */
+	function getTemplateVarsFromRow($row) {
+		$submissionFileData = $row->getData();
+		$submissionFile = $submissionFileData['submissionFile'];
+		assert(is_a($submissionFile, 'SubmissionFile'));
+        $mtimestamp = strtotime($submissionFile->getDateModified());
+        $dateFormatShort = \Config::getVar('general', 'date_format_long');
+        $date = strftime($dateFormatShort, $mtimestamp);
+        // File age
+        $age = (int)floor((date('U') - $mtimestamp) / 86400);
+        switch( true ) {
+            case $age <= 7:
+                $cls = " pkp_helpers_text_warn"; break;
+            case $age <= 28:
+                $cls = " pkp_helpers_text_primary"; break;
+            default:
+                $cls = ""; break;
+        }
+        return array('label' => sprintf("<span class='label%s'>%s</span>", $cls, $date));
+	}
+
+	//
+	// Private methods
+	//
+	/**
+	 * Determine whether or not submission note status should be included.
+	 */
+	function _getIncludeNotes() {
+		return $this->_includeNotes;
+	}
+
+	/**
+	 * Get stage id, if any.
+	 * @return mixed int or null
+	 */
+	function _getStageId() {
+		return $this->_stageId;
+	}
+}
+
+?>

--- a/controllers/grid/files/SubmissionFilesGridHandler.inc.php
+++ b/controllers/grid/files/SubmissionFilesGridHandler.inc.php
@@ -19,6 +19,7 @@ import('lib.pkp.classes.controllers.grid.GridHandler');
 // Import submission files grid specific classes.
 import('lib.pkp.controllers.grid.files.SubmissionFilesGridRow');
 import('lib.pkp.controllers.grid.files.FileNameGridColumn');
+import('lib.pkp.controllers.grid.files.FileDateGridColumn');
 
 // Import submission file class which contains the SUBMISSION_FILE_* constants.
 import('lib.pkp.classes.submission.SubmissionFile');
@@ -147,6 +148,9 @@ class SubmissionFilesGridHandler extends GridHandler {
 
 		// The file name column is common to all file grid types.
 		$this->addColumn(new FileNameGridColumn($capabilities->canViewNotes(), $this->getStageId()));
+
+        // Additional column with file upload date/creation date
+		$this->addColumn(new FileDateGridColumn($capabilities->canViewNotes()));
 
 		// Set the no items row text
 		$this->setEmptyRowText('grid.noFiles');

--- a/controllers/grid/files/SubmissionFilesGridHandler.inc.php
+++ b/controllers/grid/files/SubmissionFilesGridHandler.inc.php
@@ -149,7 +149,7 @@ class SubmissionFilesGridHandler extends GridHandler {
 		// The file name column is common to all file grid types.
 		$this->addColumn(new FileNameGridColumn($capabilities->canViewNotes(), $this->getStageId()));
 
-        // Additional column with file upload date/creation date
+		// Additional column with file upload date/creation date
 		$this->addColumn(new FileDateGridColumn($capabilities->canViewNotes()));
 
 		// Set the no items row text
@@ -216,4 +216,3 @@ class SubmissionFilesGridHandler extends GridHandler {
 	}
 }
 
-?>

--- a/styles/helpers.less
+++ b/styles/helpers.less
@@ -467,3 +467,6 @@
 .pkp_helpers_black_bg {
 	background-color: black;
 }
+
+.pkp_helpers_text_warn    { color: @warn; }
+.pkp_helpers_text_primary { color: black; }


### PR DESCRIPTION
Added a new column to display the supplementary file modification date (format: `date_format_long`). Modification dates for files younger than 7 days are currently highlighted in `color: @warn;`, those younger than 28 days `color: black;` and older files in the default text color (`color: rgb(0,0,0,0.54);`). The color is just a suggestion/idea but not of most importance. 

However, we are convinced that the date is important for the editors/authors to get an overview of the files without always going into the "More information"-tab of several files. Would be nice to see this in one of the next releases (or optional via settings?).