### PR TITLE
pkp/pkp-lib#5256 Fixed bug in RoleDAO::getUsersByRoleId

### DIFF
--- a/classes/security/RoleDAO.inc.php
+++ b/classes/security/RoleDAO.inc.php
@@ -102,7 +102,7 @@ class RoleDAO extends DAO {
 			LEFT JOIN controlled_vocab_entries cve ON (cve.controlled_vocab_id = cv.controlled_vocab_id)
 			LEFT JOIN controlled_vocab_entry_settings cves ON (cves.controlled_vocab_entry_id = cve.controlled_vocab_entry_id)
 			' . $this->userDao->getFetchJoins() . '
-			WHERE ' . (isset($roleId) ? 'ug.role_id = ?' : '') . (isset($contextId) ? ' AND ug.context_id = ?' : '') . ' ' . $searchSql,
+			WHERE 1=1' . (isset($roleId) ? ' AND ug.role_id = ?' : '') . (isset($contextId) ? ' AND ug.context_id = ?' : '') . ' ' . $searchSql,
 			$paramArray,
 			$dbResultRange
 		);


### PR DESCRIPTION
When the argument $roleId is left empty it results in a malformed SQL.