### PR TITLE
pkp/pkp-lib#4462: Check for preferred and primary locale within Context setting

### DIFF
--- a/classes/context/Context.inc.php
+++ b/classes/context/Context.inc.php
@@ -330,12 +330,26 @@ class Context extends DataObject {
 	/**
 	 * Get a localized context setting by name.
 	 * @param $name string
+	 * @param $preferredLocale string
 	 * @return mixed
 	 */
-	function &getLocalizedSetting($name) {
+	function &getLocalizedSetting($name, $preferredLocale = null) {
+		// Best is the requested locale, if applicable
+		if ($preferredLocale !== null) {
+			$returner = $this->getSetting($name, $preferredLocale);
+			if ($returner !== null) {
+				return $returner;
+			}
+		}
+		// Otherwise, try the user's locale
 		$returner = $this->getSetting($name, AppLocale::getLocale());
 		if ($returner === null) {
-			$returner = $this->getSetting($name, AppLocale::getPrimaryLocale());
+			// Otherwise, try this context's primary locale
+			$returner = $this->getSetting($name, $this->getPrimaryLocale());
+			if ($returner === null) {
+				// Fall back to the current context's primary locale, as an unlikely legacy fallback
+				$returner = $this->getSetting($name, AppLocale::getPrimaryLocale());
+			}
 		}
 		return $returner;
 	}


### PR DESCRIPTION
resolves pkp/pkp-lib#4462.

Not for consideration in forward porting to 3.2.
