### PR TITLE
Permit the creation of grandchild themes

### DIFF
--- a/classes/plugins/ThemePlugin.inc.php
+++ b/classes/plugins/ThemePlugin.inc.php
@@ -226,7 +226,7 @@ abstract class ThemePlugin extends LazyLoadPlugin {
 			$args['style'] = substr($args['style'], (strlen(LESS_FILENAME_SUFFIX) * -1)) == LESS_FILENAME_SUFFIX ? $this->_getBaseDir($args['style']) : $this->_getBaseUrl($args['style']);
 		}
 
-		$style = array_merge($style, $args);
+		$style = array_merge_recursive($style, $args);
 	}
 
 	/**

--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -369,9 +369,11 @@ class PKPTemplateManager extends Smarty {
 		}
 
 		// Add extra LESS variables before compiling
-		if (isset($args['addLessVariables'])) {
-			$less->parse($args['addLessVariables']);
-		}
+        if (isset($args['addLessVariables'])) {
+        	foreach ((array) $args['addLessVariables'] as $addlessVariables) {
+            	$less->parse($addlessVariables);
+            }
+        }
 
 		// Set the @baseUrl variable
 		$baseUrl = !empty($args['baseUrl']) ? $args['baseUrl'] : $request->getBaseUrl(true);

--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -369,11 +369,11 @@ class PKPTemplateManager extends Smarty {
 		}
 
 		// Add extra LESS variables before compiling
-        if (isset($args['addLessVariables'])) {
-        	foreach ((array) $args['addLessVariables'] as $addlessVariables) {
-            	$less->parse($addlessVariables);
-            }
-        }
+		if (isset($args['addLessVariables'])) {
+			foreach ((array) $args['addLessVariables'] as $addlessVariables) {
+				$less->parse($addlessVariables);
+			}
+		}
 
 		// Set the @baseUrl variable
 		$baseUrl = !empty($args['baseUrl']) ? $args['baseUrl'] : $request->getBaseUrl(true);


### PR DESCRIPTION
Resolves the issue where a child of a child theme does not work as intended, reported as issue #4704.

The fix is based on suggestions by @Vitaliy-1 and @NateWr at https://forum.pkp.sfu.ca/t/trouble-creating-grandchild-theme/52803.

Sample theme for testing: [bnzseeManuscript.tar.gz](https://github.com/pkp/pkp-lib/files/5092994/bnzseeManuscript.tar.gz)
