### PR TITLE
pkp/pkp-lib#4595 Consider sessions for journals using alternative domains

### DIFF
--- a/classes/session/SessionManager.inc.php
+++ b/classes/session/SessionManager.inc.php
@@ -38,11 +38,17 @@ class SessionManager {
 		ini_set('session.name', Config::getVar('general', 'session_cookie_name')); // Cookie name
 		ini_set('session.cookie_lifetime', 0);
 		ini_set('session.cookie_path', Config::getVar('general', 'session_cookie_path', $request->getBasePath() . '/'));
-		ini_set('session.cookie_domain', $request->getServerHost(null, false));
 		ini_set('session.gc_probability', 1);
 		ini_set('session.gc_maxlifetime', 60 * 60);
 		ini_set('session.auto_start', 1);
 		ini_set('session.cache_limiter', 'none');
+
+		// Allow cookie_domain override from config.inc.php
+		if (Config::getVar('general', 'session_cookie_domain')){
+			ini_set('session.cookie_domain', Config::getVar('general', 'session_cookie_domain'));
+		} else {
+			ini_set('session.cookie_domain', $request->getServerHost(null, false));
+		}
 
 		session_set_save_handler(
 			array($this, 'open'),
@@ -53,6 +59,14 @@ class SessionManager {
 			array($this, 'gc')
 		);
 
+		// Check if the session is tied to the parent domain
+		if (isset($this->userSession) && $this->userSession->getDomain() && $this->userSession->getDomain() != $request->getServerHost(null, false)) {
+			// if current host contains . and the session domain (is a subdomain of the session domain), adjust the session's domain parameter to the parent
+			if (strtolower(substr($request->getServerHost(null, false), -1 - strlen($this->userSession->getDomain()))) == '.'.strtolower($this->userSession->getDomain())) {
+				ini_set('session.cookie_domain', $this->userSession->getDomain());
+			}
+		}
+
 		// Initialize the session. This calls SessionManager::read() and
 		// sets $this->userSession if a session is present.
 		session_start();
@@ -61,14 +75,6 @@ class SessionManager {
 		$ip = $request->getRemoteAddr();
 		$userAgent = $request->getUserAgent();
 		$now = time();
-
-		// Check if the session is tied to the parent domain
-		if (isset($this->userSession) && $this->userSession->getDomain() && $this->userSession->getDomain() != $request->getServerHost(null, false)) {
-			// if current host contains . and the session domain (is a subdomain of the session domain), adjust the session's domain parameter to the parent
-			if (strtolower(substr($request->getServerHost(null, false), -1 - strlen($this->userSession->getDomain()))) == '.'.strtolower($this->userSession->getDomain())) {
-				ini_set('session.cookie_domain', $this->userSession->getDomain());
-			}
-		}
 
 		if (!isset($this->userSession) || (Config::getVar('security', 'session_check_ip') && $this->userSession->getIpAddress() != $ip) || $this->userSession->getUserAgent() != substr($userAgent, 0, 255)) {
 			if (isset($this->userSession)) {
@@ -215,7 +221,14 @@ class SessionManager {
 	 * @return boolean
 	 */
 	function updateSessionCookie($sessionId = false, $expireTime = 0) {
-		$domain = ini_get('session.cookie_domain');
+
+		if (isset($this->userSession)) {
+			$domain = $this->userSession->getDomain();
+		}
+		else {
+			$domain = ini_get('session.cookie_domain');
+		}
+
 		// Specific domains must contain at least one '.' (e.g. Chrome)
 		if (strpos($domain, '.') === false) $domain = false;
 


### PR DESCRIPTION
Consider journals using alternative domains and allow session domain overrides from config.inc.php

With these changes, if no config value is given, each journal using alternative domain will create a new session for the journal.

Scenario 1: an OJS installation with:
site.com
site.com/journal1
journal2.com (own domain)

When the user goes journal2.com a new session and cookie is created. If that user logs in and moves to the site level (site.com) she will have to log in again. This is the ideal functionality with environments where the journals need to act independent from the site level.

Scenario 2:  an OJS installation with:
site.com
site.com/journal1
journal2.site.com (subdomain)

The ideal solution is to use the config setting to override the cookie domain so that it will always be site.com.
This means that only one cookie and session is ever created even when the user visits journal2.site.com. Also, the user only has to log in once.

*Question*

What would happen, if in scenario 1 the site would override the cookie domain and just use "site.com". Would that break the journal2.com site?

@asmecher @ctgraham 





