### PR TITLE
pkp/pkp-lib#4308 Don't show privacy checkbox if no privacy statement …

### DIFF
--- a/classes/submission/form/PKPSubmissionSubmitStep1Form.inc.php
+++ b/classes/submission/form/PKPSubmissionSubmitStep1Form.inc.php
@@ -16,6 +16,9 @@
 import('lib.pkp.classes.submission.form.SubmissionSubmitForm');
 
 class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
+	/** @var boolean Is there a privacy statement to be confirmed? */
+	public $hasPrivacyStatement = true;
+
 	/**
 	 * Constructor.
 	 * @param $context Context
@@ -23,6 +26,13 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 	 */
 	function __construct($context, $submission = null) {
 		parent::__construct($context, $submission, 1);
+
+		$enableSiteWidePrivacyStatement = Config::getVar('general', 'sitewide_privacy_statement');
+		if (!$enableSiteWidePrivacyStatement && $context) {
+			$this->hasPrivacyStatement = (boolean) $context->getData('privacyStatement');
+		} else {
+			$this->hasPrivacyStatement = (boolean) Application::getRequest()->getSite()->getData('privacyStatement');
+		}
 
 		// Validation checks for this form
 		$supportedSubmissionLocales = $context->getSupportedSubmissionLocales();
@@ -32,7 +42,9 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 			$this->addCheck(new FormValidator($this, 'copyrightNoticeAgree', 'required', 'submission.submit.copyrightNoticeAgreeRequired'));
 		}
 		$this->addCheck(new FormValidator($this, 'userGroupId', 'required', 'submission.submit.availableUserGroupsDescription'));
-		$this->addCheck(new FormValidator($this, 'privacyConsent', 'required', 'user.profile.form.privacyConsentRequired'));
+		if ($this->hasPrivacyStatement) {
+			$this->addCheck(new FormValidator($this, 'privacyConsent', 'required', 'user.profile.form.privacyConsentRequired'));
+		}
 
 		foreach ((array) $context->getLocalizedData('submissionChecklist') as $key => $checklistItem) {
 			$this->addCheck(new FormValidator($this, "checklist-$key", 'required', 'submission.submit.checklistErrors'));
@@ -130,10 +142,13 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 			$noExistingRoles = true;
 		}
 
-		$templateMgr->assign('managerGroups', $managerGroups);
-		$templateMgr->assign('userGroupOptions', $userGroupNames);
-		$templateMgr->assign('defaultGroup', $defaultGroup);
-		$templateMgr->assign('noExistingRoles', $noExistingRoles);
+		$templateMgr->assign([
+			'managerGroups' => $managerGroups,
+			'userGroupOptions' => $userGroupNames,
+			'defaultGroup' => $defaultGroup,
+			'noExistingRoles' => $noExistingRoles,
+			'hasPrivacyStatement' => $this->hasPrivacyStatement,
+		]);
 
 		return parent::fetch($request, $template, $display);
 	}
@@ -264,7 +279,7 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 	 */
 	function execute() {
 		$submissionDao = Application::getSubmissionDAO();
-		$request = Application::getRequest(); 
+		$request = Application::getRequest();
 		$user = $request->getUser();
 		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
 
@@ -345,5 +360,3 @@ class PKPSubmissionSubmitStep1Form extends SubmissionSubmitForm {
 		return $this->submissionId;
 	}
 }
-
-

--- a/pages/about/AboutSiteHandler.inc.php
+++ b/pages/about/AboutSiteHandler.inc.php
@@ -58,7 +58,7 @@ class AboutSiteHandler extends Handler {
 		if (!$enableSiteWidePrivacyStatement && $context) {
 			$privacyStatement = $context->getLocalizedData('privacyStatement');
 		} else {
-			$privacyStatement = $request->getSite()->getLocalizedSetting('privacyStatement');
+			$privacyStatement = $request->getSite()->getLocalizedData('privacyStatement');
 		}
 		if (!$privacyStatement) {
 			$dispatcher = $this->getDispatcher();
@@ -69,5 +69,3 @@ class AboutSiteHandler extends Handler {
 		$templateMgr->display('frontend/pages/privacy.tpl');
 	}
 }
-
-

--- a/templates/frontend/pages/privacy.tpl
+++ b/templates/frontend/pages/privacy.tpl
@@ -13,7 +13,7 @@
 
 <div class="page page_privacy">
 	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey="manager.setup.privacyStatement"}
-	{$currentContext->getLocalizedData('privacyStatement')}
+	{$privacyStatement}
 </div><!-- .page -->
 
 {include file="frontend/components/footer.tpl"}

--- a/templates/submission/form/step1.tpl
+++ b/templates/submission/form/step1.tpl
@@ -91,11 +91,13 @@
 	{/if}
 
 	{* Privacy Statement *}
-	{fbvFormSection list="true"}
-		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
-		{capture assign="privacyLabel"}{translate key="user.register.form.privacyConsent" privacyUrl=$privacyUrl}{/capture}
-		{fbvElement type="checkbox" id="privacyConsent" required=true value=1 label=$privacyLabel translate=false checked=$privacyConsent}
-	{/fbvFormSection}
+	{if $hasPrivacyStatement}
+		{fbvFormSection list="true"}
+			{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+			{capture assign="privacyLabel"}{translate key="user.register.form.privacyConsent" privacyUrl=$privacyUrl}{/capture}
+			{fbvElement type="checkbox" id="privacyConsent" required=true value=1 label=$privacyLabel translate=false checked=$privacyConsent}
+		{/fbvFormSection}
+	{/if}
 
 	{* Buttons *}
 	{fbvFormButtons id="step1Buttons" submitText="common.saveAndContinue"}


### PR DESCRIPTION
…exists

This commit hides the privacy consent checkbox during submission if no
privacy statement exists. It also fixes errors in how the privacy statement
page displays when sitewide_privacy_statement is On, which were intrudced
with a faulty rebase for #3594.