### PR TITLE
pkp/pkp-lib#4273: Move h1 out of breadcrumbs nav

### DIFF
--- a/templates/frontend/components/breadcrumbs.tpl
+++ b/templates/frontend/components/breadcrumbs.tpl
@@ -23,6 +23,7 @@
 			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
+			<a href="{$currentUrl}" aria-current="page">
 			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
@@ -31,6 +32,7 @@
 				{/if}
 			{/capture}
 			{$smarty.capture.currentTitleH1}
+			</a>
 		</li>
 	</ol>
 </nav>

--- a/templates/frontend/components/breadcrumbs.tpl
+++ b/templates/frontend/components/breadcrumbs.tpl
@@ -23,13 +23,16 @@
 			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
-			<h1>
+			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			</h1>
+			{/capture}
+			{$smarty.capture.currentTitleH1}
 		</li>
 	</ol>
 </nav>
+<h1 class="pageCurrentTitle">{$smarty.capture.currentTitleH1}</h1>
+


### PR DESCRIPTION
Moves the page-level `h1` out of the breadcrumbs `nav` for pkp/pkp-lib#4273.