### PR TITLE
try to ensure API clients get JSON responses, even in tough times

### DIFF
--- a/classes/handler/APIHandler.inc.php
+++ b/classes/handler/APIHandler.inc.php
@@ -49,6 +49,8 @@ class APIHandler extends PKPHandler {
 				'determineRouteBeforeAppMiddleware' => true,
 			)
 		));
+		unset($this->_app->getContainer()['errorHandler']);
+		unset($this->_app->getContainer()['phpErrorHandler']);
 		$this->_app->add(new ApiAuthorizationMiddleware($this));
 		$this->_app->add(new ApiTokenDecodingMiddleware($this));
 		$this->_app->add(new ApiCsrfMiddleware($this));

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -41,6 +41,11 @@ function fatalError($reason) {
 		$isErrorCondition = false;
 	}
 
+	if (key_exists('HTTP_ACCEPT', $GLOBALS['_SERVER']) &&
+		$GLOBALS['_SERVER']['HTTP_ACCEPT'] == 'application/json') {
+		throw new Exception("Fatal Error: " . $reason);
+	}
+
 	echo "<h1>" . htmlspecialchars($reason) . "</h1>";
 
 	if ($showStackTrace) {


### PR DESCRIPTION
Hi @asmecher & @NateWr,

Here is an elaboration on work discussed here:
https://github.com/quoideneuf/pkp-lib/commit/9a02a61d0892f277071ac24d0a3f1d455de12ea8

Here is the rationale:

Goal: To give API clients JSON responses whenever the application goes belly up, without disturbing the existing behavior for browser clients.

The Slim framework has built-in error handling that can be customized. Currently, if an Exception gets thrown after the APIHandler has been invoked, the user gets the default message in the default Slim format, which uses "message" as the key in the JSON object (as opposed to the "error" convention Nate mentioned).

It seems straightforward to write a custom handler for Slim, but this wouldn't solve the problem right now because there is a lot of application logic above the Slim layer, including expected cases such as the application being unable to establish a db connection. So I disabled the Slim error handling and used built-in PHP functions `register_shutdown_function` and `set_exception_handler` as a more generalized error handler. I also tweaked the `fatalError` function in `functions.inc.php` so that it simple throws an exception when the request comes with an accept-json directive.


