### PR TITLE
Fix for empty date boundaries.

### DIFF
--- a/classes/services/PKPPublicationService.inc.php
+++ b/classes/services/PKPPublicationService.inc.php
@@ -256,9 +256,9 @@ class PKPPublicationService implements EntityPropertyInterface, EntityReadInterf
 		$result = $publicationDao->retrieve($publicationQO->toSql(), $publicationQO->getBindings());
 		$row = $result->current();
 		import('classes.statistics.StatisticsHelper');
-		return $row ?
-			[$row->min_date_published, $row->max_date_published] :
-			[STATISTICS_EARLIEST_DATE, date('Y-m-d', strtotime('yesterday'))];
+		$startDate = $row->min_date_published ?: STATISTICS_EARLIEST_DATE;
+                $endDate = $row->max_date_published ?: date('Y-m-d', strtotime('yesterday'));
+                return [$startDate, $endDate];
 	}
 
 	/**


### PR DESCRIPTION
Date boundaries were empty on site wide searches. Rewrote the conditional logic so that the returned array contains those values. Fixes this issue https://github.com/pkp/pkp-lib/issues/7168