### PR TITLE
pkp/pkp-lib#6085 Forwarded the context's locale where needed to avoid delivering the report with the wrong translation.

### DIFF
--- a/api/v1/stats/editorial/PKPStatsEditorialHandler.inc.php
+++ b/api/v1/stats/editorial/PKPStatsEditorialHandler.inc.php
@@ -106,7 +106,13 @@ abstract class PKPStatsEditorialHandler extends APIHandler {
 			return $response->withStatus(400)->withJsonError($result);
 		}
 
-		return $response->withJson(Services::get('editorialStats')->getOverview($params));
+		return $response->withJson(array_map(
+			function ($item) {
+				$item['name'] = __($item['name']);
+				return $item;
+			},
+			Services::get('editorialStats')->getOverview($params)
+		));
 	}
 
 	/**

--- a/api/v1/stats/users/PKPStatsUserHandler.inc.php
+++ b/api/v1/stats/users/PKPStatsUserHandler.inc.php
@@ -101,6 +101,12 @@ class PKPStatsUserHandler extends APIHandler {
 			return $response->withStatus(400)->withJsonError($result);
 		}
 
-		return $response->withJson(Services::get('user')->getRolesOverview($params));
+		return $response->withJson(array_map(
+			function ($item) {
+				$item['name'] = __($item['name']);
+				return $item;
+			},
+			Services::get('user')->getRolesOverview($params)
+		));
 	}
 }

--- a/classes/core/PKPApplication.inc.php
+++ b/classes/core/PKPApplication.inc.php
@@ -751,11 +751,11 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider {
 	public static function getWorkflowStageName($stageId) {
 		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_SUBMISSION, LOCALE_COMPONENT_APP_SUBMISSION);
 		switch ($stageId) {
-			case WORKFLOW_STAGE_ID_SUBMISSION: return __('submission.submission');
-			case WORKFLOW_STAGE_ID_INTERNAL_REVIEW: return __('workflow.review.internalReview');
-			case WORKFLOW_STAGE_ID_EXTERNAL_REVIEW: return __('workflow.review.externalReview');
-			case WORKFLOW_STAGE_ID_EDITING: return __('submission.editorial');
-			case WORKFLOW_STAGE_ID_PRODUCTION: return __('submission.production');
+			case WORKFLOW_STAGE_ID_SUBMISSION: return 'submission.submission';
+			case WORKFLOW_STAGE_ID_INTERNAL_REVIEW: return 'workflow.review.internalReview';
+			case WORKFLOW_STAGE_ID_EXTERNAL_REVIEW: return 'workflow.review.externalReview';
+			case WORKFLOW_STAGE_ID_EDITING: return 'submission.editorial';
+			case WORKFLOW_STAGE_ID_PRODUCTION: return 'submission.production';
 		}
 		throw new Exception('Name requested for an unrecognized stage id.');
 	}

--- a/classes/services/PKPStatsEditorialService.inc.php
+++ b/classes/services/PKPStatsEditorialService.inc.php
@@ -27,8 +27,7 @@ class PKPStatsEditorialService {
 	public function getOverview($args = []) {
 		import('classes.workflow.EditorDecisionActionsManager');
 		import('lib.pkp.classes.submission.PKPSubmission');
-		\AppLocale::requireComponents(LOCALE_COMPONENT_PKP_MANAGER);
-		\AppLocale::requireComponents(LOCALE_COMPONENT_APP_MANAGER);
+		\AppLocale::requireComponents(LOCALE_COMPONENT_PKP_MANAGER, LOCALE_COMPONENT_APP_MANAGER);
 
 		$received = $this->countSubmissionsReceived($args);
 		$accepted = $this->countByDecisions(SUBMISSION_EDITOR_DECISION_ACCEPT, $args);
@@ -88,67 +87,67 @@ class PKPStatsEditorialService {
 		$overview = [
 			[
 				'key' => 'submissionsReceived',
-				'name' => __('stats.name.submissionsReceived'),
+				'name' => 'stats.name.submissionsReceived',
 				'value' => $received,
 			],
 			[
 				'key' => 'submissionsAccepted',
-				'name' => __('stats.name.submissionsAccepted'),
+				'name' => 'stats.name.submissionsAccepted',
 				'value' => $accepted,
 			],
 			[
 				'key' => 'submissionsDeclined',
-				'name' => __('stats.name.submissionsDeclined'),
+				'name' => 'stats.name.submissionsDeclined',
 				'value' => $declined,
 			],
 			[
 				'key' => 'submissionsDeclinedDeskReject',
-				'name' => __('stats.name.submissionsDeclinedDeskReject'),
+				'name' => 'stats.name.submissionsDeclinedDeskReject',
 				'value' => $declinedDesk,
 			],
 			[
 				'key' => 'submissionsDeclinedPostReview',
-				'name' => __('stats.name.submissionsDeclinedPostReview'),
+				'name' => 'stats.name.submissionsDeclinedPostReview',
 				'value' => $declinedReview,
 			],
 			[
 				'key' => 'submissionsPublished',
-				'name' => __('stats.name.submissionsPublished'),
+				'name' => 'stats.name.submissionsPublished',
 				'value' => $this->countSubmissionsPublished($args),
 			],
 			[
 				'key' => 'daysToDecision',
-				'name' => __('stats.name.daysToDecision'),
+				'name' => 'stats.name.daysToDecision',
 				'value' => $firstDecisionDaysRate,
 			],
 			[
 				'key' => 'daysToAccept',
-				'name' => __('stats.name.daysToAccept'),
+				'name' => 'stats.name.daysToAccept',
 				'value' => $acceptDecisionDaysRate,
 			],
 			[
 				'key' => 'daysToReject',
-				'name' => __('stats.name.daysToReject'),
+				'name' => 'stats.name.daysToReject',
 				'value' => $declineDecisionDaysRate,
 			],
 			[
 				'key' => 'acceptanceRate',
-				'name' => __('stats.name.acceptanceRate'),
+				'name' => 'stats.name.acceptanceRate',
 				'value' => round($acceptanceRate, 2),
 			],
 			[
 				'key' => 'declineRate',
-				'name' => __('stats.name.declineRate'),
+				'name' => 'stats.name.declineRate',
 				'value' => round($declineRate, 2),
 			],
 			[
 				'key' => 'declinedDeskRate',
-				'name' => __('stats.name.declinedDeskRate'),
+				'name' => 'stats.name.declinedDeskRate',
 				'value' => round($declinedDeskRate, 2),
 			],
 			[
 				'key' => 'declinedReviewRate',
-				'name' => __('stats.name.declinedReviewRate'),
+				'name' => 'stats.name.declinedReviewRate',
 				'value' => round($declinedReviewRate, 2),
 			],
 		];

--- a/classes/services/PKPUserService.inc.php
+++ b/classes/services/PKPUserService.inc.php
@@ -587,7 +587,7 @@ class PKPUserService implements EntityPropertyInterface, EntityReadInterface {
 		$result = [
 			[
 				'id' => 'total',
-				'name' => __('stats.allUsers'),
+				'name' => 'stats.allUsers',
 				'value' => $this->count($args),
 			],
 		];
@@ -602,7 +602,7 @@ class PKPUserService implements EntityPropertyInterface, EntityReadInterface {
 		foreach ($roleNames as $roleId => $roleName) {
 			$result[] = [
 				'id' => $roleId,
-				'name' => __($roleName),
+				'name' => $roleName,
 				'value' => $this->count(array_merge($args, ['roleIds' => $roleId])),
 			];
 		}

--- a/classes/task/StatisticsReport.inc.php
+++ b/classes/task/StatisticsReport.inc.php
@@ -42,17 +42,15 @@ class StatisticsReport extends ScheduledTask {
 		@set_time_limit(0);
 		import('lib.pkp.classes.notification.managerDelegate.EditorialReportNotificationManager');
 
-		AppLocale::requireComponents(
-			LOCALE_COMPONENT_PKP_USER,
-			LOCALE_COMPONENT_PKP_MANAGER,
-			LOCALE_COMPONENT_PKP_SUBMISSION
-		);
-
 		$contextDao = Application::get()->getContextDAO();
 		$userGroupDao = DAORegistry::getDAO('UserGroupDAO'); /* @var $userGroupDao UserGroupDAO */
 
 		$sentMessages = 0;
 		for ($contexts = $contextDao->getAll(true); $context = $contexts->next(); ) {
+			AppLocale::requireComponents(
+				[LOCALE_COMPONENT_PKP_USER, LOCALE_COMPONENT_PKP_MANAGER, LOCALE_COMPONENT_PKP_SUBMISSION, LOCALE_COMPONENT_PKP_COMMON, LOCALE_COMPONENT_APP_COMMON],
+				$context->getPrimaryLocale()
+			);
 			$editorialReportNotificationManager = new EditorialReportNotificationManager(NOTIFICATION_TYPE_EDITORIAL_REPORT);
 			$editorialReportNotificationManager->initialize(
 				$context,

--- a/pages/stats/PKPStatsHandler.inc.php
+++ b/pages/stats/PKPStatsHandler.inc.php
@@ -103,7 +103,7 @@ class PKPStatsHandler extends Handler {
 		foreach ($totals as $i => $stat) {
 			$row = [
 				'key' => $stat['key'],
-				'name' => $stat['name'],
+				'name' => __($stat['name']),
 				'total' => $stat['value'],
 				'dateRange' => $dateRangeTotals[$i]['value'],
 			];
@@ -133,7 +133,7 @@ class PKPStatsHandler extends Handler {
 		$activeByStage = [];
 		foreach (Application::get()->getApplicationStages() as $stageId) {
 			$activeByStage[] = [
-				'name' => Application::get()->getWorkflowStageName($stageId),
+				'name' => __(Application::get()->getWorkflowStageName($stageId)),
 				'count' => Services::get('editorialStats')->countActiveByStages($stageId, $args),
 				'color' => Application::get()->getWorkflowStageColor($stageId),
 			];
@@ -322,7 +322,13 @@ class PKPStatsHandler extends Handler {
 
 		$templateMgr = TemplateManager::getManager($request);
 		$this->setupTemplate($request);
-		$templateMgr->assign('userStats', Services::get('user')->getRolesOverview(['contextId' => $context->getId()]));
+		$templateMgr->assign('userStats', array_map(
+			function ($item) {
+				$item['name'] = __($item['name']);
+				return $item;
+			},
+			Services::get('user')->getRolesOverview(['contextId' => $context->getId()])
+		));
 		$templateMgr->display('stats/users.tpl');
 	}
 


### PR DESCRIPTION
Here I'm just forwarding the [context's locale](https://github.com/pkp/pkp-lib/compare/stable-3_2_1...jonasraoni:bugfix/3_2_1/i6085-fix-stats-report-locale?expand=1#diff-cce0767384a557843849cacbdc15fcf7R50) and adding locale [arguments where needed](https://github.com/pkp/pkp-lib/compare/stable-3_2_1...jonasraoni:bugfix/3_2_1/i6085-fix-stats-report-locale?expand=1#diff-3fed0569f5f0ae40c985f62cfe134c27R752).

Since using `setlocale(new) then setlocale(previous)` isn't very safe, I'm using the [IntlDateFormatter class](https://github.com/pkp/pkp-lib/compare/stable-3_2_1...jonasraoni:bugfix/3_2_1/i6085-fix-stats-report-locale?expand=1#diff-cce0767384a557843849cacbdc15fcf7R162) to localize the date, but as I didn't see it elsewhere in the code base, I'm leaving this warning/advice =]

Also added a BOM to the CSV file, as the screenshot provided in the issue looks broken.