### PR TITLE
Adding a missing key to English locale

### DIFF
--- a/locale/en_US/grid.xml
+++ b/locale/en_US/grid.xml
@@ -119,6 +119,7 @@
 	<message key="grid.action.preview">Preview</message>
 	<message key="grid.action.install">Install</message>
 	<message key="grid.action.moreItems">Load more</message>
+	<message key="grid.action.users">View/Select users</message>
 
 	<!--  grid task status -->
 	<message key="grid.task.status.completed">This task is completed</message>


### PR DESCRIPTION
This missing key is for the tool tip shown when hovering the action link (Users) under each record in the list of hosted journals.
It is under the permissions of site admin.