### PR TITLE
Small fix. fr_CA translation. Vocabulary compliance with plugin locale.

### DIFF
--- a/locale/fr_CA/submission.po
+++ b/locale/fr_CA/submission.po
@@ -640,7 +640,7 @@ msgid "submission.howToCite"
 msgstr "Comment citer"
 
 msgid "submission.howToCite.citationFormats"
-msgstr "Formats de citations"
+msgstr "Styles bibliographiques"
 
 msgid "submission.howToCite.downloadCitation"
 msgstr "Télécharger la référence"


### PR DESCRIPTION
For vocabulary compliance with
https://github.com/pkp/citationStyleLanguage/pull/58/commits/62eef0f8e975b8b67c2aa838f9183c3f67c762af