### PR TITLE
pkp/pkp-lib#4024 Allow admins to upload files in the admin settings tabs

### DIFF
--- a/controllers/tab/settings/AdminSettingsTabHandler.inc.php
+++ b/controllers/tab/settings/AdminSettingsTabHandler.inc.php
@@ -25,7 +25,7 @@ class AdminSettingsTabHandler extends SettingsTabHandler {
 	function __construct($additionalTabs = array()) {
 		$role = array(ROLE_ID_SITE_ADMIN);
 
-		$this->addRoleAssignment(ROLE_ID_MANAGER,
+		$this->addRoleAssignment([ROLE_ID_MANAGER, ROLE_ID_SITE_ADMIN],
 			array(
 				'showFileUploadForm',
 				'uploadFile',
@@ -212,5 +212,3 @@ class AdminSettingsTabHandler extends SettingsTabHandler {
 		return $fileUploadForm;
 	}
 }
-
-


### PR DESCRIPTION
`ROLE_ID_MANAGER` does not apply from the site-wide admin form because a user can not have the role outside of a context.