### PR TITLE
Fixes pkp/pkp-lib#4780, pkp/pkp-lib#4783 and pkp/pkp-lib#4784

### DIFF
--- a/controllers/grid/queries/form/QueryForm.inc.php
+++ b/controllers/grid/queries/form/QueryForm.inc.php
@@ -231,7 +231,7 @@ class QueryForm extends Form {
 				}
 
 				// if current user is editor, add all reviewers
-				if ( $user->hasRole(array(ROLE_ID_MANAGER), $context->getId()) || $user->hasRole(array(ROLE_ID_SITE_ADMIN), CONTEXT_SITE) || array_intersect(array(ROLE_ID_SUB_EDITOR), $userRoles) ) {
+				if ($user->hasRole(array(ROLE_ID_MANAGER), $context->getId()) || $user->hasRole(array(ROLE_ID_SITE_ADMIN), CONTEXT_SITE) || array_intersect(array(ROLE_ID_SUB_EDITOR), $userRoles)) {
 					foreach ($reviewAssignments as $reviewAssignment) {
 						$includeUsers[] = $reviewAssignment->getReviewerId();
 					}
@@ -293,7 +293,9 @@ class QueryForm extends Form {
 							$userRoles[] =  __('user.role.reviewer') . " (" . __($assignment->getReviewMethodKey()) . ")";
 						}
 					}
-
+					if (!count($userRoles)) {
+						$userRoles[] = __('submission.status.unassigned');
+					}
 					$items[] = [
 						'id' => $user->getId(),
 						'title' => __('submission.query.participantTitle', [

--- a/locale/en_US/grid.xml
+++ b/locale/en_US/grid.xml
@@ -88,6 +88,7 @@
 	<message key="grid.action.notify">Notify this user</message>
 	<message key="grid.action.addUserGroup">Add a new User Group</message>
 	<message key="grid.action.editUserGroup">Edit this user group</message>
+	<message key="grid.action.removeUserGroup">Remove this user group</message>
 	<message key="grid.action.disable">Disable</message>
 	<message key="grid.action.details">View this item</message>
 	<message key="grid.action.enrolExisting">Enrol an existing user as a reviewer</message>

--- a/pages/help/HelpHandler.inc.php
+++ b/pages/help/HelpHandler.inc.php
@@ -58,7 +58,7 @@ class HelpHandler extends Handler {
 		// Use a URL filter to prepend the current path to relative URLs.
 		$parser = new \Michelf\Markdown;
 		$parser->url_filter_func = function ($url) use ($filename) {
-			return dirname($filename) . '/' . $url;
+			return (empty(parse_url($url)['host']) ? dirname($filename) . '/' : '') . $url;
 		};
 		return new JSONMessage(
 			true,


### PR DESCRIPTION
Fixes pkp/pkp-lib#4780, pkp/pkp-lib#4783 and pkp/pkp-lib#4784 by respectively checking absolute URLs in the code that fixes relative URLs, creating the missing locale key and setting a "placeholder" for the role name.