### PR TITLE
pkp/pkp-lib#4926 missing getByPressId in CategoryDAO

### DIFF
--- a/classes/context/CategoryDAO.inc.php
+++ b/classes/context/CategoryDAO.inc.php
@@ -68,6 +68,16 @@ class CategoryDAO extends DAO {
 	}
 
 	/**
+	 * Retrieve all categories for a press.
+	 * @param $pressId int
+	 * @param $rangeInfo Object Optional range information.
+	 * @return DAOResultFactory containing Category ordered by sequence
+	 */
+	function getByPressId($pressId, $rangeInfo = null) {
+	    return $this->getByContextId($pressId, $rangeInfo);
+	}
+
+	/**
 	 * Retrieve an category by title.
 	 * @param $categoryTitle string
 	 * @param $contextId int


### PR DESCRIPTION
This fixes the error, and thumbnails get resized as expected.

I'm unsure though if this is the right way to do it since getByPressId is specific to OMP.