### PR TITLE
pkp/pkp-lib#5423 Fix error with pre-existing journal stylesheet

### DIFF
--- a/classes/services/PKPContextService.inc.php
+++ b/classes/services/PKPContextService.inc.php
@@ -613,20 +613,12 @@ abstract class PKPContextService implements EntityPropertyInterface, EntityReadI
 			return null;
 		}
 
-		// Get uploaded file to move
-		if ($isImage) {
-			if (empty($value['temporaryFileId'])) {
-				return $value; // nothing to upload
-			}
-			$temporaryFileId = (int) $value['temporaryFileId'];
-		} else {
-			if (!ctype_digit($value)) {
-				return $value; // nothing to upload
-			}
-			$temporaryFileId = (int) $value;
+		// Check if there is something to upload
+		if (empty($value['temporaryFileId'])) {
+			return $value;
 		}
 
-		$temporaryFile = $temporaryFileManager->getFile($temporaryFileId, $userId);
+		$temporaryFile = $temporaryFileManager->getFile((int) $value['temporaryFileId'], $userId);
 		$fileName = $this->moveTemporaryFile($context, $temporaryFile, $settingName, $userId, $localeKey);
 
 		if ($fileName) {
@@ -648,7 +640,11 @@ abstract class PKPContextService implements EntityPropertyInterface, EntityReadI
 					'altText' => $altText,
 				];
 			} else {
-				return $fileName;
+				return [
+					'name' => $temporaryFile->getOriginalFileName(),
+					'uploadName' => $fileName,
+					'dateUploaded' => \Core::getCurrentDate(),
+				];
 			}
 		}
 

--- a/classes/services/PKPPublicationService.inc.php
+++ b/classes/services/PKPPublicationService.inc.php
@@ -682,17 +682,9 @@ class PKPPublicationService implements EntityPropertyInterface, EntityReadInterf
 			return null;
 		}
 
-		// Get uploaded file to move
-		if ($isImage) {
-			if (empty($value['temporaryFileId'])) {
-				return $value; // nothing to upload
-			}
-			$temporaryFileId = (int) $value['temporaryFileId'];
-		} else {
-			if (!ctype_digit($value)) {
-				return $value; // nothing to upload
-			}
-			$temporaryFileId = (int) $value;
+		// Check if there is something to upload
+		if (empty($value['temporaryFileId'])) {
+			return $value;
 		}
 
 		// Get the submission context
@@ -703,7 +695,7 @@ class PKPPublicationService implements EntityPropertyInterface, EntityReadInterf
 
 		import('lib.pkp.classes.file.TemporaryFileManager');
 		$temporaryFileManager = new \TemporaryFileManager();
-		$temporaryFile = $temporaryFileManager->getFile($temporaryFileId, $userId);
+		$temporaryFile = $temporaryFileManager->getFile((int) $value['temporaryFileId'], $userId);
 		$fileNameBase = join('_', ['submission', $submission->getId(), $publication->getId(), $settingName]); // eg - submission_1_1_coverImage
 		$fileName = Services::get('context')->moveTemporaryFile($submissionContext, $temporaryFile, $fileNameBase, $userId, $localeKey);
 
@@ -715,7 +707,10 @@ class PKPPublicationService implements EntityPropertyInterface, EntityReadInterf
 					'uploadName' => $fileName,
 				];
 			} else {
-				return $fileName;
+				return [
+					'dateUploaded' => \Core::getCurrentDate(),
+					'uploadName' => $fileName,
+				];
 			}
 		}
 

--- a/classes/services/PKPSiteService.inc.php
+++ b/classes/services/PKPSiteService.inc.php
@@ -273,20 +273,12 @@ class PKPSiteService implements EntityPropertyInterface {
 			return null;
 		}
 
-		// Get uploaded file to move
-		if ($isImage) {
-			if (empty($value['temporaryFileId'])) {
-				return $value; // nothing to upload
-			}
-			$temporaryFileId = (int) $value['temporaryFileId'];
-		} else {
-			if (!ctype_digit($value)) {
-				return $value; // nothing to upload
-			}
-			$temporaryFileId = (int) $value;
+		// Check if there is something to upload
+		if (empty($value['temporaryFileId'])) {
+			return $value;
 		}
 
-		$temporaryFile = $temporaryFileManager->getFile($temporaryFileId, $userId);
+		$temporaryFile = $temporaryFileManager->getFile((int) $value['temporaryFileId'], $userId);
 		$fileName = $this->moveTemporaryFile($site, $temporaryFile, $settingName, $userId, $localeKey);
 
 		if ($fileName) {
@@ -307,7 +299,11 @@ class PKPSiteService implements EntityPropertyInterface {
 					'altText' => $altText,
 				];
 			} else {
-				return $fileName;
+				return [
+					'originalFilename' => $temporaryFile->getOriginalFileName(),
+					'uploadName' => $fileName,
+					'dateUploaded' => \Core::getCurrentDate(),
+				];
 			}
 		}
 

--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -275,7 +275,7 @@ class PKPTemplateManager extends Smarty {
 						$publicFileManager = new PublicFileManager();
 						$this->addStyleSheet(
 							'contextStylesheet',
-							$request->getBaseUrl() . '/' . $publicFileManager->getContextFilesPath($currentContext->getId()) . '/' . $contextStyleSheet,
+							$request->getBaseUrl() . '/' . $publicFileManager->getContextFilesPath($currentContext->getId()) . '/' . $contextStyleSheet['uploadName'],
 							array(
 								'priority' => STYLE_SEQUENCE_LATE
 							)

--- a/classes/validation/ValidatorFactory.inc.php
+++ b/classes/validation/ValidatorFactory.inc.php
@@ -363,7 +363,10 @@ class ValidatorFactory {
 						}
 					}
 				} else {
-					if (!$temporaryFileManager->getFile($props[$uploadProp], $userId)) {
+					if (!isset($props[$uploadProp]['temporaryFileId'])) {
+						continue;
+					}
+					if (!$temporaryFileManager->getFile($props[$uploadProp]['temporaryFileId'], $userId)) {
 						$validator->errors()->add($uploadProp, __('common.noTemporaryFile'));
 					}
 				}

--- a/schemas/context.json
+++ b/schemas/context.json
@@ -554,10 +554,25 @@
 			]
 		},
 		"styleSheet": {
-			"type": "string",
+			"type": "object",
 			"validation": [
 				"nullable"
-			]
+			],
+			"properties": {
+				"temporaryFileId": {
+					"type": "integer",
+					"writeOnly": true
+				},
+				"name": {
+					"type": "string"
+				},
+				"uploadName": {
+					"type": "string"
+				},
+				"dateUploaded": {
+					"type": "string"
+				}
+			}
 		},
 		"subjects": {
 			"type": "string",

--- a/schemas/site.json
+++ b/schemas/site.json
@@ -107,11 +107,25 @@
 			}
 		},
 		"styleSheet": {
-			"type": "string",
-			"writeOnly": true,
+			"type": "object",
 			"validation": [
 				"nullable"
-			]
+			],
+			"properties": {
+				"temporaryFileId": {
+					"type": "integer",
+					"writeOnly": true
+				},
+				"name": {
+					"type": "string"
+				},
+				"uploadName": {
+					"type": "string"
+				},
+				"dateUploaded": {
+					"type": "string"
+				}
+			}
 		},
 		"supportedLocales": {
 			"type": "array",


### PR DESCRIPTION
Changes properties for non-image files to be an object rather
than a string, so that a temporaryFileId can be sent and
detected properly during update requests. Also adds a couple
properties to file data for consistency and future use.