### PR TITLE
pkp/pkp-lib#5261 additional mime type for svg

### DIFF
--- a/classes/file/FileManager.inc.php
+++ b/classes/file/FileManager.inc.php
@@ -462,6 +462,7 @@ class FileManager {
 			case 'image/ico':
 				return '.ico';
 			case 'image/svg+xml':
+			case 'image/svg':
 				return '.svg';
 			case 'application/x-shockwave-flash':
 				return '.swf';


### PR DESCRIPTION
Allows to upload SVG images that are detected by PHP with a MIME type `image/svg`