### PR TITLE
pkp/pkp-lib#4985 Disabled the execution of actions through a right-click

### DIFF
--- a/js/controllers/grid/notifications/NotificationsGridHandler.js
+++ b/js/controllers/grid/notifications/NotificationsGridHandler.js
@@ -29,13 +29,14 @@
 	 */
 	$.pkp.controllers.grid.notifications.NotificationsGridHandler =
 			function($grid, options) {
-		$grid.find('a[id*="markNew"]').mousedown(
+
+		$grid.find('a[id*="markNew"]').click(
 				this.callbackWrapper(this.markNewHandler_));
 
-		$grid.find('a[id*="markRead"]').mousedown(
+		$grid.find('a[id*="markRead"]').click(
 				this.callbackWrapper(this.markReadHandler_));
 
-		$grid.find('a[id*="deleteNotifications"]').mousedown(
+		$grid.find('a[id*="deleteNotifications"]').click(
 				this.callbackWrapper(this.deleteHandler_));
 
 		this.parent($grid, options);


### PR DESCRIPTION
Changed mousedown to click, to avoid the execution of actions through a right-click.