### PR TITLE
Small fix. fr_CA translation. Vocabulary compliance with plugin locale.

### DIFF
--- a/locale/fr_CA/submission.xml
+++ b/locale/fr_CA/submission.xml
@@ -230,7 +230,7 @@
 	<message key="submission.history.submissionNotes">Notes de soumissions</message>
 	<message key="submission.history.viewLog">Voir le registre</message>
 	<message key="submission.howToCite">Comment citer</message>
-	<message key="submission.howToCite.citationFormats">Formats de citations</message>
+	<message key="submission.howToCite.citationFormats">Styles bibliographiques</message>
 	<message key="submission.howToCite.downloadCitation">Télécharger la référence</message>
 	<message key="submission.indexing">Indexation</message>
 	<message key="submission.initiated">En cours</message>


### PR DESCRIPTION
For vocabulary compliance with
https://github.com/pkp/citationStyleLanguage/pull/58/commits/62eef0f8e975b8b67c2aa838f9183c3f67c762af