### PR TITLE
pkp/pkp-lib#5725 add new index on notifications table

### DIFF
--- a/xml/schema/common.xml
+++ b/xml/schema/common.xml
@@ -366,6 +366,10 @@
 			<col>assoc_type</col>
 			<col>assoc_id</col>
 		</index>
+		<index name="notifications_user_id_level">
+			<col>user_id</col>
+			<col>level</col>
+		</index>
 	</table>
 
 	<!--


### PR DESCRIPTION
Creates a new index on the notifications table that allows the NotificationDAO::getByUserId method to use an index if called without a context_id.