### PR TITLE
Cypress: allow baseUrl to be overwritten from env file

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,7 +11,7 @@
 // See https://github.com/bahmutov/cypress-failed-log
 // See https://github.com/cypress-io/cypress/issues/3199#issuecomment-534717443
 let shouldSkip = false;
-module.exports = ( on ) => {
+module.exports = ( on, config ) => {
 	on('task', {
 		resetShouldSkipFlag () {
 			shouldSkip = false;
@@ -27,4 +27,14 @@ module.exports = ( on ) => {
 			return null;
 		}
 	});
+
+	// Allow the baseUrl to be overwritten
+	// in a local cypress.env.json file.
+	// https://github.com/cypress-io/cypress/issues/909#issuecomment-578505704
+	const baseUrl = config.env.baseUrl || null;
+	if (baseUrl) {
+		config.baseUrl = baseUrl;
+	}
+
+	return config;
 }

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -10,6 +10,7 @@
 // See https://stackoverflow.com/questions/58657895/is-there-a-reliable-way-to-have-cypress-exit-as-soon-as-a-test-fails/58660504#58660504
 // See https://github.com/bahmutov/cypress-failed-log
 // See https://github.com/cypress-io/cypress/issues/3199#issuecomment-534717443
+// See https://github.com/cypress-io/cypress/issues/909#issuecomment-578505704
 let shouldSkip = false;
 module.exports = ( on, config ) => {
 	on('task', {
@@ -30,7 +31,6 @@ module.exports = ( on, config ) => {
 
 	// Allow the baseUrl to be overwritten
 	// in a local cypress.env.json file.
-	// https://github.com/cypress-io/cypress/issues/909#issuecomment-578505704
 	const baseUrl = config.env.baseUrl || null;
 	if (baseUrl) {
 		config.baseUrl = baseUrl;


### PR DESCRIPTION
@asmecher so it turns out the trouble I was having with the `baseUrl` and the plugin tests exists on the main application too. Not sure why I didn't catch it in the first run, but a `baseUrl` set in the `cypress.env.json` will _not_ overwrite the `baseUrl` in the `cypress.json` file.

The whole story, including frustration over how misleading the Cypress docs are: https://github.com/cypress-io/cypress/issues/909

This is a plugin which adds this, so that each dev can have the `baseUrl` in their own `cypress.env.json` file.

Does this look alright?