### PR TITLE
pkp/pkp-lib#6502 Fix fatal errors when accessing file that doesn't exist

### DIFF
--- a/api/v1/submissions/PKPSubmissionFileHandler.inc.php
+++ b/api/v1/submissions/PKPSubmissionFileHandler.inc.php
@@ -194,15 +194,13 @@ class PKPSubmissionFileHandler extends APIHandler {
 
 		$items = [];
 		$filesIterator = Services::get('submissionFile')->getMany($params);
-		if (count($filesIterator)) {
-			$propertyArgs = [
-				'request' => $request,
-				'slimRequest' => $slimRequest,
-				'submission' => $this->getAuthorizedContextObject(ASSOC_TYPE_SUBMISSION),
-			];
-			foreach ($filesIterator as $file) {
-				$items[] = Services::get('submissionFile')->getSummaryProperties($file, $propertyArgs);
-			}
+		$propertyArgs = [
+			'request' => $request,
+			'slimRequest' => $slimRequest,
+			'submission' => $this->getAuthorizedContextObject(ASSOC_TYPE_SUBMISSION),
+		];
+		foreach ($filesIterator as $file) {
+			$items[] = Services::get('submissionFile')->getSummaryProperties($file, $propertyArgs);
 		}
 
 		$data = [

--- a/classes/migration/FilesMigration.inc.php
+++ b/classes/migration/FilesMigration.inc.php
@@ -25,6 +25,7 @@ class FilesMigration extends Migration {
 		Capsule::schema()->create('files', function (Blueprint $table) {
 			$table->bigIncrements('file_id');
 			$table->string('path', 255);
+			$table->string('mimetype', 255);
 		});
 	}
 

--- a/classes/migration/upgrade/PKPv3_3_0UpgradeMigration.inc.php
+++ b/classes/migration/upgrade/PKPv3_3_0UpgradeMigration.inc.php
@@ -260,6 +260,7 @@ class PKPv3_3_0UpgradeMigration extends Migration {
 		Capsule::schema()->create('files', function (Blueprint $table) {
 			$table->bigIncrements('file_id');
 			$table->string('path', 255);
+			$table->string('mimetype', 255);
 		});
 
 		// Create a new table to track submission file revisions
@@ -292,6 +293,7 @@ class PKPv3_3_0UpgradeMigration extends Migration {
 				'revision',
 				'submission_files.submission_id',
 				'genre_id',
+				'file_type',
 				'file_stage',
 				'date_uploaded',
 				'original_file_name'
@@ -320,7 +322,10 @@ class PKPv3_3_0UpgradeMigration extends Migration {
 			if ($fileService->fs->has($path)) {
 				error_log("A submission file was expected but not found at $path.");
 			}
-			$newFileId = Capsule::table('files')->insertGetId(['path' => $path], 'file_id');
+			$newFileId = Capsule::table('files')->insertGetId([
+				'path' => $path,
+				'mimetype' => $row->file_type,
+			], 'file_id');
 			Capsule::table('submission_files')
 				->where('file_id', $row->file_id)
 				->where('revision', $row->revision)

--- a/classes/search/SearchFileParser.inc.php
+++ b/classes/search/SearchFileParser.inc.php
@@ -98,10 +98,8 @@ class SearchFileParser {
 	 * @return SearchFileParser
 	 */
 	static function fromFile($submissionFile) {
-		$path = Services::get('file')->getPath($submissionFile->getData('fileId'));
-		$mimetype = Services::get('file')->fs->getMimetype($path);
-		$fullPath = rtrim(Config::getVar('files', 'files_dir'), '/') . '/' . $path;
-		return SearchFileParser::fromFileType($mimetype, $fullPath);
+		$fullPath = rtrim(Config::getVar('files', 'files_dir'), '/') . '/' . $submissionFile->getData('path');
+		return SearchFileParser::fromFileType($submissionFile->getData('mimetype'), $fullPath);
 	}
 
 	/**

--- a/classes/services/PKPSubmissionFileService.inc.php
+++ b/classes/services/PKPSubmissionFileService.inc.php
@@ -55,8 +55,9 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 		$submissionFileQO = $this
 			->getQueryBuilder($args)
 			->getQuery()
-			->leftJoin('submissions as s', 's.submission_id', '=', 'sf.submission_id')
-			->select(['sf.*', 's.locale as locale']);
+			->join('submissions as s', 's.submission_id', '=', 'sf.submission_id')
+			->join('files as f', 'f.file_id', '=', 'sf.file_id')
+			->select(['sf.*', 'f.*', 's.locale as locale']);
 		$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO');
 		$result = $submissionFileDao->retrieve($submissionFileQO->toSql(), $submissionFileQO->getBindings());
 		$queryResults = new DAOResultFactory($result, $submissionFileDao, '_fromRow');
@@ -69,17 +70,6 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 	 */
 	public function getMax($args = null) {
 		return $this->getCount($args);
-	}
-
-	/**
-	 * Get the file ids for each revision of a submission file
-	 *
-	 * @param int $submissionFileId
-	 * @return array
-	 */
-	public function getRevisionFileIds($submissionFileId) {
-		$q = new PKPSubmissionFileQueryBuilder();
-		return $q->getRevisionFileIds($submissionFileId);
 	}
 
 	/**
@@ -126,8 +116,6 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 		$request = $args['request'];
 		$submission = $args['submission'];
 		$dispatcher = $request->getDispatcher();
-		$path = Services::get('file')->getPath($submissionFile->getData('fileId'));
-		$mimetype = Services::get('file')->fs->getMimeType($path);
 
 		$values = [];
 
@@ -156,30 +144,20 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 					$values[$prop] = $dependentFiles;
 					break;
 				case 'documentType':
-					$values[$prop] = Services::get('file')->getDocumentType($mimetype);
-					break;
-				case 'mimetype':
-					$values[$prop] = $mimetype;
-					break;
-				case 'path':
-					$values[$prop] = $path;
+					$values[$prop] = Services::get('file')->getDocumentType($submissionFile->getData('mimetype'));
 					break;
 				case 'revisions':
-					$revisions = [];
-					$qb = new PKPSubmissionFileQueryBuilder();
-					$revisionFileIds = $qb->getRevisionFileIds($submissionFile->getId());
-					foreach ($revisionFileIds as $revisionFileId) {
-						if ($revisionFileId === $submissionFile->getData('fileId')) {
+					$files = [];
+					$revisions = DAORegistry::getDAO('SubmissionFileDAO')->getRevisions($submissionFile->getId());
+					foreach ($revisions as $revision) {
+						if ($revision->fileId === $submissionFile->getData('fileId')) {
 							continue;
 						}
-						$revisionPath = Services::get('file')->getPath($revisionFileId);
-						$mimetype = Services::get('file')->fs->getMimeType($revisionPath);
-						$revisions[] = [
-							'documentType' => Services::get('file')->getDocumentType($mimetype),
-							'fileId' => $revisionFileId,
-							'mimetype' => $mimetype,
-							'path' => $revisionPath,
-							'size' => Services::get('file')->fs->getSize($revisionPath),
+						$files[] = [
+							'documentType' => Services::get('file')->getDocumentType($revision->mimetype),
+							'fileId' => $revision->fileId,
+							'mimetype' => $revision->mimetype,
+							'path' => $revision->path,
 							'url' => $dispatcher->url(
 								$request,
 								ROUTE_COMPONENT,
@@ -188,7 +166,7 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 								'downloadFile',
 								null,
 								[
-									'fileId' => $revisionFileId,
+									'fileId' => $revision->fileId,
 									'submissionFileId' => $submissionFile->getId(),
 									'submissionId' => $submissionFile->getData('submissionId'),
 									'stageId' => $this->getWorkflowStageId($submissionFile),
@@ -196,10 +174,7 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 							),
 						];
 					}
-					$values[$prop] = $revisions;
-					break;
-				case 'size':
-					$values[$prop] = Services::get('file')->fs->getSize($path);
+					$values[$prop] = $files;
 					break;
 				case 'url':
 					$values[$prop] = $dispatcher->url(
@@ -589,20 +564,20 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 				break;
 		}
 
-		// Get all revision file ids before they are deleted in SubmissionFileDAO::deleteObject
-		$revisionFileIds = $this->getRevisionFileIds($submissionFile->getId());
+		// Get all revision files before they are deleted in SubmissionFileDAO::deleteObject
+		$revisions = $submissionFileDao->getRevisions($submissionFile->getId());
 
 		// Delete the submission file
 		$submissionFileDao->deleteObject($submissionFile);
 
 		// Delete all files not referenced by other files
-		foreach ($revisionFileIds as $fileId) {
+		foreach ($revisions as $revision) {
 			$countFileShares = $this->getCount([
-				'fileIds' => [$fileId],
+				'fileIds' => [$revision->fileId],
 				'includeDependentFiles' => true,
 			]);
 			if (!$countFileShares) {
-				Services::get('file')->delete($fileId);
+				Services::get('file')->delete($revision->fileId);
 			}
 		}
 
@@ -804,12 +779,10 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 	 * Check if a submission file supports dependent files
 	 *
 	 * @param SubmissionFile $submissionFile
-	 * @param string $path
 	 * @return boolean
 	 */
-	public function supportsDependentFiles($submissionFile, $path) {
+	public function supportsDependentFiles($submissionFile) {
 		$fileStage = $submissionFile->getData('fileStage');
-		$mimetype = Services::get('file')->fs->getMimeType($path);
 		$excludedFileStages = [
 			SUBMISSION_FILE_DEPENDENT,
 			SUBMISSION_FILE_QUERY,
@@ -820,9 +793,9 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 			'text/xml',
 		];
 
-		$result = !in_array($fileStage, $excludedFileStages) && in_array($mimetype, $allowedMimetypes);
+		$result = !in_array($fileStage, $excludedFileStages) && in_array($submissionFile->getData('mimetype'), $allowedMimetypes);
 
-		HookRegistry::call('SubmissionFile::supportsDependentFiles', [&$result, $submissionFile, $path]);
+		HookRegistry::call('SubmissionFile::supportsDependentFiles', [&$result, $submissionFile]);
 
 		return $result;
 	}

--- a/classes/services/queryBuilders/PKPSubmissionFileQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionFileQueryBuilder.inc.php
@@ -229,18 +229,4 @@ class PKPSubmissionFileQueryBuilder implements EntityQueryBuilderInterface {
 
 		return $q;
 	}
-
-	/**
-	 * Get the file ids for each revision of a submission file
-	 *
-	 * @param int $submissionFileId
-	 * @return array
-	 */
-	public function getRevisionFileIds($submissionFileId) {
-		return Capsule::table('submission_file_revisions')
-			->where('submission_file_id', '=', $submissionFileId)
-			->orderBy('revision_id', 'desc')
-			->pluck('file_id')
-			->toArray();
-	}
 }

--- a/classes/submission/PKPSubmissionFileDAO.inc.php
+++ b/classes/submission/PKPSubmissionFileDAO.inc.php
@@ -63,13 +63,12 @@ abstract class PKPSubmissionFileDAO extends SchemaDAO implements PKPPubIdPluginD
 	 * @copydoc SchemaDAO::getById
 	 */
 	public function getById($objectId) {
-		$result = $this->retrieve(
-			'SELECT * FROM ' . $this->tableName . ' as sf'
-			. ' LEFT JOIN submissions as s ON (s.submission_id = sf.submission_id)'
-			. ' WHERE ' . $this->primaryKeyColumn . ' = ?',
-			[(int) $objectId]
-		);
-		$row = $result->current();
+		$row = Capsule::table($this->tableName . ' as sf')
+			->leftJoin('submissions as s', 's.submission_id', '=', 'sf.submission_id')
+			->leftJoin('files as f', 'f.file_id', '=', 'sf.file_id')
+			->where($this->primaryKeyColumn, '=', (int) $objectId)
+			->select(['sf.*', 'f.*', 's.locale as locale'])
+			->first();
 		return $row ? $this->_fromRow((array) $row) : null;
 	}
 
@@ -79,6 +78,8 @@ abstract class PKPSubmissionFileDAO extends SchemaDAO implements PKPPubIdPluginD
 	public function _fromRow($primaryRow) {
 		$submissionFile = parent::_fromRow($primaryRow);
 		$submissionFile->setData('locale', $primaryRow['locale']);
+		$submissionFile->setData('path', $primaryRow['path']);
+		$submissionFile->setData('mimetype', $primaryRow['mimetype']);
 
 		return $submissionFile;
 	}
@@ -154,6 +155,21 @@ abstract class PKPSubmissionFileDAO extends SchemaDAO implements PKPPubIdPluginD
 			->delete();
 
 		parent::deleteById($submissionFileId);
+	}
+
+	/**
+	 * Get the files for each revision of a submission file
+	 *
+	 * @param int $submissionFileId
+	 * @return Illuminate\Support\Collection
+	 */
+	public function getRevisions($submissionFileId) {
+		return Capsule::table('submission_file_revisions as sfr')
+			->leftJoin('files as f', 'f.file_id', '=', 'sfr.file_id')
+			->where('submission_file_id', '=', $submissionFileId)
+			->orderBy('revision_id', 'desc')
+			->select(['f.file_id as fileId', 'f.path', 'f.mimetype'])
+			->get();
 	}
 
 

--- a/classes/submission/form/PKPSubmissionSubmitStep2Form.inc.php
+++ b/classes/submission/form/PKPSubmissionSubmitStep2Form.inc.php
@@ -67,7 +67,7 @@ class PKPSubmissionSubmitStep2Form extends SubmissionSubmitForm {
 
 		$templateMgr = TemplateManager::getManager($request);
 
-		$templateMgr->setState([
+		$state = [
 			'components' => [
 				'submissionFiles' => [
 					'addFileLabel' => __('common.addFile'),
@@ -120,12 +120,15 @@ class PKPSubmissionSubmitStep2Form extends SubmissionSubmitForm {
 					'uploadProgressLabel' => __('submission.upload.percentComplete'),
 				],
 			],
-		]);
+		];
 
 		// Temporary workaround that allows state to be passed to a
 		// page fragment retrieved by $templateMgr->fetch(). This
 		// should not be done under normal circumstances!
-		$templateMgr->assignState($templateMgr->_state);
+		//
+		// This should be removed when the submission wizard is updated to
+		// make use of the new forms powered by Vue.js.
+		$templateMgr->assign(['state' => $state]);
 
 		return parent::fetch($request, $template, $display);
 	}

--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -1210,29 +1210,6 @@ class PKPTemplateManager extends Smarty {
 	}
 
 	/**
-	 * DO NOT USE. Assign the state data to the template
-	 *
-	 * This method is a temporary workaround and should not be used
-	 * to pass state to the template. It is only used during submission
-	 * as a temporary method to initialize a Vue.js component inside
-	 * of a tab template.
-	 *
-	 * This can lead to a separate Vue instance embedded inside of the
-	 * main app's Vue instance. The instances can not talk to each other.
-	 *
-	 * This should be removed when the submission wizard is updated to
-	 * make use of the new forms powered by Vue.js.
-	 *
-	 * @deprecated 3.3
-	 * @param [type] $state
-	 * @return void
-	 */
-	function assignState($state) {
-		$this->assign('state', $this->_state);
-	}
-
-
-	/**
 	 * Clear template compile and cache directories.
 	 */
 	function clearTemplateCache() {
@@ -1960,9 +1937,7 @@ class PKPTemplateManager extends Smarty {
 
 		$hasEmbeddedStyle = false;
 		foreach ($embeddedFiles as $embeddedFile) {
-			$path = Services::get('file')->getPath($embeddedFile->getData('fileId'));
-			$mimetype = Services::get('file')->fs->getMimetype($path);
-			if ($mimetype === 'text/css') {
+			if ($embeddedFile->getData('mimetype') === 'text/css') {
 				$hasEmbeddedStyle = true;
 				break;
 			}

--- a/classes/tombstone/DataObjectTombstoneDAO.inc.php
+++ b/classes/tombstone/DataObjectTombstoneDAO.inc.php
@@ -57,8 +57,8 @@ class DataObjectTombstoneDAO extends DAO {
 			'SELECT * FROM data_object_tombstones WHERE data_object_id = ?',
 			[(int) $dataObjectId]
 		);
-
-		return $this->_fromRow((array) $result->current());
+		$row = $result->current();
+		return $row ? $this->_fromRow((array) $row) : null;
 	}
 
 	/**
@@ -111,11 +111,12 @@ class DataObjectTombstoneDAO extends DAO {
 	/**
 	 * Delete DataObjectTombstone by data object id.
 	 * @param $dataObjectId int
-	 * @return boolean
 	 */
 	function deleteByDataObjectId($dataObjectId) {
 		$dataObjectTombstone = $this->getByDataObjectId($dataObjectId);
-		return $this->deleteById($dataObjectTombstone->getId());
+		if ($dataObjectTombstone) {
+			$this->deleteById($dataObjectTombstone->getId());
+		}
 	}
 
 	/**

--- a/controllers/api/file/FileApiHandler.inc.php
+++ b/controllers/api/file/FileApiHandler.inc.php
@@ -77,13 +77,18 @@ class FileApiHandler extends Handler {
 	function downloadFile($args, $request) {
 		$submissionFile = $this->getAuthorizedContextObject(ASSOC_TYPE_SUBMISSION_FILE);
 		$fileId = $request->getUserVar('fileId') ?? $submissionFile->getData('fileId');
-		$validFileIds = Services::get('submissionFile')->getRevisionFileIds($submissionFile->getId());
-		if (!in_array($fileId, $validFileIds)) {
+		$revisions = DAORegistry::getDAO('SubmissionFileDAO')->getRevisions($submissionFile->getId());
+		$file = null;
+		foreach ($revisions as $revision) {
+			if ($revision->fileId == $fileId) {
+				$file = $revision;
+			}
+		}
+		if (!$file) {
 			throw new Exception('File ' . $fileId . ' is not a revision of submission file ' . $submissionFile->getId());
 		}
-		$path = Services::get('file')->getPath((int) $fileId);
-		if (!Services::get('file')->fs->has($path)) {
-			throw new Exception('File ' . $fileId . ' at ' . $path . ' does not exist or can not be read.');
+		if (!Services::get('file')->fs->has($file->path)) {
+			$request->getDispatcher()->handle404();
 		}
 
 		$filename = $request->getUserVar('filename') ?? $submissionFile->getLocalizedData('name');
@@ -106,9 +111,9 @@ class FileApiHandler extends Handler {
 			);
 		}
 
-		$filename = Services::get('file')->formatFilename($path, $filename);
+		$filename = Services::get('file')->formatFilename($file->path, $filename);
 
-		Services::get('file')->download($path, $filename);
+		Services::get('file')->download($file->path, $filename);
 	}
 
 	/**
@@ -133,7 +138,7 @@ class FileApiHandler extends Handler {
 
 		$files = [];
 		foreach ($submissionFiles as $submissionFile) {
-			$path = Services::get('file')->getPath($submissionFile->getData('fileId'));
+			$path = $submissionFile->getData('path');
 			$files[$path] = Services::get('file')->formatFilename($path, $submissionFile->getLocalizedData('name'));
 		}
 

--- a/controllers/grid/files/FileNameGridColumn.inc.php
+++ b/controllers/grid/files/FileNameGridColumn.inc.php
@@ -58,7 +58,7 @@ class FileNameGridColumn extends GridColumn {
 		$submissionFileData = $row->getData();
 		$submissionFile = $submissionFileData['submissionFile'];
 		assert(is_a($submissionFile, 'SubmissionFile'));
-		$fileExtension = pathinfo(Services::get('file')->getPath($submissionFile->getData('fileId')), PATHINFO_EXTENSION);
+		$fileExtension = pathinfo($submissionFile->getData('path'), PATHINFO_EXTENSION);
 		return array('label' => '<span class="file_extension ' . $fileExtension . '">' . $submissionFile->getId() . '</span>');
 	}
 

--- a/controllers/modals/editorDecision/form/EditorDecisionWithEmailForm.inc.php
+++ b/controllers/modals/editorDecision/form/EditorDecisionWithEmailForm.inc.php
@@ -252,7 +252,7 @@ class EditorDecisionWithEmailForm extends EditorDecisionForm {
 					assert(!is_null($reviewIndex));
 
 					// Add the attachment to the email.
-					$path = rtrim(Config::getVar('files', 'files_dir'), '/') . '/' . Services::get('file')->getPath($submissionFile->getData('fileId'));
+					$path = rtrim(Config::getVar('files', 'files_dir'), '/') . '/' . $submissionFile->getData('path');
 					$email->addAttachment(
 						$path,
 						PKPString::enumerateAlphabetically($reviewIndex).'-'.$submissionFile->getLocalizedData('name')

--- a/controllers/wizard/fileUpload/form/PKPSubmissionFilesUploadBaseForm.inc.php
+++ b/controllers/wizard/fileUpload/form/PKPSubmissionFilesUploadBaseForm.inc.php
@@ -155,7 +155,7 @@ class PKPSubmissionFilesUploadBaseForm extends Form {
 				} elseif ($reviewRound) {
 					// Retrieve the submission files for the given review round.
 					$submissionFilesIterator = Services::get('submissionFile')->getMany([
-						'reviewRoundIds' => [(int) $reviewRound],
+						'reviewRoundIds' => [(int) $reviewRound->getId()],
 						'submissionIds' => [(int) $this->getData('submissionId')],
 					]);
 					$this->_submissionFiles = iterator_to_array($submissionFilesIterator);

--- a/controllers/wizard/fileUpload/form/SubmissionFilesMetadataForm.inc.php
+++ b/controllers/wizard/fileUpload/form/SubmissionFilesMetadataForm.inc.php
@@ -126,14 +126,13 @@ class SubmissionFilesMetadataForm extends Form {
 	function fetch($request, $template = null, $display = false) {
 		$templateMgr = TemplateManager::getManager($request);
 		$reviewRound = $this->getReviewRound();
-		$filepath = Services::get('file')->getPath($this->getSubmissionFile()->getData('fileId'));
 		$genre = DAORegistry::getDAO('GenreDAO')->getById($this->getSubmissionFile()->getData('genreId'), $request->getContext()->getId());
 
 		$templateMgr->assign(array(
 			'submissionFile' => $this->getSubmissionFile(),
 			'stageId' => $this->getStageId(),
 			'reviewRoundId' => $reviewRound?$reviewRound->getId():null,
-			'supportsDependentFiles' => Services::get('submissionFile')->supportsDependentFiles($this->getSubmissionFile(), $filepath),
+			'supportsDependentFiles' => Services::get('submissionFile')->supportsDependentFiles($this->getSubmissionFile()),
 			'genre' => $genre,
 		));
 		return parent::fetch($request, $template, $display);

--- a/plugins/generic/usageEvent/PKPUsageEventPlugin.inc.php
+++ b/plugins/generic/usageEvent/PKPUsageEventPlugin.inc.php
@@ -193,16 +193,13 @@ abstract class PKPUsageEventPlugin extends GenericPlugin {
 		$htmlPageAssocTypes = $this->getHtmlPageAssocTypes();
 		if (in_array($assocType, $htmlPageAssocTypes)) {
 			// HTML pages with no file downloads.
-			$docSize = 0;
 			$mimeType = 'text/html';
 		} elseif (is_a($pubObject, 'IssueGalley')) {
-			$docSize = (int)$pubObject->getFileSize();
 			$mimeType = $pubObject->getFileType();
 		} else {
 			// Files.
-			$path = Services::get('file')->getPath($pubObject->getData('fileId'));
-			$docSize = Services::get('file')->fs->getSize($path);
-			$mimeType = Services::get('file')->fs->getMimetype($path);
+			$path = $pubObject->getData('path');
+			$mimeType = $pubObject->getData('mimetype');
 		}
 
 		$canonicalUrl = $router->url(
@@ -316,7 +313,6 @@ abstract class PKPUsageEventPlugin extends GenericPlugin {
 		* %t: request time => $time
 		* %r: query => derived objects: $pubObject, $assocType, $canonicalUrl, $identifiers, $serviceUri, $classification
 		* %s: status => not supported (always 200 in our case)
-		* %b: response size => $docSize
 		*
 		* 2) other common parameters
 		* %O: bytes sent => not supported (cannot be reliably determined from within PHP)
@@ -333,7 +329,7 @@ abstract class PKPUsageEventPlugin extends GenericPlugin {
 		// Collect all information into an array.
 		$usageEvent = compact(
 			'time', 'pubObject', 'assocType', 'canonicalUrl', 'mimeType',
-			'identifiers', 'docSize', 'downloadSuccess', 'serviceUri',
+			'identifiers', 'downloadSuccess', 'serviceUri',
 			'ip', 'host', 'user', 'roles', 'userAgent', 'referrer',
 			'classification'
 		);

--- a/plugins/importexport/native/filter/SubmissionFileNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/SubmissionFileNativeXmlFilter.inc.php
@@ -134,14 +134,13 @@ class SubmissionFileNativeXmlFilter extends NativeExportFilter {
 		$this->addIdentifiers($doc, $submissionFileNode, $submissionFile);
 
 		// Create the revision nodes
-		$fileIds = Services::get('submissionFile')->getRevisionFileIds($submissionFile->getId());
-		foreach ($fileIds as $fileId) {
-			$path = Services::get('file')->getPath($fileId);
-			$localPath = rtrim(Config::getVar('files', 'files_dir'), '/') . '/' . $path;
+		$revisions = DAORegistry::getDAO('SubmissionFileDAO')->getRevisions($submissionFile->getId());
+		foreach ($revisions as $revision) {
+			$localPath = rtrim(Config::getVar('files', 'files_dir'), '/') . '/' . $revision->path;
 			$revisionNode = $doc->createElementNS($deployment->getNamespace(), 'file');
-			$revisionNode->setAttribute('id', $fileId);
+			$revisionNode->setAttribute('id', $revision->fileId);
 			$revisionNode->setAttribute('filesize', filesize($localPath));
-			$revisionNode->setAttribute('extension', pathinfo($path, PATHINFO_EXTENSION));
+			$revisionNode->setAttribute('extension', pathinfo($revision->path, PATHINFO_EXTENSION));
 
 			if (array_key_exists('no-embed', $this->opts)) {
 				$hrefNode = $doc->createElementNS($deployment->getNamespace(), 'href');
@@ -157,9 +156,9 @@ class SubmissionFileNativeXmlFilter extends NativeExportFilter {
 					$url = $dispatcher->url($request, ROUTE_COMPONENT, $context->getPath(), "api.file.FileApiHandler", "downloadFile", null, $params);
 					$hrefNode->setAttribute('src', $url);
 				} else {
-					$hrefNode->setAttribute('src', $path);
+					$hrefNode->setAttribute('src', $revision->path);
 				}
-				$hrefNode->setAttribute('mime_type', Services::get('file')->fs->getMimetype($path));
+				$hrefNode->setAttribute('mime_type', $revision->mimetype);
 				$revisionNode->appendChild($hrefNode);
 			} else {
 				$embedNode = $doc->createElementNS($deployment->getNamespace(), 'embed', base64_encode(file_get_contents($localPath)));

--- a/schemas/submissionFile.json
+++ b/schemas/submissionFile.json
@@ -183,20 +183,11 @@
 					"path": {
 						"type": "string"
 					},
-					"size": {
-						"type": "string"
-					},
 					"url": {
 						"type": "string"
 					}
 				}
 			}
-		},
-		"size": {
-			"type": "string",
-			"apiSummary": true,
-			"readOnly": true,
-			"description": "The size of this file in bytes."
 		},
 		"sourceSubmissionFileId": {
 			"type": "integer",


### PR DESCRIPTION
This commit checks that a file exists before trying to retrieve details
like the mimetype or file size. To improve support for third-party file
storage systems, it reduces the number of cases where the file needs
to be accessed on the file system to return information about it. These
changes include:

- Mimetype is now stored in the files table.
- The size property is no longer returned in API requests.
- File mimetypes are now migrated from the old database when upgrading
  to 3.3.
- The docSize property was removed from usageEvent data.