### PR TITLE
pkp/pkp-lib#2993 switch google.com URL to recaptcha.net

### DIFF
--- a/classes/form/validation/FormValidatorReCaptcha.inc.php
+++ b/classes/form/validation/FormValidatorReCaptcha.inc.php
@@ -14,7 +14,7 @@
  */
 
 define('RECAPTCHA_RESPONSE_FIELD', 'g-recaptcha-response');
-define('RECAPTCHA_HOST', 'https://www.google.com');
+define('RECAPTCHA_HOST', 'https://www.recaptcha.net');
 define("RECAPTCHA_PATH", "/recaptcha/api/siteverify");
 
 class FormValidatorReCaptcha extends FormValidator {

--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -180,7 +180,7 @@ class PKPTemplateManager extends Smarty {
 			if (Config::getVar('captcha', 'recaptcha') && Config::getVar('captcha', 'captcha_on_register')) {
 				$this->addJavaScript(
 					'recaptcha',
-					'https://www.google.com/recaptcha/api.js?hl=' . substr(AppLocale::getLocale(),0,2),
+					'https://www.recaptcha.net/recaptcha/api.js?hl=' . substr(AppLocale::getLocale(),0,2),
 					array(
 						'contexts' => array('frontend-user-register', 'frontend-user-registerUser'),
 					)


### PR DESCRIPTION
This switches the URL used for loading the reCaptcha javascript.  To fully fix problems for users from China, `enable_cdn` will also need to be turned off in the installation's `config.inc.php` file but I suspect that this will have already been done for Chinese users since a large portion of interface depends on jQuery anyway.