### PR TITLE
pkp/pkp-lib#4756: Create NMI custom page URL via page/op/path instead of handler

### DIFF
--- a/classes/services/PKPNavigationMenuService.inc.php
+++ b/classes/services/PKPNavigationMenuService.inc.php
@@ -328,11 +328,16 @@ class PKPNavigationMenuService {
 					break;
 				case NMI_TYPE_CUSTOM:
 					if ($navigationMenuItem->getPath()) {
+						$path = explode("/", $navigationMenuItem->getPath());
+						$page = array_shift($path);
+						$op = array_shift($path);
 						$navigationMenuItem->setUrl($dispatcher->url(
 							$request,
 							ROUTE_PAGE,
 							null,
-							$navigationMenuItem->getPath()
+							$page,
+							$op,
+							$path
 						));
 					}
 					break;


### PR DESCRIPTION
Resolves pkp/pkp-lib#4756 for stable 3.1.2