### PR TITLE
minor fix in de_DE locale

### DIFF
--- a/locale/de_DE/common.xml
+++ b/locale/de_DE/common.xml
@@ -394,7 +394,7 @@
 	<message key="locale.supported">Unterstützte Regionaleinstellungen</message>
 	<message key="navigation.access"><![CDATA[Benutzer/innen &amp; Rollen]]></message>
 	<message key="navigation.about">Über uns</message>
-	<message key="navigation.admin">Leitung</message>
+	<message key="navigation.admin">Administration</message>
 	<message key="navigation.archives">Archiv</message>
 	<message key="navigation.breadcrumbLabel">Sie sind hier:</message>
 	<message key="navigation.breadcrumbSeparator">/</message>


### PR DESCRIPTION
* changing translation of adminstration to "Administration" after a receiving a change request
* since the "management" nav item does not exist anymore, this should be clear (key was previously renamed to stress the difference between management and admin
* this will rename a nav item in future releases, but it should be self-explaining