### PR TITLE
pkp#4208 Keyword separator character interferes with Arabic and Cyrillic

### DIFF
--- a/js/lib/jquery/plugins/jquery.tag-it.js
+++ b/js/lib/jquery/plugins/jquery.tag-it.js
@@ -241,7 +241,7 @@
                     // Tab will also create a tag, unless the tag input is empty,
                     // in which case it isn't caught.
                     if (
-                        (event.which === $.ui.keyCode.COMMA && event.shiftKey === false) ||
+                        (event.key === ',' && event.shiftKey === false) ||
                         event.which === $.ui.keyCode.ENTER ||
                         (
                             event.which == $.ui.keyCode.TAB &&


### PR DESCRIPTION
see pkp/pkp-lib#4208 for explanation.