### PR TITLE
indexing pdf files fix

### DIFF
--- a/classes/search/SearchHelperParser.inc.php
+++ b/classes/search/SearchHelperParser.inc.php
@@ -31,7 +31,10 @@ class SearchHelperParser extends SearchFileParser {
 
 		if (isset($prog)) {
 			$exec = sprintf($prog, escapeshellarg($this->getFilePath()));
-			$this->fp = @popen($exec, 'r');
+			$this->fp = @popen($exec, 'rb');
+			$this->type = 'text/plain';
+			$this->setFilePath(substr($this->filePath, 0, strrpos($this->filePath, ".")).".txt");
+			$this->fp = @fopen($this->filePath, 'rb');
 			return $this->fp ? true : false;
 		}
 


### PR DESCRIPTION
there was an issue with indexing the pdf files.

After creating the txt file
$exec = sprintf($prog, escapeshellarg($this->getFilePath()));
$this->fp = @Popen($exec, 'rb');

this->fp was still pointing at the pdf file so the parsing could'nt work.

Changed the filepath
$this->setFilePath(substr($this->filePath, 0, strrpos($this->filePath, ".")).".txt");
$this->fp = @fopen($this->filePath, 'rb');
So the fp to point at the new txt file.