### PR TITLE
fix articles on a category page to be listed by date_published not date submitted

### DIFF
--- a/classes/services/queryBuilders/PKPSubmissionListQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionListQueryBuilder.inc.php
@@ -84,7 +84,9 @@ abstract class PKPSubmissionListQueryBuilder extends BaseQueryBuilder {
 			$this->orderColumn = 's.last_modified';
 		} elseif ($column === 'title') {
 			$this->orderColumn = Capsule::raw('COALESCE(submission_tl.setting_value, submission_tpl.setting_value)');
-		} else {
+		} elseif($column === 'datePublished'){
+			$this->orderColumn = 'ps.date_published';
+		}else {
 			$this->orderColumn = 's.date_submitted';
 		}
 		$this->orderDirection = $direction;


### PR DESCRIPTION
This is a fix in response to the ordering problem with articles on category pages (/catalog/category/XXXX) explained here:
https://forum.pkp.sfu.ca/t/ojs-3-1-2-4-category-pages-not-ordered-by-publication-date/60366