### PR TITLE
Update ModalHandler.js

### DIFF
--- a/js/controllers/modal/ModalHandler.js
+++ b/js/controllers/modal/ModalHandler.js
@@ -166,8 +166,10 @@
 		var $modal = $('<div class="pkp_modal_panel"></div>');
 
 		// Title bar
-		if (this.options.title !== 'undefined') {
+		if (typeof(this.options.title) !== 'undefined') {
 			$modal.append('<div class="header">' + this.options.title + '</div>');
+		} else {
+            $modal.append('<div class="header">' + '</div>');
 		}
 
 		// Close button

--- a/js/controllers/modal/ModalHandler.js
+++ b/js/controllers/modal/ModalHandler.js
@@ -169,7 +169,7 @@
 		if (typeof(this.options.title) !== 'undefined') {
 			$modal.append('<div class="header">' + this.options.title + '</div>');
 		} else {
-            $modal.append('<div class="header">' + '</div>');
+			$modal.append('<div class="header">' + '</div>');
 		}
 
 		// Close button


### PR DESCRIPTION
Fixes bug on modals that don't have title. Instead of undefined, displays only empty div header. For example, on submission > activity log & notes modal. 