### PR TITLE
pkp/pkp-lib#5127 Align code architecture of service classes

### DIFF
--- a/classes/services/PKPStatsService.inc.php
+++ b/classes/services/PKPStatsService.inc.php
@@ -166,8 +166,6 @@ class PKPStatsService {
 		$defaultArgs = [
 			'dateStart' => STATISTICS_EARLIEST_DATE,
 			'dateEnd' => date('Ymd', strtotime('yesterday')),
-			'count' => 30,
-			'offset' => 0,
 
 			// Require a context to be specified to prevent unwanted data leakage
 			// if someone forgets to specify the context. If you really want to

--- a/classes/services/PKPSubmissionService.inc.php
+++ b/classes/services/PKPSubmissionService.inc.php
@@ -96,8 +96,6 @@ abstract class PKPSubmissionService implements EntityPropertyInterface, EntityRe
 			'status' => null,
 			'stageIds' => null,
 			'searchPhrase' => null,
-			'count' => 20,
-			'offset' => 0,
 			'isIncomplete' => false,
 			'isOverdue' => false,
 			'daysInactive' => null,

--- a/classes/services/PKPUserService.inc.php
+++ b/classes/services/PKPUserService.inc.php
@@ -100,8 +100,6 @@ class PKPUserService implements EntityPropertyInterface, EntityReadInterface {
 			'excludeUsers' => null,
 			'status' => 'active',
 			'searchPhrase' => null,
-			'count' => 20,
-			'offset' => 0,
 		);
 
 		$args = array_merge($defaultArgs, $args);


### PR DESCRIPTION
- Get rid of count/offset defaults where not used.
- Process request params directly in op unless params
  are shared across more than one op. Where that is
  the case, use a common _processAllowedParams method.