### PR TITLE
suppress the SMTP check by adding SMTPOptions parameter to PHPMailer instance #5781

### DIFF
--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -488,16 +488,16 @@ class Mail extends DataObject {
 				$mailer->SMTPDebug = 3;
 				$mailer->Debugoutput = 'error_log';
 			}
-            if (Config::getVar('email', 'smtp_suppress_cert_check')) {
-                // disabling the SMTP certificate check.
-                $mailer->SMTPOptions = array(
-                    'ssl' => array(
-                        'verify_peer' => false,
-                        'verify_peer_name' => false,
-                        'allow_self_signed' => true
-                    )
-                );
-            }
+			if (Config::getVar('email', 'smtp_suppress_cert_check')) {
+				// disabling the SMTP certificate check.
+				$mailer->SMTPOptions = array(
+					'ssl' => array(
+						'verify_peer' => false,
+						'verify_peer_name' => false,
+						'allow_self_signed' => true
+					)
+				);
+			}
 		}
 		$mailer->CharSet = Config::getVar('i18n', 'client_charset');
 		if (($t = $this->getContentType()) != null) $mailer->ContentType = $t;

--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -488,6 +488,16 @@ class Mail extends DataObject {
 				$mailer->SMTPDebug = 3;
 				$mailer->Debugoutput = 'error_log';
 			}
+            if (Config::getVar('email', 'smtp_suppress_cert_check')) {
+                // disabling the SMTP certificate check.
+                $mailer->SMTPOptions = array(
+                    'ssl' => array(
+                        'verify_peer' => false,
+                        'verify_peer_name' => false,
+                        'allow_self_signed' => true
+                    )
+                );
+            }
 		}
 		$mailer->CharSet = Config::getVar('i18n', 'client_charset');
 		if (($t = $this->getContentType()) != null) $mailer->ContentType = $t;


### PR DESCRIPTION
This alters the PHPMailer parameters if the new configuration variable is set "On". The configuration variable is added to the OJS config file in the other PR.

Issue description:
https://github.com/pkp/pkp-lib/issues/5781