### PR TITLE
An update of tinymceParamDefaults

### DIFF
--- a/js/controllers/SiteHandler.js
+++ b/js/controllers/SiteHandler.js
@@ -148,7 +148,7 @@
 				paste_auto_cleanup_on_paste: true,
 				apply_source_formatting: false,
 				theme: 'modern',
-				toolbar: 'copy paste | bold italic underline | link unlink ' +
+				toolbar: 'copy paste | bold italic underline | bullist numlist | link unlink ' +
 						'code fullscreen | jbimages | pkpTags',
 				richToolbar: 'copy paste | bold italic underline | bullist numlist | ' +
 						'superscript subscript | link unlink code fullscreen | ' +


### PR DESCRIPTION
I think that, as default, 'toolbar' selection of tinyMCE need also 'bullist' and 'numlist'.
I think is not correct to limit them only into 'richToolbar',
In fact 'toolbar' is very much used inside OJS, I think 70%-80% of times.
My fix is only about this.