### PR TITLE
pkp/pkp-lib#6439 error when adding new roles

### DIFF
--- a/controllers/grid/settings/roles/UserGroupGridHandler.inc.php
+++ b/controllers/grid/settings/roles/UserGroupGridHandler.inc.php
@@ -69,7 +69,7 @@ class UserGroupGridHandler extends GridHandler {
 			$this->addPolicy(new WorkflowStageRequiredPolicy($request->getUserVar('stageId')));
 		}
 
-		$userGroupRequiredOps = array_merge($workflowStageRequiredOps, array('editUserGroup', 'updateUserGroup', 'removeUserGroup'));
+		$userGroupRequiredOps = array_merge($workflowStageRequiredOps, array('editUserGroup', 'removeUserGroup'));
 		if (in_array($operation, $userGroupRequiredOps)) {
 			// Validate the user group object.
 			$userGroupId = $request->getUserVar('userGroupId');


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/6439

I've separated addUserGroup (does not require userGroupId) and editUserGroupt (requires userGroupId), and removed updateUserGroup operation from the `userGroupRequiredOps` (because it is used for creating a new group as well for editing the existing). OK so?