### PR TITLE
fix for a typo in PKPTemplateManager::smartyLoadStylesheet()

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -1433,7 +1433,7 @@ class PKPTemplateManager extends Smarty {
 	function smartyLoadStylesheet($params, $smarty) {
 
 		if (empty($params['context'])) {
-			$context = 'frontend';
+			$params['context'] = 'frontend';
 		}
 
 		$stylesheets = $this->getResourcesByContext($this->_styleSheets, $params['context']);


### PR DESCRIPTION
$context variable isn't used anywhere in this method.