### PR TITLE
Make context check explicit when removing base URLs

### DIFF
--- a/classes/core/Core.inc.php
+++ b/classes/core/Core.inc.php
@@ -260,7 +260,7 @@ class Core {
 			// We found the contextPath using the base_url
 			// config file settings. Check if the url starts
 			// with the context path, if not, prepend it.
-			if (strpos($url, '/' . $contextPath) !== 0) {
+			if (strpos($url, '/' . $contextPath . '/') !== 0) {
 				$url = '/' . $contextPath . $url;
 			}
 		}

--- a/tests/classes/core/CoreTest.inc.php
+++ b/tests/classes/core/CoreTest.inc.php
@@ -49,6 +49,8 @@ class CoreTest extends PKPTestCase {
 		$configData =& Config::getData();
 		$configData['general']['base_url[' . $contextPath . ']'] = $baseUrl;
 		$configData['general']['base_url[test2]'] = $baseUrl . '/test';
+		// edge case: context matches a page
+		$configData['general']['base_url[art]'] = $baseUrl . '/art';
 
 		$actualUrl = Core::removeBaseUrl($url);
 		$this->assertEquals($expectUrl, $actualUrl);
@@ -94,6 +96,9 @@ class CoreTest extends PKPTestCase {
 		// Path info disabled without host and rewrite rules removing index.php.
 		$cases[] = array('http://localhost/ojs', '/ojs?journal=test', '?journal=test');
 
+		// Edge cases
+		$cases[] = array('http://localhost/ojs', 'http://localhost/ojs/index.php/art/article/view/100', '/art/article/view/100');
+
 		return $cases;
 	}
 
@@ -134,6 +139,9 @@ class CoreTest extends PKPTestCase {
 		$cases[] = array('test', 'http://localhost/ojstest', '/ojstest?journal=test&page=index', '/test?journal=test&page=index');
 		// Path info disabled only.
 		$cases[] = array('test', 'http://localhost/ojstest', '/ojstest/index.php?journal=test&page=index', '/test?journal=test&page=index');
+
+		// Edge cases
+		$cases[] = array('art', 'http://localhost', 'http://localhost/art/article/view/100', '/art/article/view/100');
 
 		return $cases;
 	}


### PR DESCRIPTION
Shared library fix for pkp/pkp-lib#4009.