### PR TITLE
make HookRegistry ignore non-callable callbacks

### DIFF
--- a/classes/plugins/HookRegistry.inc.php
+++ b/classes/plugins/HookRegistry.inc.php
@@ -104,6 +104,8 @@ class HookRegistry {
 			ksort($hooks[$hookName], SORT_NUMERIC);
 			foreach ($hooks[$hookName] as $priority => $hookList) {
 				foreach ($hookList as $hook) {
+					if (!is_callable($hook))
+						continue;  // else broken plugins break OJS if display_errors = On
 					if ($result = call_user_func($hook, $hookName, $args)) return true;
 				}
 			}


### PR DESCRIPTION
If display_errors=on, a broken plugin (such as OpenAIREPlugin
in my case) that registers something that cannot be called,
will provoke a message that breaks OJS's AJAX pages (because
many JSON responses will become ill-formed).
This patch ignores hook callbacks that are !is_callable
and so makes OJS robust against such cases.