### PR TITLE
pkp/pkp-lib#6791 Fix fatal error when deleting announcement types

### DIFF
--- a/classes/announcement/AnnouncementDAO.inc.php
+++ b/classes/announcement/AnnouncementDAO.inc.php
@@ -116,8 +116,7 @@ class AnnouncementDAO extends SchemaDAO {
 	function getByTypeId($typeId) {
 		$result = $this->retrieveRange(
 			'SELECT * FROM announcements WHERE type_id = ? ORDER BY date_posted DESC',
-			[(int) $typeId],
-			$rangeInfo
+			[(int) $typeId]
 		);
 		foreach ($result as $row) {
 			yield $row->announcement_id => $this->_fromRow((array) $row);

--- a/controllers/grid/announcements/AnnouncementTypeGridHandler.inc.php
+++ b/controllers/grid/announcements/AnnouncementTypeGridHandler.inc.php
@@ -212,7 +212,7 @@ class AnnouncementTypeGridHandler extends GridHandler {
 			$user = $request->getUser();
 			$notificationManager->createTrivialNotification($user->getId(), NOTIFICATION_TYPE_SUCCESS, array('contents' => __('notification.removedAnnouncementType')));
 
-			return DAO::getDataChangedEvent($announcementTypeId);
+			return DAO::getDataChangedEvent();
 		}
 
 		return new JSONMessage(false);


### PR DESCRIPTION
The grid tried to reload the deleted row. This commit has it reload
the full grid.