### PR TITLE
PKPRequest::getServerHost() enchanced to deal with multiple host names in a host header.

### DIFF
--- a/classes/core/PKPRequest.inc.php
+++ b/classes/core/PKPRequest.inc.php
@@ -331,6 +331,8 @@ class PKPRequest {
 				: (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST']
 				: (isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME']
 				: $default));
+                        // in case of multiple host entries in the header (e.g. multiple reverse proxies) take the first entry
+                        $this->_serverHost = trim(explode(',', $this->_serverHost)[0]);
 			HookRegistry::call('Request::getServerHost', array(&$this->_serverHost, &$default, &$includePort));
 		}
 		if (!$includePort) {

--- a/classes/core/PKPRequest.inc.php
+++ b/classes/core/PKPRequest.inc.php
@@ -331,8 +331,8 @@ class PKPRequest {
 				: (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST']
 				: (isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME']
 				: $default));
-                        // in case of multiple host entries in the header (e.g. multiple reverse proxies) take the first entry
-                        $this->_serverHost = trim(explode(',', $this->_serverHost)[0]);
+			// in case of multiple host entries in the header (e.g. multiple reverse proxies) take the first entry
+			$this->_serverHost = trim(explode(',', $this->_serverHost)[0]);
 			HookRegistry::call('Request::getServerHost', array(&$this->_serverHost, &$default, &$includePort));
 		}
 		if (!$includePort) {


### PR DESCRIPTION
Depending on the reverse proxy configuration every reverse proxy may append its host name to the HTTP_X_FORWARDED_HOST instead of replacing it (this is e.g. a default Apache behaviour).

In such a case the final header value is a (comma-delimited) list of server names with the original request server name in front, e.g. `clarin.oeaw.ac.at, tokeneditor.apollo.arz.oeaw.ac.at` and the right way to process it is to split it into single host names and take the first value.