### PR TITLE
Replace call to preg_replace with preg_replace callback - OJS 2 on PHP 7

### DIFF
--- a/classes/core/PKPString.inc.php
+++ b/classes/core/PKPString.inc.php
@@ -719,8 +719,9 @@ class PKPString {
 		$str = strtr($str, PKPString::getHTMLEntities());
 
 		// use PCRE-aware replace function to replace numeric entities
-		$str = PKPString::regexp_replace('~&#x([0-9a-f]+);~ei', 'PKPString::code2utf(hexdec("\\1"))', $str);
-		$str = PKPString::regexp_replace('~&#([0-9]+);~e', 'PKPString::code2utf(\\1)', $str);
+                $str = PKPString::regexp_replace_callback('~&#x([0-9a-f]+);~i', function ($matches) { return PKPString::code2utf(hexdec($matches[0])); }, $str);
+                $str = PKPString::regexp_replace_callback('~&#([0-9]+);~', function ($matches) { return PKPString::code2utf(matches[0]); }, $str);
+
 
 		return $str;
 	}


### PR DESCRIPTION
This fixes the call to preg_replace() with a deprecated /e flag on PHP 7 by changing it to a preg_replace_callback() instead.

Please see this forum thread for more details: https://forum.pkp.sfu.ca/t/import-peer-reviews-button-template-field-names-missing/52383

The fix turned out to be a bit simpler than I originally suggested in that thread. It does not appear to have any negative side-effects elsewhere, and the "Import Peer Reviews" button works again.