### PR TITLE
pkp/pkp-lib#5023 Add no-match clause for no values specified

### DIFF
--- a/classes/statistics/PKPMetricsDAO.inc.php
+++ b/classes/statistics/PKPMetricsDAO.inc.php
@@ -146,13 +146,16 @@ class PKPMetricsDAO extends DAO {
 				if (is_scalar($values)) {
 					$currentClause .= "$column = ?";
 					$params[] = $values;
-				} else {
+				} elseif (count($values)) {
 					$placeholders = array_pad(array(), count($values), '?');
 					$placeholders = implode(', ', $placeholders);
 					$currentClause .= "$column IN ($placeholders)";
 					foreach ($values as $value) {
 						$params[] = $value;
 					}
+				} else {
+					// count($values) == 0: No matches should be returned.
+					$currentClause .= '1=0';
 				}
 			}
 


### PR DESCRIPTION
This should fix the issue raised by @israelcefrin at https://github.com/pkp/pkp-lib/issues/5023#issuecomment-529725907.

The problem is that the submission ID condition is specified, but no submission ID is given.

This change adds an anything-goes SQL clause for that case.