### PR TITLE
Added possibility to inject environment variables into config.inc.php for Docker

### DIFF
--- a/classes/config/ConfigParser.inc.php
+++ b/classes/config/ConfigParser.inc.php
@@ -103,6 +103,8 @@ class ConfigParser {
 					} else if (defined($value)) {
 						// The value matches a named constant
 						$value = constant($value);
+					} else if (preg_match('/^[A-Z_]+$/', $value) && getenv($value) !== false) {
+						$value = getenv($value);
 					}
 				}
 


### PR DESCRIPTION
When creating containerised applications using a tool such as Docker, it is desirable to inject configuration using environment variables due to the transient nature of containers and images.

This additional check will look for uppercased strings allowing underscores also and check if an environment variable exists with the same name. This occurs after the `defined` check so it will not affect the existing constants check.