### PR TITLE
put the api token middleware upstream of the csrf (last in, first exe…

### DIFF
--- a/classes/handler/APIHandler.inc.php
+++ b/classes/handler/APIHandler.inc.php
@@ -50,8 +50,8 @@ class APIHandler extends PKPHandler {
 			)
 		));
 		$this->_app->add(new ApiAuthorizationMiddleware($this));
-		$this->_app->add(new ApiTokenDecodingMiddleware($this));
 		$this->_app->add(new ApiCsrfMiddleware($this));
+		$this->_app->add(new ApiTokenDecodingMiddleware($this));
 		// remove trailing slashes
 		$this->_app->add(function ($request, $response, $next) {
 			$uri = $request->getUri();


### PR DESCRIPTION
If you make a POST, PUT, or DELETE request to the API, the following line of code appears to be executed before the API token has been decoded:

https://github.com/pkp/pkp-lib/blob/master/classes/security/authorization/internal/ApiCsrfMiddleware.inc.php#L57

As a result, all POST, PUT, or DELETE requests from non-browser clients are being rebuffed. 

Slim executes middleware in reverse order:
http://www.slimframework.com/docs/v3/concepts/middleware.html

