### PR TITLE
 mail::send hook returns true in Mail.inc.php 

### DIFF
--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -450,7 +450,7 @@ class Mail extends DataObject {
 	 * @return boolean
 	 */
 	function send() {
-		if (HookRegistry::call('Mail::send', array($this))) return;
+		if (HookRegistry::call('Mail::send', array($this))) return true;
 
 		// Replace all the private parameters for this message.
 		$mailBody = $this->getBody();


### PR DESCRIPTION
make sure Mail::send returns true when hook is used which causes send to skip using PKP standard mailer. This ensures MassMail works when you use the `Mail::send` hook to skip using the regular PKP mailer and use a plugin to do the emailing for you.