### PR TITLE
Make user email lookup case insensitive.

### DIFF
--- a/classes/user/PKPUserDAO.inc.php
+++ b/classes/user/PKPUserDAO.inc.php
@@ -127,7 +127,7 @@ class PKPUserDAO extends DAO {
 	 */
 	function &getUserByEmail($email, $allowDisabled = true) {
 		$result = $this->retrieve(
-			'SELECT * FROM users WHERE email = ?' . ($allowDisabled?'':' AND disabled = 0'),
+			'SELECT * FROM users WHERE LOWER(email) = LOWER(?)' . ($allowDisabled?'':' AND disabled = 0'),
 			array($email)
 		);
 


### PR DESCRIPTION
Make email-based user lookup case insensitive.

As discussed in https://forum.pkp.sfu.ca/t/forget-your-password-function-not-working-in-ojs-3-0-1/27063/24