### PR TITLE
Bring forward AppLocale inicialization to fix web_cache bug

### DIFF
--- a/classes/core/Dispatcher.inc.php
+++ b/classes/core/Dispatcher.inc.php
@@ -90,6 +90,8 @@ class Dispatcher {
 		$routerNames = $this->getRouterNames();
 		assert(count($routerNames) > 0);
 
+		AppLocale::initialize($request);
+
 		// Go through all configured routers by priority
 		// and find out whether one supports the incoming request
 		foreach($routerNames as $shortcut => $routerCandidateName) {
@@ -128,7 +130,6 @@ class Dispatcher {
 			}
 		}
 
-		AppLocale::initialize($request);
 		PluginRegistry::loadCategory('generic', true);
 
 		$router->route($request);


### PR DESCRIPTION
We are in an OJS instalation and have enabled web_cache for testing purposes recently. Unfortunately, public pages fail when the web cache is active. This is a fix for the problem.

Explanation:
When web_cache config option is enabled (classes/core/Dispatcher.inc.php:121) the call to _displayCached method calls in turn to PKPPageRouter::getCacheFilename, which needs AppLocale had been initialized (classes/core/PKPPageRouter.inc.php:127), but it is not.

The fix just bring forward the AppLocale initialization to the begining of dispatch method.