### PR TITLE
Fix `getIntMaxFileMBs`

### DIFF
--- a/classes/core/PKPApplication.inc.php
+++ b/classes/core/PKPApplication.inc.php
@@ -910,7 +910,8 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider
                 break;
             default:
                 // No suffix or nothing matched, so this is "b" (Byte)
-                $num = $num / 1024 / 1024
+                // Reset $num to the limit without cut the last digit
+                $num = UPLOAD_MAX_FILESIZE / 1024 / 1024;
                 break;
         }
         return floor($num);

--- a/classes/core/PKPApplication.inc.php
+++ b/classes/core/PKPApplication.inc.php
@@ -908,6 +908,10 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider
             case 'k':
                 $num = $num / 1024;
                 break;
+            default:
+                // No suffix or nothing matched, so this is "b" (Byte)
+                $num = $num / 1024 / 1024
+                break;
         }
         return floor($num);
     }

--- a/classes/core/PKPApplication.inc.php
+++ b/classes/core/PKPApplication.inc.php
@@ -903,10 +903,11 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider
         $scale = strtolower(substr(UPLOAD_MAX_FILESIZE, -1));
         switch ($scale) {
             case 'g':
-                $num = $num / 1024;
-                // no break
-            case 'k':
                 $num = $num * 1024;
+                break;
+            case 'k':
+                $num = $num / 1024;
+                break;
         }
         return floor($num);
     }

--- a/classes/core/PKPApplication.inc.php
+++ b/classes/core/PKPApplication.inc.php
@@ -908,8 +908,10 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider
             case 'k':
                 $num = $num / 1024;
                 break;
+            case 'm':
+                break; // Is set as MB already, do nothing.
             default:
-                // No suffix or nothing matched, so this is "b" (Byte)
+                // No suffix, so this is "b" (Byte)
                 // Reset $num to the limit without cut the last digit
                 $num = UPLOAD_MAX_FILESIZE / 1024 / 1024;
                 break;


### PR DESCRIPTION
I think we might have a problem here:

The function name says, we want MBs as output unit, right?

I have `1G` set in my php.ini.

The function gets `1` in `$num` and `G` in `$scale`. So far so good.
If the scale is g, the function divides by 1024?? Why? If we want MB, we had to multiply. And case k vice versa.

Second change: `// no break` to `break;` - we use PHP 7.4 and with no break, all cases are actaully executed.

```php
<?php
define('UPLOAD_MAX_FILESIZE', ini_get('upload_max_filesize'));
echo UPLOAD_MAX_FILESIZE;
echo "<br />";

		$num = substr(UPLOAD_MAX_FILESIZE, 0, (strlen(UPLOAD_MAX_FILESIZE) - 1));
		$scale = strtolower(substr(UPLOAD_MAX_FILESIZE, -1));
		

		switch ($scale) {
			case 'g':
			echo "is g<br />";
				$num = $num * 1024;
			case 'k':
			echo "is k<br />";
				$num = $num / 1024;
		}
		echo floor($num);
```

returns: 

```
1G
is g
is k
1
```

which is wrong, in my opinion.

With breaks it results in:

```
1G
is g
1024
```

which seems right to me. Where does the comment `// no break` comes from and why is it noted explicitly?

If I got something wrong, let me know.