### PR TITLE
pkp/pkp-lib#4982 Modified the ID of the LinkAction to delete notifications due to a missing locale key.

### DIFF
--- a/controllers/grid/notifications/NotificationsGridHandler.inc.php
+++ b/controllers/grid/notifications/NotificationsGridHandler.inc.php
@@ -72,7 +72,7 @@ class NotificationsGridHandler extends GridHandler {
 		$router = $request->getRouter();
 		$this->addAction(
 			new LinkAction(
-				'deleteNotifications',
+				'deleteNotification',
 				new NullAction(),
 				__('grid.action.delete'),
 				'delete'

--- a/js/controllers/grid/notifications/NotificationsGridHandler.js
+++ b/js/controllers/grid/notifications/NotificationsGridHandler.js
@@ -35,7 +35,7 @@
 		$grid.find('a[id*="markRead"]').mousedown(
 				this.callbackWrapper(this.markReadHandler_));
 
-		$grid.find('a[id*="deleteNotifications"]').mousedown(
+		$grid.find('a[id*="deleteNotification"]').mousedown(
 				this.callbackWrapper(this.deleteHandler_));
 
 		this.parent($grid, options);


### PR DESCRIPTION
Previously I had updated the locale from `grid.action.deleteNotification` to `grid.action.deleteNotifications`... But since the locale has the right translation, I've decided to just change the ID of the LinkAction.