### PR TITLE
PreviewReviewForm - Remove unused and incorrect variable

### DIFF
--- a/controllers/grid/settings/reviewForms/form/PreviewReviewForm.inc.php
+++ b/controllers/grid/settings/reviewForms/form/PreviewReviewForm.inc.php
@@ -61,7 +61,6 @@ class PreviewReviewForm extends Form {
 			// Get review form elements
 			$reviewFormElementDao = DAORegistry::getDAO('ReviewFormElementDAO'); /* @var $reviewFormElementDao ReviewFormElementDAO */
 			$reviewFormElements = $reviewFormElementDao->getByReviewFormId($this->reviewFormId);
-			$count = count($reviewFormElements);
 
 			// Set data
 			$this->setData('title', $reviewForm->getLocalizedTitle(null));


### PR DESCRIPTION
The $count variable is incorrectly set, receiving the value 1 instead of the number of review form elements. It is also unused and so can be removed.