### PR TITLE
Wrong ca_ES translation for "submission.submit.submissionLocaleDescription"

### DIFF
--- a/locale/ca_ES/submission.po
+++ b/locale/ca_ES/submission.po
@@ -2049,7 +2049,7 @@ msgstr "Carregueu un arxiu de discussió"
 msgid "submission.submit.submissionLocaleDescription"
 msgstr ""
 "S'accepten trameses en diversos idiomes. Trieu l'idioma principal de la "
-"tramesa des del menú desplegable que hi ha a sota."
+"tramesa des del menú desplegable que hi ha a sobre."
 
 msgid "submission.submissionTitle"
 msgstr "Títol de la tramesa:"


### PR DESCRIPTION
Fix wrong Catalan translation for "submission.submit.submissionLocaleDescription" for pkp-lib stable-3_2_1
https://github.com/pkp/pkp-lib/issues/6912