### PR TITLE
defstat/pln#44 append unique id to deposit grid id

### DIFF
--- a/templates/controllers/tab/settings/archiving/form/archivingForm.tpl
+++ b/templates/controllers/tab/settings/archiving/form/archivingForm.tpl
@@ -51,7 +51,7 @@
 
 				{fbvFormSection translate=false}
 					{capture assign=depositsGridUrl}{url component="plugins.generic.pln.controllers.grid.PLNStatusGridHandler" op="fetchGrid" escape=false}{/capture}
-					{load_url_in_div id="depositsGridContainer" url=$depositsGridUrl}
+					{load_url_in_div id="depositsGridContainer"|uniqid url=$depositsGridUrl}
 				{/fbvFormSection}
 			{/if}
 		{/fbvFormArea}


### PR DESCRIPTION
Appends a unique id to the div element, fixing the double-bind problem, and solves defstat/pln#44