### PR TITLE
Wrong es_ES translation for "submission.submit.submissionLocaleDescription"

### DIFF
--- a/locale/es_ES/submission.po
+++ b/locale/es_ES/submission.po
@@ -1524,7 +1524,7 @@ msgid "submission.howToCite.citationFormats"
 msgstr "Más formatos de cita"
 
 msgid "submission.submit.submissionLocaleDescription"
-msgstr "Se aceptan envíos en varios idiomas. Elija el idioma principal del envío desde el menú desplegable de abajo."
+msgstr "Se aceptan envíos en varios idiomas. Elija el idioma principal del envío desde el menú desplegable de arriba."
 
 msgid "submission.upload.proof"
 msgstr "Subir un archivo listo para publicación"


### PR DESCRIPTION
Fix wrong Spanish translation for "submission.submit.submissionLocaleDescription" for pkp-lib stable-3_2_1
#6912