### PR TITLE
bugfix: Too few arguments to function

### DIFF
--- a/classes/services/UserService.inc.php
+++ b/classes/services/UserService.inc.php
@@ -242,7 +242,7 @@ class UserService extends PKPBaseEntityPropertyService {
 					$values[$prop] = $user->getBiography(null);
 					break;
 				case 'signature':
-					$values[$prop] = $user->getSignature();
+					$values[$prop] = $user->getSignature(null);
 					break;
 				case 'authId':
 					$values[$prop] = $user->getAuthId();


### PR DESCRIPTION
Following the call pattern for other methods within this switch case that have $locale as argument and are passing null. I put null as an argument and the problem was solved.

Solve #4891