### PR TITLE
pkp/pkp-lib#5121 return default base_url if none in customized list

### DIFF
--- a/classes/core/Core.inc.php
+++ b/classes/core/Core.inc.php
@@ -329,6 +329,13 @@ class Core {
 			}
 		}
 
+		// If we still have no base URL, this may be a situation where we have an install with some customized URLs, and some not.
+		// Return the default base URL.
+
+		if (!$baseUrl) {
+			$baseUrl = Config::getVar('general', 'base_url');
+		}
+
 		return array($baseUrl, $contextPath);
 	}
 


### PR DESCRIPTION
This seems like a reasonable fix, since the normal behaviour in an installation with no customized base_urls is to get the default base url and just return it with no context path:

https://github.com/pkp/pkp-lib/blob/master/classes/core/Core.inc.php#L291

I've tested this on a local installation and it now parses usage stats from both journals, where one has a customized base url and one did not.  