### PR TITLE
pkp/pkp-lib#6683 preserve ordering of blocks on appearance form

### DIFF
--- a/classes/components/forms/context/PKPAppearanceSetupForm.inc.php
+++ b/classes/components/forms/context/PKPAppearanceSetupForm.inc.php
@@ -42,13 +42,30 @@ class PKPAppearanceSetupForm extends FormComponent {
 		$this->locales = $locales;
 
 		$sidebarOptions = [];
+		$enabledOptions = [];
+		$disabledOptions = [];
+
+		$currentBlocks = (array) $context->getData('sidebar');
+
 		$plugins = \PluginRegistry::loadCategory('blocks', true);
-		foreach ($plugins as $pluginName => $plugin) {
-			$sidebarOptions[] = [
-				'value' => $pluginName,
-				'label' => $plugin->getDisplayName(),
+
+		foreach ($currentBlocks as $plugin) {
+			$enabledOptions[] = [
+				'value' => $plugin,
+				'label' => $plugins[$plugin]->getDisplayName(),
 			];
+
 		}
+		foreach ($plugins as $pluginName => $plugin) {
+			if (!in_array($pluginName, $currentBlocks)) {
+				$disabledOptions[] = [
+					'value' => $pluginName,
+					'label' => $plugin->getDisplayName(),
+				];
+			}
+		}
+
+		$sidebarOptions = array_merge($enabledOptions, $disabledOptions);
 
 		$this->addField(new FieldUploadImage('pageHeaderLogoImage', [
 				'label' => __('manager.setup.logo'),
@@ -81,7 +98,7 @@ class PKPAppearanceSetupForm extends FormComponent {
 			->addField(new FieldOptions('sidebar', [
 				'label' => __('manager.setup.layout.sidebar'),
 				'isOrderable' => true,
-				'value' => (array) $context->getData('sidebar'),
+				'value' => $currentBlocks,
 				'options' => $sidebarOptions,
 			]));
 

--- a/classes/components/forms/context/PKPAppearanceSetupForm.inc.php
+++ b/classes/components/forms/context/PKPAppearanceSetupForm.inc.php
@@ -50,7 +50,7 @@ class PKPAppearanceSetupForm extends FormComponent {
 		$plugins = \PluginRegistry::loadCategory('blocks', true);
 
 		foreach ($currentBlocks as $plugin) {
-			if ($plugins[$plugin]) {
+			if (isset($plugins[$plugin])) {
 				$enabledOptions[] = [
 					'value' => $plugin,
 					'label' => $plugins[$plugin]->getDisplayName(),

--- a/classes/components/forms/context/PKPAppearanceSetupForm.inc.php
+++ b/classes/components/forms/context/PKPAppearanceSetupForm.inc.php
@@ -50,12 +50,14 @@ class PKPAppearanceSetupForm extends FormComponent {
 		$plugins = \PluginRegistry::loadCategory('blocks', true);
 
 		foreach ($currentBlocks as $plugin) {
-			$enabledOptions[] = [
-				'value' => $plugin,
-				'label' => $plugins[$plugin]->getDisplayName(),
-			];
-
+			if ($plugins[$plugin]) {
+				$enabledOptions[] = [
+					'value' => $plugin,
+					'label' => $plugins[$plugin]->getDisplayName(),
+				];
+			}
 		}
+
 		foreach ($plugins as $pluginName => $plugin) {
 			if (!in_array($pluginName, $currentBlocks)) {
 				$disabledOptions[] = [


### PR DESCRIPTION
This commit preserves the block order on the appearance form, instead of depending on how the PluginRegistry loads them.  The small side effect of doing it this way is that the enabled blocks will always appear at the top of the block list on the form, in the order they appear on the sidebar. Before, enabled and disabled blocks were mixed together.