### PR TITLE
pkp/pkp-lib#5018 ojs2 warning errors fill the server log (using PHP 7)

### DIFF
--- a/classes/core/PKPApplication.inc.php
+++ b/classes/core/PKPApplication.inc.php
@@ -50,6 +50,8 @@ class PKPApplication {
 		$errorReportingLevel = E_ALL;
 		if (defined('E_STRICT')) $errorReportingLevel &= ~E_STRICT;
 		if (defined('E_DEPRECATED')) $errorReportingLevel &= ~E_DEPRECATED;
+		if (defined('E_WARNING')) $errorReportingLevel &= ~E_WARNING;
+		if (defined('E_NOTICE')) $errorReportingLevel &= ~E_NOTICE;
 		@error_reporting($errorReportingLevel);
 
 		// Instantiate the profiler


### PR DESCRIPTION
Fix for suppressing the server errors when running ojs2 on PHP 7, discussed in forum https://forum.pkp.sfu.ca/t/ojs-2-4-8-4-is-compatible-with-php-7-3/52533/12