### PR TITLE
handle url_path attribute for galleys on import and export

### DIFF
--- a/plugins/importexport/native/filter/NativeXmlRepresentationFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlRepresentationFilter.inc.php
@@ -53,7 +53,8 @@ class NativeXmlRepresentationFilter extends NativeImportFilter {
 		$representation = $representationDao->newDataObject(); /** @var $representation Representation */
 
 		$representation->setData('publicationId', $publication->getId());
-
+		$representation->setData('urlPath', $node->getAttribute('url_path'));
+		
 		// Handle metadata in subelements.  Look for the 'name' and 'seq' elements.
 		// All other elements are handled by subclasses.
 		for ($n = $node->firstChild; $n !== null; $n=$n->nextSibling) if (is_a($n, 'DOMElement')) switch($n->tagName) {

--- a/plugins/importexport/native/filter/RepresentationNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/RepresentationNativeXmlFilter.inc.php
@@ -76,7 +76,8 @@ class RepresentationNativeXmlFilter extends NativeExportFilter {
 		$representationNode = $doc->createElementNS($deployment->getNamespace(), $deployment->getRepresentationNodeName());
 
 		$representationNode->setAttribute('locale', $representation->getData('locale'));
-
+		$representationNode->setAttribute('url_path', $representation->getData('urlPath'));
+		
 		$this->addIdentifiers($doc, $representationNode, $representation);
 
 		// Add metadata


### PR DESCRIPTION
This pull request aims to fix bug reported #6501 ("Galley url_path not imported in Native XML Import/Export")

I have tested it on OJS 3.2.1-1 and it produces the desired result, i.e. imported galleys now have the url_path specified in the article_galley element in the xml and exporting articles also has the corresponding url_path in the exported XML.

thanks @defstat for review and advice on earlier attempt https://github.com/pkp/ojs/pull/2957