### PR TITLE
pkp/pkp-lib#4323 Compatibility with old paths to templates

### DIFF
--- a/classes/plugins/Plugin.inc.php
+++ b/classes/plugins/Plugin.inc.php
@@ -375,6 +375,7 @@ abstract class Plugin {
 	 *			override template.
 	 *		@option string Template file requested
 	 * ]
+	 * @return boolean
 	 */
 	public function _overridePluginTemplates($hookName, $args) {
 		$filePath =& $args[0];
@@ -390,7 +391,15 @@ abstract class Plugin {
 
 		// Check if an overriding plugin exists in the plugin path.
 		$checkPluginPath = sprintf('%s/%s', $this->getPluginPath(), $checkFilePath);
-		if (file_exists($checkPluginPath)) $filePath = $checkPluginPath;
+		if (file_exists($checkPluginPath)) {
+			$filePath = $checkPluginPath;
+			// Backward compatibility for OJS prior to 3.1.2; changed path to templates for plugins.
+		} else {
+			$checkPluginPath = preg_replace("/templates\/(?!.*templates\/)/", "", $checkPluginPath);
+			if (file_exists($checkPluginPath)) {
+				$filePath = $checkPluginPath;
+			}
+		}
 
 		return false;
 	}

--- a/classes/plugins/Plugin.inc.php
+++ b/classes/plugins/Plugin.inc.php
@@ -397,6 +397,7 @@ abstract class Plugin {
 		} else {
 			$checkPluginPath = preg_replace("/templates\/(?!.*templates\/)/", "", $checkPluginPath);
 			if (file_exists($checkPluginPath)) {
+				error_log("Deprecated: The path to the template overridden from " . $checkPluginPath . " has changed, the compatibility will be removed in the future.");
 				$filePath = $checkPluginPath;
 			}
 		}


### PR DESCRIPTION
From OJS 3.1.2 templates for block plugins and several generic plugins were moved inside `templates` dir. I've added a check to the old template path for overriding. Didn't figure out any better regex than with negative lookahead.  