### PR TITLE
pkp/pkp-lib#5390 Improve error messages for API auth failures

### DIFF
--- a/classes/core/APIRouter.inc.php
+++ b/classes/core/APIRouter.inc.php
@@ -139,13 +139,17 @@ class APIRouter extends PKPRouter {
 	/**
 	 * @copydoc PKPRouter::handleAuthorizationFailure()
 	 */
-	function handleAuthorizationFailure($request, $authorizationMessage) {
+	function handleAuthorizationFailure(
+		$request,
+		$authorizationMessage,
+		array $messageParams = []
+	) {
 		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_API, LOCALE_COMPONENT_APP_API);
 		http_response_code('403');
 		header('Content-Type: application/json');
 		echo json_encode([
 			'error' => $authorizationMessage,
-			'errorMessage' => __($authorizationMessage),
+			'errorMessage' => __($authorizationMessage, $messageParams),
 		]);
 		exit;
 	}

--- a/classes/core/PKPComponentRouter.inc.php
+++ b/classes/core/PKPComponentRouter.inc.php
@@ -350,13 +350,17 @@ class PKPComponentRouter extends PKPRouter {
 	/**
 	 * @copydoc PKPRouter::handleAuthorizationFailure()
 	 */
-	function handleAuthorizationFailure($request, $authorizationMessage) {
+	function handleAuthorizationFailure(
+		$request,
+		$authorizationMessage,
+		array $messageParams = []
+	) {
 		// Translate the authorization error message.
 		if (defined('LOCALE_COMPONENT_APP_COMMON')) {
 			AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON);
 		}
 		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_USER);
-		$translatedAuthorizationMessage = __($authorizationMessage);
+		$translatedAuthorizationMessage = __($authorizationMessage, $messageParams);
 
 		// Add the router name and operation if show_stacktrace is enabled.
 		if (Config::getVar('debug', 'show_stacktrace')) {

--- a/classes/core/PKPPageRouter.inc.php
+++ b/classes/core/PKPPageRouter.inc.php
@@ -396,7 +396,7 @@ class PKPPageRouter extends PKPRouter {
 	/**
 	 * @copydoc PKPRouter::handleAuthorizationFailure()
 	 */
-	function handleAuthorizationFailure($request, $authorizationMessage) {
+	function handleAuthorizationFailure($request, $authorizationMessage, array $messageParams = []) {
 		// Redirect to the authorization denied page.
 		if (!$request->getUser()) Validation::redirectLogin();
 		$request->redirect(null, 'user', 'authorizationDenied', null, array('message' => $authorizationMessage));

--- a/classes/core/PKPRouter.inc.php
+++ b/classes/core/PKPRouter.inc.php
@@ -342,7 +342,11 @@ class PKPRouter {
 	 * @param $authorizationMessage string a translation key with the authorization
 	 *  failure message.
 	 */
-	function handleAuthorizationFailure($request, $authorizationMessage) {
+	function handleAuthorizationFailure(
+		$request,
+		$authorizationMessage,
+		array $messageParams = []
+	) {
 		// Must be implemented by sub-classes.
 		assert(false);
 	}

--- a/locale/en_US/api.po
+++ b/locale/en_US/api.po
@@ -17,6 +17,12 @@ msgstr ""
 msgid "api.400.paramNotSupported"
 msgstr "The {$param} parameter is not supported."
 
+msgid "api.400.invalidApiToken"
+msgstr "The API token could not be validated. This may indicate an error in the API token or that the API token is no longer valid."
+
+msgid "api.400.tokenCouldNotBeDecoded"
+msgstr "The apiToken could not be decoded because of the following error: {$error}"
+
 msgid "api.files.400.notAllowedCreatedAt"
 msgstr "It is not possible to change the time this was created."
 
@@ -28,6 +34,9 @@ msgstr "The requested resource was not found."
 
 msgid "api.404.endpointNotFound"
 msgstr "The requested URL was not recognized."
+
+msgid "api.500.apiSecretKeyMissing"
+msgstr "The API token can not be used to access this site because the site administrator has not configured a secret key."
 
 msgid "api.announcements.404.announcementNotFound"
 msgstr "The announcement you requested was not found."


### PR DESCRIPTION
Testing out a rebase of https://github.com/pkp/pkp-lib/pull/6562 to see if this sorts the test errors out.