### PR TITLE
Updated templates + minor corrections.

### DIFF
--- a/classes/controllers/grid/plugins/PluginGridHandler.inc.php
+++ b/classes/controllers/grid/plugins/PluginGridHandler.inc.php
@@ -357,6 +357,7 @@ abstract class PluginGridHandler extends CategoryGridHandler {
 		$user = $request->getUser();
 
 		if ($installedPlugin) {
+			$pluginName = array('pluginName' => $plugin->getDisplayName());
 			$pluginDest = Core::getBaseDir() . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . $category . DIRECTORY_SEPARATOR . $productName;
 			$pluginLibDest = Core::getBaseDir() . DIRECTORY_SEPARATOR . PKP_LIB_PATH . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . $category . DIRECTORY_SEPARATOR . $productName;
 
@@ -369,13 +370,13 @@ abstract class PluginGridHandler extends CategoryGridHandler {
 			}
 
 			if(is_dir($pluginDest) || is_dir($pluginLibDest)) {
-				$notificationMgr->createTrivialNotification($user->getId(), NOTIFICATION_TYPE_ERROR, array('contents' => __('manager.plugins.deleteError', array('pluginName' => $plugin->getDisplayName()))));
+				$notificationMgr->createTrivialNotification($user->getId(), NOTIFICATION_TYPE_ERROR, array('contents' => __('manager.plugins.deleteError', $pluginName)));
 			} else {
 				$versionDao->disableVersion('plugins.'.$category, $productName);
-				$notificationMgr->createTrivialNotification($user->getId(), NOTIFICATION_TYPE_SUCCESS, array('contents' => __('manager.plugins.deleteSuccess', array('pluginName' => $plugin->getDisplayName()))));
+				$notificationMgr->createTrivialNotification($user->getId(), NOTIFICATION_TYPE_SUCCESS, array('contents' => __('manager.plugins.deleteSuccess', $pluginName)));
 			}
 		} else {
-			$notificationMgr->createTrivialNotification($user->getId(), NOTIFICATION_TYPE_ERROR, array('contents' => __('manager.plugins.doesNotExist', array('pluginName' => $plugin->getDisplayName()))));
+			$notificationMgr->createTrivialNotification($user->getId(), NOTIFICATION_TYPE_ERROR, array('contents' => __('manager.plugins.doesNotExist', $pluginName)));
 		}
 
 		return DAO::getDataChangedEvent($plugin->getName());

--- a/classes/plugins/PluginHelper.inc.php
+++ b/classes/plugins/PluginHelper.inc.php
@@ -66,7 +66,7 @@ class PluginHelper {
 			$returnCode = 0;
 			exec($tarBinary.' -xzf ' . escapeshellarg($filePath) . ' -C ' . escapeshellarg($pluginExtractDir), $output, $returnCode);
 			if ($returnCode) {
-				$errorMsg = __('common.invalidFileType');
+				$errorMsg = __('form.dropzone.dictInvalidFileType');
 			}
 		} else {
 			$errorMsg = __('manager.plugins.tarCommandNotFound');

--- a/controllers/grid/settings/user/UserGridHandler.inc.php
+++ b/controllers/grid/settings/user/UserGridHandler.inc.php
@@ -529,7 +529,7 @@ class UserGridHandler extends GridHandler {
 			$userEmailForm->execute();
 			return new JSONMessage(true);
 		} else {
-			return new JSONMessage(false, $userEmailForm->fetch($request));
+			return new JSONMessage(false, __('validator.filled'));
 		}
 	}
 

--- a/templates/controllers/grid/files/copyedit/manageCopyeditFiles.tpl
+++ b/templates/controllers/grid/files/copyedit/manageCopyeditFiles.tpl
@@ -8,16 +8,16 @@
  * Allows users to manage the list of copyedit files, potentially adding more
  *}
 
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#manageCopyeditFilesForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
 	{rdelim});
 </script>
 
-<!-- Current copyedited files -->
-<div id="existingFilesContainer">
-	<form class="pkp_form" id="manageCopyeditFilesForm" action="{url component="grid.files.copyedit.ManageCopyeditFilesGridHandler" op="updateCopyeditFiles" submissionId=$submissionId stageId=$smarty.const.WORKFLOW_STAGE_ID_EDITING}" method="post">
+<form class="pkp_form" id="manageCopyeditFilesForm" action="{url component="grid.files.copyedit.ManageCopyeditFilesGridHandler" op="updateCopyeditFiles" submissionId=$submissionId stageId=$smarty.const.WORKFLOW_STAGE_ID_EDITING}" method="post">
+	<!-- Current copyedited files -->
+	<div id="existingFilesContainer">
 		{csrf}
 		{fbvFormArea id="manageCopyeditFiles"}
 			{fbvFormSection}
@@ -27,5 +27,5 @@
 
 			{fbvFormButtons}
 		{/fbvFormArea}
-	</form>
-</div>
+	</div>
+</form>

--- a/templates/controllers/grid/files/final/manageFinalDraftFiles.tpl
+++ b/templates/controllers/grid/files/final/manageFinalDraftFiles.tpl
@@ -8,16 +8,16 @@
  * Allows editor to add more file to the review (that weren't added when the submission was sent to review)
  *}
 
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#manageFinalDraftFilesForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
 	{rdelim});
 </script>
 
-<!-- Current final draft files -->
-<div id="existingFilesContainer">
-	<form class="pkp_form" id="manageFinalDraftFilesForm" action="{url component="grid.files.final.ManageFinalDraftFilesGridHandler" op="updateFinalDraftFiles" submissionId=$submissionId}" method="post">
+<form class="pkp_form" id="manageFinalDraftFilesForm" action="{url component="grid.files.final.ManageFinalDraftFilesGridHandler" op="updateFinalDraftFiles" submissionId=$submissionId}" method="post">
+	<!-- Current final draft files -->
+	<div id="existingFilesContainer">
 		{csrf}
 		{fbvFormArea id="manageFinalDraftFiles"}
 			{fbvFormSection}
@@ -29,5 +29,5 @@
 
 			{fbvFormButtons}
 		{/fbvFormArea}
-	</form>
-</div>
+	</div>
+</form>

--- a/templates/controllers/grid/files/proof/manageProofFiles.tpl
+++ b/templates/controllers/grid/files/proof/manageProofFiles.tpl
@@ -8,18 +8,18 @@
  * Allows editor to add more files to the publication format
  *}
 
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#manageProofFilesForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
 	{rdelim});
 </script>
 
-<!-- Current proof files -->
-<p>{translate key="editor.submission.proof.manageProofFilesDescription"}</p>
+<form class="pkp_form" id="manageProofFilesForm" action="{url component="grid.files.proof.ManageProofFilesGridHandler" op="updateProofFiles" submissionId=$submissionId}" method="post">
+	<!-- Current proof files -->
+	<p>{translate key="editor.submission.proof.manageProofFilesDescription"}</p>
 
-<div id="existingFilesContainer">
-	<form class="pkp_form" id="manageProofFilesForm" action="{url component="grid.files.proof.ManageProofFilesGridHandler" op="updateProofFiles" submissionId=$submissionId}" method="post">
+	<div id="existingFilesContainer">
 		{csrf}
 		{fbvFormArea id="manageProofFiles"}
 			{fbvFormSection}
@@ -32,5 +32,5 @@
 
 			{fbvFormButtons}
 		{/fbvFormArea}
-	</form>
-</div>
+	</div>
+</form>

--- a/templates/controllers/grid/files/query/manageQueryNoteFiles.tpl
+++ b/templates/controllers/grid/files/query/manageQueryNoteFiles.tpl
@@ -8,18 +8,18 @@
  * Allows users to manage the list of files available to a query.
  *}
 
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#manageQueryNoteFilesForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
 	{rdelim});
 </script>
 
-<!-- Current query files -->
-<p>{translate key="editor.submission.query.manageQueryNoteFilesDescription"}</p>
+<form class="pkp_form" id="manageQueryNoteFilesForm" action="{url component="grid.files.query.ManageQueryNoteFilesGridHandler" op="updateQueryNoteFiles" params=$actionArgs submissionId=$submissionId queryId=$queryId noteId=$noteId stageId=$smarty.const.WORKFLOW_STAGE_ID_EDITING}" method="post">
+	<!-- Current query files -->
+	<p>{translate key="editor.submission.query.manageQueryNoteFilesDescription"}</p>
 
-<div id="existingFilesContainer">
-	<form class="pkp_form" id="manageQueryNoteFilesForm" action="{url component="grid.files.query.ManageQueryNoteFilesGridHandler" op="updateQueryNoteFiles" params=$actionArgs submissionId=$submissionId queryId=$queryId noteId=$noteId stageId=$smarty.const.WORKFLOW_STAGE_ID_EDITING}" method="post">
+	<div id="existingFilesContainer">
 		{csrf}
 		{fbvFormArea id="manageQueryNoteFiles"}
 			{fbvFormSection}
@@ -29,5 +29,5 @@
 
 			{fbvFormButtons}
 		{/fbvFormArea}
-	</form>
-</div>
+	</div>
+</form>

--- a/templates/controllers/grid/files/review/manageReviewFiles.tpl
+++ b/templates/controllers/grid/files/review/manageReviewFiles.tpl
@@ -8,20 +8,19 @@
  * Allows editor to add more file to the review (that weren't added when the submission was sent to review)
  *}
 
-
-<!-- Current review files -->
-<div id="existingFilesContainer">
-	<script type="text/javascript">
-		$(function() {ldelim}
-			// Attach the form handler.
-			$('#manageReviewFilesForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
-		{rdelim});
-	</script>
-	<form class="pkp_form" id="manageReviewFilesForm" action="{url component="grid.files.review.ManageReviewFilesGridHandler" op="updateReviewFiles" submissionId=$submissionId|escape stageId=$stageId|escape reviewRoundId=$reviewRoundId|escape}" method="post">
+<script>
+	$(function() {ldelim}
+		// Attach the form handler.
+		$('#manageReviewFilesForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
+	{rdelim});
+</script>
+<form class="pkp_form" id="manageReviewFilesForm" action="{url component="grid.files.review.ManageReviewFilesGridHandler" op="updateReviewFiles" submissionId=$submissionId|escape stageId=$stageId|escape reviewRoundId=$reviewRoundId|escape}" method="post">
+	<!-- Current review files -->
+	<div id="existingFilesContainer">
 		{csrf}
 		<!-- Available submission files -->
 		{capture assign=availableReviewFilesGridUrl}{url router=$smarty.const.ROUTE_COMPONENT component="grid.files.review.ManageReviewFilesGridHandler" op="fetchGrid" submissionId=$submissionId stageId=$stageId reviewRoundId=$reviewRoundId escape=false}{/capture}
 		{load_url_in_div id="availableReviewFilesGrid" url=$availableReviewFilesGridUrl}
 		{fbvFormButtons}
-	</form>
-</div>
+	</div>
+</form>

--- a/templates/controllers/grid/settings/user/form/userEmailForm.tpl
+++ b/templates/controllers/grid/settings/user/form/userEmailForm.tpl
@@ -7,7 +7,7 @@
  *
  * Display form to send user an email.
  *}
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#sendEmailForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
@@ -31,5 +31,6 @@
 	{/fbvFormSection}
 
 	{fbvFormButtons submitText="common.sendEmail"}
+
+	<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
 </form>
-<p><span class="formRequired">{translate key="common.requiredField"}</span></p>

--- a/templates/controllers/informationCenter/newNoteForm.tpl
+++ b/templates/controllers/informationCenter/newNoteForm.tpl
@@ -8,7 +8,7 @@
  * Display submission file notes/note form in information center.
  *}
 
-<script type="text/javascript">
+<script>
 	// Attach the Notes handler.
 	$(function() {ldelim}
 		$('#newNoteForm').pkpHandler(
@@ -20,12 +20,12 @@
 	{rdelim});
 </script>
 
-<div id="newNoteContainer">
-	<form class="pkp_form" id="newNoteForm" action="{url router=$smarty.const.ROUTE_COMPONENT op="saveNote" params=$linkParams}" method="post">
+<form class="pkp_form" id="newNoteForm" action="{url router=$smarty.const.ROUTE_COMPONENT op="saveNote" params=$linkParams}" method="post">
+	<div id="newNoteContainer">
 		{csrf}
 		{fbvFormSection title="informationCenter.addNote" for="newNote"}
 			{fbvElement type="textarea" id="newNote"}
 		{/fbvFormSection}
 		{fbvFormButtons hideCancel=true submitText=$submitNoteText}
-	</form>
-</div>
+	</div>
+</form>

--- a/templates/controllers/modals/editorDecision/form/initiateExternalReviewForm.tpl
+++ b/templates/controllers/modals/editorDecision/form/initiateExternalReviewForm.tpl
@@ -8,16 +8,16 @@
  * Form used to initiate the first review round.
  *
  *}
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#initiateReview').pkpHandler('$.pkp.controllers.form.AjaxFormHandler', null);
 	{rdelim});
 </script>
 
-<p>{translate key="editor.submission.externalReviewDescription"}</p>
 <form class="pkp_form" id="initiateReview" method="post" action="{url op="saveExternalReview"}" >
+	<p>{translate key="editor.submission.externalReviewDescription"}</p>
+
 	{csrf}
 	<input type="hidden" name="submissionId" value="{$submissionId|escape}" />
 	<input type="hidden" name="stageId" value="{$stageId|escape}" />

--- a/templates/controllers/modals/editorDecision/form/newReviewRoundForm.tpl
+++ b/templates/controllers/modals/editorDecision/form/newReviewRoundForm.tpl
@@ -8,16 +8,16 @@
  * Form used to create a new review round (after the first round)
  *
  *}
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#newRoundForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler', null);
 	{rdelim});
 </script>
 
-<p>{translate key="editor.submission.newRoundDescription"}</p>
 <form class="pkp_form" id="newRoundForm" method="post" action="{url op="saveNewReviewRound"}" >
+	<p>{translate key="editor.submission.newRoundDescription"}</p>
+
 	{csrf}
 	<input type="hidden" name="submissionId" value="{$submissionId|escape}" />
 	<input type="hidden" name="stageId" value="{$stageId|escape}" />
@@ -31,4 +31,3 @@
 
 	{fbvFormButtons submitText="editor.submission.createNewRound"}
 </form>
-

--- a/templates/management/tools/permissions.tpl
+++ b/templates/management/tools/permissions.tpl
@@ -8,26 +8,26 @@
  * Display the permissions tool page.
  *
  *}
-<div class="pkp_page_content pkp_page_permissions">
-	{help file="tools" class="pkp_help_tab"}
+<script>
+$(function() {ldelim}
+	// Attach the form handler.
+	$('#resetPermissionsForm').pkpHandler(
+		'$.pkp.controllers.form.AjaxFormHandler',
+		{ldelim}
+			confirmText: {translate|json_encode key="manager.setup.resetPermissions.confirm"},
+		{rdelim}
+	);
+{rdelim});
+</script>
 
-	<h3>{translate key="manager.setup.resetPermissions"}</h3>
-	<p>{translate key="manager.setup.resetPermissions.description"}</p>
+<form class="pkp_form" id="resetPermissionsForm" method="post" action="{url router=$smarty.const.ROUTE_PAGE page="management" op="tools" path="resetPermissions"}">
+	<div class="pkp_page_content pkp_page_permissions">
+		{help file="tools" class="pkp_help_tab"}
 
-	<script type="text/javascript">
-	$(function() {ldelim}
-		// Attach the form handler.
-		$('#resetPermissionsForm').pkpHandler(
-			'$.pkp.controllers.form.AjaxFormHandler',
-			{ldelim}
-				confirmText: {translate|json_encode key="manager.setup.resetPermissions.confirm"},
-			{rdelim}
-		);
-	{rdelim});
-	</script>
+		<h3>{translate key="manager.setup.resetPermissions"}</h3>
+		<p>{translate key="manager.setup.resetPermissions.description"}</p>
 
-	<form class="pkp_form" id="resetPermissionsForm" method="post" action="{url router=$smarty.const.ROUTE_PAGE page="management" op="tools" path="resetPermissions"}">
 		{csrf}
 		{fbvElement type="submit" id="resetPermissionsFormButton" label="manager.setup.resetPermissions"}
-	</form>
-</div>
+	</div>
+</form>

--- a/templates/manager/reviewForms/previewReviewForm.tpl
+++ b/templates/manager/reviewForms/previewReviewForm.tpl
@@ -8,10 +8,7 @@
  * Preview of a review form.
  *
  *}
-<h3>{$title|escape}</h3>
-<p>{$description}</p>
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#previewReviewForm').pkpHandler(
@@ -24,5 +21,8 @@
 </script>
 
 <form class="pkp_form" id="previewReviewForm" method="post" action="#">
+	<h3>{$title|escape}</h3>
+	<p>{$description}</p>
+
 	{include file="reviewer/review/reviewFormResponse.tpl"}
 </form>

--- a/templates/user/apiProfileForm.tpl
+++ b/templates/user/apiProfileForm.tpl
@@ -8,10 +8,7 @@
  * Public user profile form.
  *}
 
-{* Help Link *}
-{help file="user-profile" class="pkp_help_tab"}
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#apiProfileForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
@@ -19,6 +16,9 @@
 </script>
 
 <form class="pkp_form" id="apiProfileForm" method="post" action="{url op="saveAPIProfile"}" enctype="multipart/form-data">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
 
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="apiProfileNotification"}

--- a/templates/user/changePassword.tpl
+++ b/templates/user/changePassword.tpl
@@ -7,10 +7,6 @@
  *
  * Form to change a user's password.
  *}
-
-{* Help Link *}
-{help file="user-profile" class="pkp_help_tab"}
-
 <script>
 	$(function() {ldelim}
 		// Attach the form handler.
@@ -19,6 +15,9 @@
 </script>
 
 <form class="pkp_form" id="changePasswordForm" method="post" action="{url op="savePassword"}">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
 
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="changePasswordFormNotification"}

--- a/templates/user/contactForm.tpl
+++ b/templates/user/contactForm.tpl
@@ -7,11 +7,7 @@
  *
  * User profile form.
  *}
-
-{* Help Link *}
-{help file="user-profile" class="pkp_help_tab"}
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#contactForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
@@ -19,6 +15,9 @@
 </script>
 
 <form class="pkp_form" id="contactForm" method="post" action="{url op="saveContact"}">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
 
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="contactFormNotification"}

--- a/templates/user/identityForm.tpl
+++ b/templates/user/identityForm.tpl
@@ -8,10 +8,7 @@
  * User profile form.
  *}
 
-{* Help Link *}
-{help file="user-profile" class="pkp_help_tab"}
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#identityForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
@@ -19,6 +16,9 @@
 </script>
 
 <form class="pkp_form" id="identityForm" method="post" action="{url op="saveIdentity"}" enctype="multipart/form-data">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
 
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="identityFormNotification"}

--- a/templates/user/notificationSettingsForm.tpl
+++ b/templates/user/notificationSettingsForm.tpl
@@ -7,11 +7,7 @@
  *
  * User profile form.
  *}
-
-{* Help Link *}
-{help file="user-profile" class="pkp_help_tab"}
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#notificationSettingsForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler', {ldelim}
@@ -26,9 +22,12 @@
 	{rdelim});
 </script>
 
-<p>{translate key="notification.settingsDescription"}</p>
-
 <form class="pkp_form" id="notificationSettingsForm" method="post" action="{url op="saveNotificationSettings"}" enctype="multipart/form-data">
+	<p>{translate key="notification.settingsDescription"}</p>
+	
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
 
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="notificationSettingsFormNotification"}

--- a/templates/user/rolesForm.tpl
+++ b/templates/user/rolesForm.tpl
@@ -7,11 +7,7 @@
  *
  * Roles area of user profile form tabset.
  *}
-
-{* Help Link *}
-{help file="user-profile" class="pkp_help_tab"}
-
-<script type="text/javascript">
+<script>
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#rolesForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
@@ -19,6 +15,9 @@
 </script>
 
 <form class="pkp_form" id="rolesForm" method="post" action="{url op="saveRoles"}" enctype="multipart/form-data">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
 
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="rolesFormNotification"}


### PR DESCRIPTION
- Templates using the AjaxFormHandler had their content moved into the `<form>` to avoid displaying duplicated content in case there's a submit error (pkp/pkp-lib#4533), also removed the type attribute from the `<script>` tag
- Fixed the notification message when removing a plugin (pkp/pkp-lib#4532)
- PluginHelper.inc.php: replaced an invalid translation key when uploading an invalid file type
- UserGridHandler.inc.php: replaced an invalid error message (the HTML content of the form was being displayed in an alert) by the text "validator.filled"