### PR TITLE
Fix turkish language selection

### DIFF
--- a/classes/i18n/PKPLocale.inc.php
+++ b/classes/i18n/PKPLocale.inc.php
@@ -174,6 +174,10 @@ class PKPLocale {
 				default: assert(false);
 			}
 		}
+		// Fix known php issue for turkish language selection, see also:
+		// https://www.sobstel.org/blog/php-call-to-undefined-method-on-tr-tr-locale/
+		if ($locale == 'tr_TR') setlocale(LC_CTYPE, 'en_US');
+
 	}
 
 	/**


### PR DESCRIPTION
As explained in https://forum.pkp.sfu.ca/t/12764

We came across this issue a few days ago. The whole ojs instance stopped working when activating tr_TR and clicking on the selection "Türkçe". Since this is a rather grave outcome, we think this should simply be fixed with a oneliner for everybody.