### PR TITLE
pkp/pkp-lib#4139 clarify grid label for declined request

### DIFF
--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.inc.php
@@ -163,7 +163,7 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider {
 			case REVIEW_ASSIGNMENT_STATUS_RESPONSE_OVERDUE:
 				return '<span class="state overdue">'.__('common.overdue').'</span><span class="details">'.__('editor.review.responseDue', array('date' => substr($reviewAssignment->getDateResponseDue(),0,10))).'</span>';
 			case REVIEW_ASSIGNMENT_STATUS_DECLINED:
-				return '<span class="state declined">'.__('common.declined').'</span>';
+				return '<span class="state declined" title="' . __('editor.review.requestDeclined.tooltip') . '">'.__('editor.review.requestDeclined').'</span>';
 			case REVIEW_ASSIGNMENT_STATUS_RECEIVED:
 				return  $this->_getStatusWithRecommendation('editor.review.reviewSubmitted', $reviewAssignment);
 			default:

--- a/locale/en_US/editor.xml
+++ b/locale/en_US/editor.xml
@@ -65,6 +65,8 @@
 	<message key="editor.review.responseDue">Response due: {$date}</message>
 	<message key="editor.review.requestSent">Request Sent</message>
 	<message key="editor.review.requestAccepted">Request Accepted</message>
+    <message key="editor.review.requestDeclined">Request Declined</message>
+    <message key="editor.review.requestDeclined.tooltip">The reviewer declined this review request.</message>
 	<message key="editor.review.revertDecision">Revert Decision</message>
 	<message key="editor.review.reviewDue">Review due: {$date}</message>
 	<message key="editor.review.reviewDueDate">Review Due Date</message>

--- a/locale/en_US/editor.xml
+++ b/locale/en_US/editor.xml
@@ -65,8 +65,8 @@
 	<message key="editor.review.responseDue">Response due: {$date}</message>
 	<message key="editor.review.requestSent">Request Sent</message>
 	<message key="editor.review.requestAccepted">Request Accepted</message>
-    <message key="editor.review.requestDeclined">Request Declined</message>
-    <message key="editor.review.requestDeclined.tooltip">The reviewer declined this review request.</message>
+	<message key="editor.review.requestDeclined">Request Declined</message>
+	<message key="editor.review.requestDeclined.tooltip">The reviewer declined this review request.</message>
 	<message key="editor.review.revertDecision">Revert Decision</message>
 	<message key="editor.review.reviewDue">Review due: {$date}</message>
 	<message key="editor.review.reviewDueDate">Review Due Date</message>


### PR DESCRIPTION
Fix #4139 

This should make it clear to editors that the request for review is declined, not the submission.