### PR TITLE
A small fix when using restful urls.

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -740,7 +740,7 @@ class PKPTemplateManager extends Smarty {
 			'currentLocale' => AppLocale::getLocale(),
 			'primaryLocale' => AppLocale::getPrimaryLocale(),
 			'baseUrl' => $this->_request->getBaseUrl(),
-			'contextPath' => isset($context) ? $context->getPath() : '',
+			'contextPath' => empty($context) ? $context->getPath() : '',
 			'apiBasePath' => '/api/v1',
 			'pathInfoEnabled' => Config::getVar('general', 'disable_path_info') ? false : true,
 			'restfulUrlsEnabled' => Config::getVar('general', 'restful_urls') ? true : false,


### PR DESCRIPTION
When you use restful urls, context may be empty. So you should check for empty instead isset.
I.e. in submissions page it give 404 http://jounal.com//journal_short/api/v1/_submissions?status=1&assignedTo=-1&searchPhrase=&count=20&offset=0&_=1576335660594
with empty it will be http://jounal.com/api/v1/_submissions?status=1&assignedTo=-1&searchPhrase=&count=20&offset=0&_=1576335660594