### PR TITLE
pkp/pkp-lib#3691 default CSS for HTML galleys for stable-3.1.1

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -1496,6 +1496,48 @@ class PKPTemplateManager extends Smarty {
 	}
 
 	/**
+	 * Inject default styles into a HTML galley
+	 *
+	 * Any styles assigned to the `htmlGalley` context will be injected into the
+	 * galley unless the galley already has an embedded CSS file.
+	 *
+	 * @param $htmlContent string The HTML file content
+	 * @param $embeddedFiles array Additional files embedded in this galley
+	 */
+	function loadHtmlGalleyStyles($htmlContent, $embeddedFiles) {
+		
+		if (empty($htmlContent)) {
+			return $htmlContent;
+		}
+		
+		$hasEmbeddedStyle = false;
+		foreach ($embeddedFiles as $embeddedFile) {
+			if ($embeddedFile->getFileType() === 'text/css') {
+				$hasEmbeddedStyle = true;
+				break;
+			}
+		}
+		
+		if ($hasEmbeddedStyle) {
+			return $htmlContent;
+		}
+		
+		$links = '';
+		$styles = $this->getResourcesByContext($this->_styleSheets, 'htmlGalley');
+		
+		if (!empty($styles)) {
+			ksort($styles);
+			foreach ($styles as $priorityGroup) {
+				foreach ($priorityGroup as $htmlStyle) {
+					$links .= '<link rel="stylesheet" href="' . $htmlStyle['style'] . '" type="text/css">' . "\n";
+				}
+			}
+		}
+		
+		return str_ireplace('<head>', '<head>' . "\n" . $links, $htmlContent);
+	}
+
+	/**
 	 * Smarty usage: {load_script context="backend" scripts=$scripts}
 	 *
 	 * Custom Smarty function for printing scripts attached to a context.


### PR DESCRIPTION
Implementation for the default CSS for HTML galleys (ojs-stable-3_1_1) alongside with corresponent commit to ojs repo