### PR TITLE
pkp/pkp-lib#6643 fix wrong file data check for revision notification …

### DIFF
--- a/classes/submission/EditDecisionDAO.inc.php
+++ b/classes/submission/EditDecisionDAO.inc.php
@@ -176,7 +176,7 @@ class EditDecisionDAO extends DAO {
 		]);
 
 		foreach ($submissionFilesIterator as $submissionFile) {
-			if ($submissionFile->getData('uploadedAt') > $decision['dateDecided']) {
+			if ($submissionFile->getData('updatedAt') > $decision['dateDecided']) {
 				$sentRevisions = true;
 				break;
 			}


### PR DESCRIPTION
…update

s. https://github.com/pkp/pkp-lib/issues/6643

The automatic email to the editor is sent when author uploads a revision.
The notifications were not updated because the wrong file data was checked, `uploadedAt` (that seems not to exists) instead of `updatedAt`. This is the fix for that.