### PR TITLE
pkp/pkp-lib#4340: limit available contexts by user

### DIFF
--- a/classes/context/ContextDAO.inc.php
+++ b/classes/context/ContextDAO.inc.php
@@ -175,6 +175,9 @@ abstract class ContextDAO extends DAO {
 
 	/**
 	 * Retrieve available contexts.
+	 * If user-based contexts, retrieve all contexts assigned by user group
+	 *   or all contexts for site admin
+	 * If not user-based, retrieve all enabled contexts.
 	 * @param $userId int Optional user ID to find available contexts for
 	 * @param $rangeInfo Object optional
 	 * @return DAOResultFactory containing matching Contexts
@@ -188,12 +191,12 @@ abstract class ContextDAO extends DAO {
 
 		$result = $this->retrieveRange(
 			'SELECT c.* FROM ' . $this->_getTableName() . ' c
-			WHERE	c.enabled = 1 ' .
+			WHERE	' .
 				($userId?
-					'OR c.' . $this->_getPrimaryKeyColumn() . ' IN (SELECT DISTINCT ug.context_id FROM user_groups ug JOIN user_user_groups uug ON (ug.user_group_id = uug.user_group_id) WHERE uug.user_id = ?)
-					OR ? IN (SELECT user_id FROM user_groups ug JOIN user_user_groups uug ON (ug.user_group_id = uug.user_group_id) WHERE ug.role_id = ?) '
-				:'') .
-			'ORDER BY seq',
+					'c.' . $this->_getPrimaryKeyColumn() . ' IN (SELECT DISTINCT ug.context_id FROM user_groups ug JOIN user_user_groups uug ON (ug.user_group_id = uug.user_group_id) WHERE uug.user_id = ?)
+					OR ? IN (SELECT user_id FROM user_groups ug JOIN user_user_groups uug ON (ug.user_group_id = uug.user_group_id) WHERE ug.role_id = ?)'
+				:'c.enabled = 1') .
+			' ORDER BY seq',
 			$params,
 			$rangeInfo
 		);


### PR DESCRIPTION
Change logic of "available" contexts from:
Any of:
- an enabled context
- any context in which the user is a member of a user group
- any context, if the user is a site admin

To:
Either:
- if no user, an enabled context
- if a user, either:
  - any context, if the user is SITE_ADMIN
  - any context in which the user is a member of user group 
