### PR TITLE
pkp/pkp-lib#4722: Cast Stringy\Stringy objects as strings in PKPString.

### DIFF
--- a/classes/core/PKPString.inc.php
+++ b/classes/core/PKPString.inc.php
@@ -151,6 +151,7 @@ class PKPString {
 	 * @see http://ca.php.net/manual/en/function.strrpos.php
 	 * @param $haystack string Haystack to search
 	 * @param $needle string Needle to search haystack for
+	 * @return int Last index of Needle in Haystack
 	 */
 	static function strrpos($haystack, $needle) {
 		return Stringy\Stringy::create($haystack)->indexOfLast($needle);
@@ -164,7 +165,7 @@ class PKPString {
 	 * @return string Substring of $string
 	 */
 	static function substr($string, $start, $length = null) {
-		return Stringy\Stringy::create($string)->substr($start, $length);
+		return (string) Stringy\Stringy::create($string)->substr($start, $length);
 	}
 
 	/**
@@ -173,7 +174,7 @@ class PKPString {
 	 * @return string Lower case version of input string
 	 */
 	static function strtolower($string) {
-		return Stringy\Stringy::create($string)->toLowerCase();
+		return (string) Stringy\Stringy::create($string)->toLowerCase();
 	}
 
 	/**
@@ -182,7 +183,7 @@ class PKPString {
 	 * @return string Upper case version of input string
 	 */
 	static function strtoupper($string) {
-		return Stringy\Stringy::create($string)->toUpperCase();
+		return (string) Stringy\Stringy::create($string)->toUpperCase();
 	}
 
 	/**
@@ -191,7 +192,7 @@ class PKPString {
 	 * @return string ucfirst version of input string
 	 */
 	static function ucfirst($string) {
-		return Stringy\Stringy::create($string)->upperCaseFirst();
+		return (string) Stringy\Stringy::create($string)->upperCaseFirst();
 	}
 
 	/**


### PR DESCRIPTION
Resolves pkp/pkp-lib#4722.

Suitable to merge into stable-3_1_2 as well.