### PR TITLE
pkp/pkp-lib#7141 Implementing Mail Service 

### DIFF
--- a/classes/core/MailServiceProvider.inc.php
+++ b/classes/core/MailServiceProvider.inc.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @file classes/core/MailServiceProvider.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MailServiceProvider
+ * @ingroup core
+ *
+ * @brief Registers Laravel's Mailer service without support for markup rendering, such as blade or markdown templates
+ */
+
+namespace PKP\core;
+
+use PKP\mail\Mailer;
+use Illuminate\Mail\MailManager;
+use Illuminate\Mail\MailServiceProvider as IlluminateMailService;
+use InvalidArgumentException;
+use Swift_SendmailTransport;
+
+class MailServiceProvider extends IlluminateMailService
+{
+    /**
+     * Register mailer excluding markdown renderer
+     * @return void
+     */
+    public function register() : void
+    {
+        $this->registerIlluminateMailer();
+    }
+
+    /**
+     * @copydoc \Illuminate\Mail\MailServiceProvider::registerIlluminateMailer()
+     */
+    public function registerIlluminateMailer() : void
+    {
+        $this->app->singleton('mail.manager', function ($app) {
+            return new class($app) extends MailManager
+            {
+                /**
+                 * @see MailManager::resolve()
+                 * @param  string  $name
+                 * @throws InvalidArgumentException
+                 */
+                protected function resolve($name) : Mailer
+                {
+                    $config = $this->getConfig($name);
+
+                    if (is_null($config)) {
+                        throw new InvalidArgumentException("Mailer [{$name}] is not defined.");
+                    }
+
+                    // Override Illuminate mailer construction to remove unsupported view
+                    $mailer = new Mailer(
+                        $name,
+                        $this->createSwiftMailer($config),
+                        $this->app['events']
+                    );
+
+                    if ($this->app->bound('queue')) {
+                        $mailer->setQueue($this->app['queue']);
+                    }
+
+                    return $mailer;
+                }
+
+                // Override Swift sendmail transport construction to allow default path
+                protected function createSendmailTransport(array $config) : Swift_SendmailTransport
+                {
+                    $path = $config['path'] ?? $this->app['config']->get('mail.sendmail');
+                    return $path ? new Swift_SendmailTransport($path) : new Swift_SendmailTransport();
+                }
+            };
+        });
+
+        $this->app->bind('mailer', function ($app) {
+            return $app->make('mail.manager')->mailer();
+        });
+    }
+
+    /**
+     * @copydoc \Illuminate\Mail\MailServiceProvider::provides()
+     */
+    public function provides() : array
+    {
+        return
+            [
+                'mail.manager',
+                'mailer',
+            ];
+    }
+}
+
+if (!PKP_STRICT_MODE) {
+    class_alias('\PKP\core\MailServiceProvider', '\MailServiceProvider');
+}

--- a/classes/core/PKPApplication.inc.php
+++ b/classes/core/PKPApplication.inc.php
@@ -25,6 +25,7 @@ use Exception;
 use PKP\config\Config;
 
 use PKP\db\DAORegistry;
+use PKP\i18n\PKPLocale;
 use PKP\plugins\PluginRegistry;
 use PKP\security\Role;
 use PKP\statistics\PKPStatisticsHelper;

--- a/classes/core/PKPContainer.inc.php
+++ b/classes/core/PKPContainer.inc.php
@@ -90,6 +90,7 @@ class PKPContainer extends Container
         $this->register(new \Illuminate\Database\DatabaseServiceProvider($this));
         $this->register(new \Illuminate\Bus\BusServiceProvider($this));
         $this->register(new \Illuminate\Queue\QueueServiceProvider($this));
+        $this->register(new MailServiceProvider($this));
         $this->register(new AppServiceProvider($this));
     }
 
@@ -164,6 +165,23 @@ class PKPContainer extends Container
             'table' => 'jobs',
             'queue' => 'default',
             'retry_after' => 90,
+        ];
+
+        // Mail Service
+        $items['mail']['default'] = Config::getVar('email', 'smtp') ? 'smtp' : 'sendmail';
+        $items['mail']['mailers']['sendmail'] = [
+            'transport' => 'sendmail',
+            'path' => Config::getVar('email', 'sendmail_path'),
+        ];
+        $items['mail']['mailers']['smtp'] = [
+            'transport' => 'smtp',
+            'host' => Config::getVar('email', 'smtp_server'),
+            'port' => Config::getVar('email', 'smtp_port'),
+            'encryption' => Config::getVar('email', 'smtp_auth'),
+            'username' => Config::getVar('email', 'smtp_username'),
+            'password' => Config::getVar('email', 'smtp_password'),
+            'timeout' => null,
+            'auth_mode' => null,
         ];
 
         $this->instance('config', new Repository($items)); // create instance and bind to use globally

--- a/classes/mail/Mailable.inc.php
+++ b/classes/mail/Mailable.inc.php
@@ -203,9 +203,23 @@ class Mailable extends IlluminateMailable
         $map = static::templateVariablesMap();
         $variables = [];
 
-        $traits = class_uses(static::class);
+        // check presence of traits in the current class and parents
+        $traits = class_uses(static::class) ?: [];
+        if ($parents = class_parents(static::class)) {
+            foreach ($parents as $parent) {
+                $parentTraits = class_uses($parent);
+                if (!$parentTraits) {
+                    continue;
+                }
 
-        if ($traits) {
+                $traits = array_merge(
+                    $traits,
+                    $parentTraits
+                );
+            }
+        }
+
+        if (!empty($traits)) {
             if (array_key_exists(Recipient::class, $traits)) {
                 $variables = array_merge(
                     $variables,

--- a/classes/mail/Mailable.inc.php
+++ b/classes/mail/Mailable.inc.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * @file classes/mail/Mailable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class Mailable
+ * @ingroup mail
+ *
+ * @brief  A base class that represents an email sent in the system.
+ *
+ * This class extends Laravel's mailable class, which provides methods to
+ * configure and send email. This class overrides Laravel's support for message
+ * templates that use blade or markdown templates. Instead, it supports PKP's
+ * email templates system.
+ *
+ * Each email sent by the system which uses an email template should extend
+ * this class. The arguments in the constructor method are used to define the
+ * variables that can be used in the corresponding email templates. This mailable
+ * class provides helper methods to compile the variables and render the email
+ * subject and body.
+ *
+ */
+
+namespace PKP\mail;
+
+use BadMethodCallException;
+use Exception;
+use Illuminate\Mail\Mailable as IlluminateMailable;
+use InvalidArgumentException;
+use PKP\context\Context;
+use PKP\mail\mailables\Recipient;
+use PKP\mail\mailables\Sender;
+use APP\mail\variables\ContextEmailVariable;
+use PKP\mail\variables\QueuedPaymentEmailVariable;
+use PKP\mail\variables\RecipientEmailVariable;
+use PKP\mail\variables\ReviewAssignmentEmailVariable;
+use PKP\mail\variables\SenderEmailVariable;
+use PKP\mail\variables\SiteEmailVariable;
+use PKP\mail\variables\StageAssignmentEmailVariable;
+use PKP\mail\variables\SubmissionEmailVariable;
+use PKP\payment\QueuedPayment;
+use PKP\site\Site;
+use PKP\stageAssignment\StageAssignment;
+use PKP\submission\PKPSubmission;
+use PKP\submission\reviewAssignment\ReviewAssignment;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+
+class Mailable extends IlluminateMailable
+{
+
+    /**
+     * Name of the variable representing a message object assigned to email templates by Illuminate Mailer by default
+     * @var string
+     */
+    public const DATA_KEY_MESSAGE = 'message';
+
+    public const GROUP_OTHER = 'other';
+    public const GROUP_SUBMISSION = 'submission';
+    public const GROUP_REVIEW = 'review';
+    public const GROUP_COPYEDITING = 'copyediting';
+    public const GROUP_PRODUCTION = 'production';
+
+    /**
+     * One or more groups this mailable should be included in
+     *
+     * Mailables are assigned to one or more groups so that they
+     * can be organized when shown in the UI.
+     */
+    protected static array $groupIds = [self::GROUP_OTHER];
+
+    public function __construct(array $args)
+    {
+        $this->setData($args);
+    }
+
+    /**
+     * @param string $localeKey
+     * @throws BadMethodCallException
+     */
+    public function locale($localeKey)
+    {
+        throw new BadMethodCallException('This method isn\'t supported, data passed to ' . static::class .
+            ' should already by localized.');
+    }
+
+    /**
+     * Adds variables to be compiled with email template
+     */
+    public function addVariables(array $variables) : self
+    {
+        $this->viewData = array_merge($this->viewData, $variables);
+        return $this;
+    }
+
+    /**
+     * Use instead of the \Illuminate\Mail\Mailable::view() to compile template message's body
+     * @param string $view HTML string with template variables
+     */
+    public function body(string $view) : self
+    {
+        return parent::view($view, []);
+    }
+
+    /**
+     * Doesn't support Illuminate markdown
+     * @throws BadMethodCallException
+     */
+    public function markdown($view, array $data = []) : self
+    {
+        throw new BadMethodCallException('Markdown isn\'t supported');
+    }
+
+    /**
+     * @return array [self::GROUP_...] workflow stages associated with a mailable
+     */
+    public static function getGroupIds() : array
+    {
+        return static::$groupIds;
+    }
+
+    /**
+     * Method's implementation is required for Mailable to be sent according to Laravel docs
+     * @see \Illuminate\Mail\Mailable::send(), https://laravel.com/docs/7.x/mail#writing-mailables
+     */
+    public function build() : self
+    {
+        return $this;
+    }
+
+    /**
+     * Allow data to be passed to the subject
+     * @param \Illuminate\Mail\Message $message
+     * @throws Exception
+     */
+    protected function buildSubject($message) : self
+    {
+        if (!$this->subject) {
+            throw new Exception('Subject isn\'t specified in ' . static::class);
+        }
+
+        $subject = app('mailer')->compileParams($this->subject, $this->viewData);
+        $message->subject($subject);
+
+        return $this;
+    }
+
+    /**
+     * Returns variables map associated with a specific object,
+     * variables names should be unique
+     * @return string[]
+     */
+    protected static function templateVariablesMap() : array
+    {
+        return
+            [
+                Site::class => SiteEmailVariable::class,
+                Context::class => ContextEmailVariable::class,
+                PKPSubmission::class => SubmissionEmailVariable::class,
+                ReviewAssignment::class => ReviewAssignmentEmailVariable::class,
+                StageAssignment::class => StageAssignmentEmailVariable::class,
+                QueuedPayment::class => QueuedPaymentEmailVariable::class,
+            ];
+    }
+
+    /**
+     * Scans arguments to retrieve variables which can be assigned to the template of the email
+     */
+    protected function setData(array $args) : void
+    {
+        $map = static::templateVariablesMap();
+
+        foreach ($args as $arg) {
+            foreach ($map as $className => $assoc) {
+                if (is_a($arg, $className)) {
+                    $assocVariable = new $assoc($arg);
+                    $this->viewData = array_merge(
+                        $this->viewData,
+                        $assocVariable->getValue()
+                    );
+                    continue 2;
+                }
+            }
+
+            // Give up, object isn't mapped
+            $type = is_object($arg) ? get_class($arg) : gettype($arg);
+            throw new InvalidArgumentException($type . ' argument passed to the ' . static::class . ' constructor isn\'t associated with template variables');
+        }
+    }
+
+    /**
+     * Retrieves array of variables that can be assigned to email templates
+     * @return array ['variableName' => description]
+     */
+    public static function getVariables() : array
+    {
+        $args = static::getParamsClass(static::getConstructor());
+        $map = static::templateVariablesMap();
+        $variables = [];
+
+        $traits = class_uses(static::class);
+
+        if ($traits) {
+            if (array_key_exists(Recipient::class, $traits)) {
+                $variables = array_merge(
+                    $variables,
+                    RecipientEmailVariable::getDescription(),
+                );
+            }
+            if (array_key_exists(Sender::class, $traits)) {
+                $variables = array_merge(
+                    $variables,
+                    SenderEmailVariable::getDescription(),
+                );
+            }
+        }
+
+        foreach ($args as $arg) { /** @var  ReflectionParameter $arg) */
+            $class = $arg->getType()->getName();
+
+            if (!array_key_exists($class, $map)) {
+                continue;
+            }
+
+            // No special treatment for others
+            $variables = array_merge(
+                $variables,
+                $map[$class]::getDescription()
+            );
+        }
+
+        return $variables;
+    }
+
+    /**
+     * @see self::getTemplateVarsDescription
+     */
+    protected static function getConstructor() : ReflectionMethod
+    {
+        $constructor = (new ReflectionClass(static::class))->getConstructor();
+        if (!$constructor) {
+            throw new BadMethodCallException(static::class . ' requires constructor to be explicitly declared');
+        }
+
+        return $constructor;
+    }
+
+    /**
+     * Retrieves arguments of the specified methods
+     * @see self::getTemplateVarsDescription
+     */
+    protected static function getParamsClass(ReflectionMethod $method) : array
+    {
+        $params = $method->getParameters();
+        if (empty($params)) {
+            throw new BadMethodCallException(static::class . ' constructor declaration requires at least one argument');
+        }
+
+        foreach ($params as $param) {
+            $type = $param->getType();
+            if (!$type) {
+                throw new BadMethodCallException(static::class . ' constructor argument $' . $param->getName() . ' should be type hinted');
+            }
+        }
+        return $params;
+    }
+}

--- a/classes/mail/Mailer.inc.php
+++ b/classes/mail/Mailer.inc.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+* @file classes/mail/Mailer.inc.php
+*
+ * Copyright (c) 2014-2021 Simon Fraser University
+* Copyright (c) 2000-2021 John Willinsky
+* Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class Mailer
+ * @ingroup mail
+*
+ * @brief Represents interface to manage emails sending and view
+ */
+
+namespace PKP\mail;
+
+use Exception;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Mail\Mailer as IlluminateMailer;
+use InvalidArgumentException;
+use PKP\core\PKPApplication;
+use PKP\i18n\PKPLocale;
+use PKP\observers\events\MessageSendingContext;
+use PKP\observers\events\MessageSendingSite;
+use Swift_Mailer;
+use Swift_Message;
+
+class Mailer extends IlluminateMailer
+{
+    const OPEN_TAG = '{';
+    const CLOSING_TAG = '}';
+    const DOLLAR_SIGN_TAG = '$';
+
+    /**
+     * Don't bind Laravel View Service, as it's not implemented
+     * @var null
+     */
+    protected $views = null;
+
+    /**
+     * Creates new Mailer instance without binding with View
+     * @copydoc \Illuminate\Mail\Mailer::__construct()
+     */
+    public function __construct(string $name, Swift_Mailer $swift, Dispatcher $events = null)
+    {
+        $this->name = $name;
+        $this->swift = $swift;
+        $this->events = $events;
+    }
+
+    /**
+     * Renders email content into HTML string
+     * @param string $view
+     * @param array $data variable => value, 'message' is reserved for the Laravel's Swift Message (Illuminate\Mail\Message)
+     * @throws Exception
+     * @see \Illuminate\Mail\Mailer::renderView()
+     */
+    protected function renderView($view, $data) : string
+    {
+        if ($view instanceof Htmlable) {
+            // return HTML without data compiling
+            return $view->toHtml();
+        }
+
+        if (!is_string($view)) {
+            throw new InvalidArgumentException('View must be instance of ' . Htmlable::class . ' or a string, ' . get_class($view) . ' is given');
+        }
+
+        return $this->compileParams($view, $data);
+    }
+
+    /**
+     * Compiles email templates by substituting variables with their real values
+     * @param string $view text or HTML string
+     * @param array $data variables with their values passes ['variable' => value]
+     * @return string compiled string with substitute variables
+     * @throws Exception
+     */
+    public function compileParams(string $view, array $data, string $locale = null) : string
+    {
+        $data = $this->localizeData($data, $locale);
+
+        // Remove pre-set message template variable assigned by Illuminate Mailer
+        unset($data[Mailable::DATA_KEY_MESSAGE]);
+
+        $stack = [];
+        $resultString = '';
+        $variable = '';
+        foreach ($template = str_split($view) as $key => $char) {
+            if ($this->openTags($key, $char, $template)) {
+                if (empty($stack)) {
+                    $stack[] = $char;
+                } else {
+                    throw new Exception('Syntax error in email template markdown: opening a new variable tag without closing previous one');
+                }
+                continue;
+            }
+
+            if ($char === self::CLOSING_TAG && !empty($stack)) {
+                array_pop($stack);
+                $resultString = $this->recordVariable($resultString, $variable, $data);
+                $variable = '';
+                continue;
+            }
+
+            if (!empty($stack)) {
+                $variable .= $char;
+                continue;
+            }
+
+            $resultString .= $char;
+        }
+
+        if (!empty($stack)) {
+            throw new Exception('Template variable tag should be closed');
+        }
+
+        return $resultString;
+    }
+
+    /**
+     * Provides localization for email template variables
+     */
+    protected function localizeData(array $data, string $locale = null) : array
+    {
+        if (is_null($locale)) {
+            $locale = PKPLocale::getLocale();
+        }
+
+        if (!PKPLocale::isLocaleValid($locale)) {
+            throw new InvalidArgumentException($locale . ' isn\'t recognized as a valid locale');
+        }
+
+        return array_map(function ($varValue) use ($locale) {
+
+            // Array values contain localized template data
+            if (is_array($varValue)) {
+                if (array_key_exists($locale, $varValue)) {
+                    return $varValue[$locale];
+                } else {
+                    throw new InvalidArgumentException('Template variables doesn\'t have localization for the ' . $locale . ' locale' );
+                }
+            }
+            return $varValue;
+        }, $data);
+    }
+
+    /**
+     * Defines an opening tag of a variable
+     * @param int $key number of char in a string starting from 0
+     * @param string $char char to evaluate
+     * @param array $template array of chars of a template
+     */
+    protected function openTags(int $key, string $char, array $template) : bool
+    {
+        if ($char !== self::OPEN_TAG) {
+            return false;
+        }
+        if ($template[$key+1] === self::DOLLAR_SIGN_TAG) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Compiles a variable and ads to the result string
+     * @param string $compiledString the part of string that has been already compiled
+     * @param string $potentialVariable candidate for a variable to seek in data
+     * @param array $data ['variable' => value]
+     * @return string string with a compiled variable
+     * @throws Exception if data doesn't include the variable
+     */
+    protected function recordVariable(string $compiledString, string $potentialVariable, array $data) : string
+    {
+        $potentialVariable = trim(ltrim($potentialVariable, self::DOLLAR_SIGN_TAG)); // makes {$ variable } and similar also allowed
+        if (array_key_exists($potentialVariable, $data)) {
+            if (filter_var($potentialVariable, FILTER_VALIDATE_URL)) {
+                return $this->handleUrl($compiledString, $potentialVariable, $data);
+            } else {
+                return $compiledString . $data[$potentialVariable];
+            }
+        }
+
+        throw new Exception('Variable with name ' . $potentialVariable . ' is not assigned to this email template');
+    }
+
+    /**
+     * Manage URLs as HTML links
+     * @param string $compiledString the port string that has been compiled already
+     * @param string $potentialVariable URL
+     * @param array $data ['variable' => value]
+     * @return string
+     */
+    protected function handleUrl(string $compiledString, string $potentialVariable, array $data) : string
+    {
+        $latestSymbols = substr($compiledString, -2);
+        $value = $data[$potentialVariable];
+        if ($latestSymbols === '=\'' || $latestSymbols === '=\"') {
+            return $compiledString . $value;
+        }
+
+        return $compiledString . '<a href="' . $value . '">' . $value . '</a>';
+    }
+
+    /**
+     * Overrides Illuminate Mailer method to provide additional parameters to the event
+     * @param Swift_Message $message
+     * @param array $data
+     * @return bool
+     */
+    protected function shouldSendMessage($message, $data = [])
+    {
+        if (!$this->events) {
+            return true;
+        }
+
+        $request = PKPApplication::get()->getRequest();
+        $context = $request->getContext();
+        if ($context) {
+            return $this->events->until(new MessageSendingContext($context, $message, $data)) !== false;
+        }
+
+        $site = $request->getSite();
+        return $this->events->until(new MessageSendingSite($site, $message, $data)) !== false;
+    }
+}

--- a/classes/mail/mailables/FormEmailData.inc.php
+++ b/classes/mail/mailables/FormEmailData.inc.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @file mail/mailables/FormEmailData.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class FormEmailData
+ * @ingroup mail_mailables
+ *
+ * @brief Serves to transfer data from the form/request to mailable
+ */
+
+namespace PKP\mail\mailables;
+
+use Illuminate\Support\LazyCollection;
+use PKP\facades\Repo;
+use PKP\user\User;
+
+class FormEmailData
+{
+    protected string $body;
+
+    protected string $subject;
+
+    protected bool $skipEmail = false;
+
+    protected array $recipientIds = [];
+
+    protected bool $separateRecipients = false;
+
+    protected int $senderId;
+
+    protected array $variables = [];
+
+    public function setBody(string $body) : FormEmailData
+    {
+        $this->body = $body;
+        return $this;
+    }
+
+    public function setSubject(?string $subject) : FormEmailData
+    {
+        if ($subject) {
+            $this->subject = $subject;
+        }
+        return $this;
+    }
+
+    public function skipEmail(bool $skip) : FormEmailData
+    {
+        $this->skipEmail = $skip;
+        return $this;
+    }
+
+    public function setRecipientIds(array $userIds) : FormEmailData
+    {
+        $this->recipientIds = $userIds;
+        return $this;
+    }
+
+    public function setSenderId(int $userId) : FormEmailData
+    {
+        $this->senderId = $userId;
+        return $this;
+    }
+
+    public function addVariables(array $variablesToAdd) : FormEmailData
+    {
+        $this->variables = $variablesToAdd + $this->variables;
+        return $this;
+    }
+
+    public function shouldBeSkipped() {
+        return $this->skipEmail;
+    }
+
+    public function getRecipients(int $contextId) : LazyCollection
+    {
+        return Repo::user()->getMany(
+            Repo::user()->getCollector()
+                ->filterByUserIds($this->recipientIds)
+                ->filterByContextIds([$contextId])
+        );
+    }
+
+    public function getSender() : ?User
+    {
+        return Repo::user()->get($this->senderId);
+    }
+
+    public function getVariables(int $userId = null) : array
+    {
+        return $userId ? $this->variables[$userId] : $this->variables;
+    }
+}

--- a/classes/mail/mailables/MailDiscussionMessage.inc.php
+++ b/classes/mail/mailables/MailDiscussionMessage.inc.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file classes/mail/mailables/MailDiscussionMessage.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MailDiscussionMessage
+ * @ingroup mail_mailables
+ *
+ * @brief Email sent when a message is added to a query
+ */
+
+namespace PKP\mail\mailables;
+
+use PKP\context\Context;
+use PKP\core\PKPServices;
+use PKP\mail\EmailTemplate;
+use PKP\mail\Mailable;
+use PKP\submission\PKPSubmission;
+
+class MailDiscussionMessage extends Mailable
+{
+    use Recipient;
+    use Sender;
+
+    public const EMAIL_KEY = 'NOTIFICATION';
+
+    protected static array $groupIds = [self::GROUP_SUBMISSION, self::GROUP_REVIEW, self::GROUP_COPYEDITING, self::GROUP_PRODUCTION];
+
+    public function __construct(Context $context, PKPSubmission $submission)
+    {
+        parent::__construct(func_get_args());
+    }
+
+    public function getTemplate(int $contextId) : EmailTemplate {
+        return PKPServices::get('emailTemplate')->getByKey($contextId, self::EMAIL_KEY);
+    }
+}

--- a/classes/mail/mailables/MailReviewerAssigned.inc.php
+++ b/classes/mail/mailables/MailReviewerAssigned.inc.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file classes/mail/mailables/MailReviewerAssigned.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MailReviewerAssigned
+ * @ingroup mail_mailables
+ *
+ * @brief An email send to a reviewer when they are assigned
+ */
+
+namespace PKP\mail\mailables;
+
+use PKP\context\Context;
+use PKP\mail\Mailable;
+use PKP\submission\PKPSubmission;
+use PKP\submission\reviewAssignment\ReviewAssignment;
+
+class MailReviewerAssigned extends Mailable
+{
+    use Recipient;
+    use Sender;
+
+    protected static array $groupIds = [self::GROUP_REVIEW];
+
+    public function __construct(Context $context, PKPSubmission $submission, ReviewAssignment $reviewAssignment)
+    {
+        parent::__construct(func_get_args());
+    }
+}

--- a/classes/mail/mailables/MailReviewerReinstated.inc.php
+++ b/classes/mail/mailables/MailReviewerReinstated.inc.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file classes/mail/mailables/MailReviewerReinstated.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MailReviewerReinstated
+ * @ingroup mail_mailables
+ *
+ * @brief Email sent to a reviewer when their assignment is reinstated
+ */
+
+namespace PKP\mail\mailables;
+
+use PKP\context\Context;
+use PKP\mail\Mailable;
+use PKP\submission\PKPSubmission;
+use PKP\submission\reviewAssignment\ReviewAssignment;
+
+class MailReviewerReinstated extends Mailable
+{
+    use Recipient;
+    use Sender;
+
+    protected static array $groupIds = [self::GROUP_REVIEW];
+
+    public function __construct(Context $context, PKPSubmission $submission, ReviewAssignment $reviewAssignment)
+    {
+        parent::__construct(func_get_args());
+    }
+}

--- a/classes/mail/mailables/MailReviewerUnassigned.inc.php
+++ b/classes/mail/mailables/MailReviewerUnassigned.inc.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file classes/mail/mailables/MailReviewerUnassigned.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MailReviewerUnassigned
+ * @ingroup mail_mailables
+ *
+ * @brief Email sent when a reviewer is unassigned
+ */
+
+namespace PKP\mail\mailables;
+
+use PKP\context\Context;
+use PKP\mail\Mailable;
+use PKP\submission\PKPSubmission;
+use PKP\submission\reviewAssignment\ReviewAssignment;
+
+class MailReviewerUnassigned extends Mailable
+{
+    use Recipient;
+    use Sender;
+
+    protected static array $groupIds = [self::GROUP_REVIEW];
+
+    public function __construct(Context $context, PKPSubmission $submission, ReviewAssignment $reviewAssignment)
+    {
+        parent::__construct(func_get_args());
+    }
+}

--- a/classes/mail/mailables/Recipient.inc.php
+++ b/classes/mail/mailables/Recipient.inc.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file mail/mailables/Recipient.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class Recipient
+ * @ingroup mail_mailables
+ *
+ * @brief mailable's trait to support User recipients
+ */
+
+namespace PKP\mail\mailables;
+
+use BadMethodCallException;
+use InvalidArgumentException;
+use PKP\mail\Mailable;
+use PKP\mail\variables\RecipientEmailVariable;
+use PKP\user\User;
+
+trait Recipient {
+
+    /**
+     * @copydoc Illuminate\Mail\Mailable::setAddress()
+     */
+    abstract protected function setAddress($address, $name = null, $property = 'to');
+
+    /**
+     * @copydoc PKP\mail\Mailable::addVariables()
+     */
+    abstract public function addVariables(array $variables) : Mailable;
+
+    /**
+     * @copydoc Illuminate\Mail\Mailable::to()
+     */
+    public function to($address, $name = null)
+    {
+        throw new BadMethodCallException(static::class . ' doesn\'t support ' . __FUNCTION__ . '(), use setRecipients() instead');
+    }
+
+    /**
+     * Set recipients of the email and set values for related template variables
+     * @param User[] $recipients
+     * @param string|null $defaultLocale
+     * @return Mailable
+     */
+    public function setRecipients(array $recipients) : Mailable
+    {
+        $to = [];
+        foreach ($recipients as $recipient) {
+            if (!is_a($recipient, User::class)) {
+                throw new InvalidArgumentException('Expecting an array consisting of instances of ' . User::class . ' to be passed to ' . static::class . '::' . __FUNCTION__);
+            }
+
+            $to[] = [
+                'email' => $recipient->getEmail(),
+                'name' => $recipient->getFullName(),
+            ];
+        }
+        $this->setAddress($to);
+
+        $recipientVars = new RecipientEmailVariable($recipients);
+        return $this->addVariables($recipientVars->getValue());
+    }
+}

--- a/classes/mail/mailables/Sender.inc.php
+++ b/classes/mail/mailables/Sender.inc.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file mail/mailables/Sender.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class Sender
+ * @ingroup mail_mailables
+ *
+ * @brief mailable's trait to support User sender
+ */
+
+namespace PKP\mail\mailables;
+
+use BadMethodCallException;
+use PKP\mail\Mailable;
+use PKP\mail\variables\SenderEmailVariable;
+use PKP\user\User;
+
+trait Sender
+{
+    /**
+     * @copydoc Illuminate\Mail\Mailable::setAddress()
+     */
+    abstract protected function setAddress($address, $name = null, $property = 'to');
+
+    /**
+     * @copydoc PKP\mail\Mailable::addVariables()
+     */
+    abstract public function addVariables(array $variables) : Mailable;
+
+    /**
+     * @copydoc Illuminate\Mail\Mailable::from()
+     */
+    public function from($address, $name = null) {
+        throw new BadMethodCallException(static::class . ' doesn\'t support ' . __FUNCTION__ . '(), use setSender() instead');
+    }
+
+    /**
+     * Set recipients of the email and set values for related template variables
+     * @param User $sender
+     * @param string|null $defaultLocale
+     * @return Mailable
+     */
+    public function setSender(User $sender, ?string $defaultLocale = null) : Mailable
+    {
+        $this->setAddress($sender->getEmail(), $sender->getFullName($defaultLocale), 'from');
+
+        $senderVars = new SenderEmailVariable($sender);
+        return $this->addVariables($senderVars->getValue());
+    }
+}

--- a/classes/mail/mailables/ValidateEmailContext.inc.php
+++ b/classes/mail/mailables/ValidateEmailContext.inc.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file classes/mail/mailables/ValidateEmailContext.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ValidateEmailContext
+ * @ingroup mail_mailables
+ *
+ * @brief Represents registration validation email
+ */
+
+namespace PKP\mail\mailables;
+
+use PKP\context\Context;
+use PKP\core\PKPServices;
+use PKP\mail\Mailable;
+use PKP\mail\EmailTemplate;
+
+class ValidateEmailContext extends Mailable
+{
+    use Recipient;
+
+    public const EMAIL_KEY = 'USER_VALIDATE';
+
+    public function __construct(Context $context)
+    {
+        parent::__construct(func_get_args());
+    }
+
+    public function getTemplate(int $contextId) : EmailTemplate
+    {
+        return PKPServices::get('emailTemplate')->getByKey($contextId, self::EMAIL_KEY);
+    }
+}

--- a/classes/mail/mailables/ValidateEmailSite.inc.php
+++ b/classes/mail/mailables/ValidateEmailSite.inc.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file classes/mail/mailables/ValidateEmailSite.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ValidateEmailSite
+ * @ingroup mail_mailables
+ *
+ * @brief Represents registration validation email
+ */
+
+namespace PKP\mail\mailables;
+
+use PKP\core\PKPServices;
+use PKP\mail\Mailable;
+use PKP\mail\EmailTemplate;
+use PKP\site\Site;
+
+class ValidateEmailSite extends Mailable
+{
+    use Recipient;
+
+    public const EMAIL_KEY = 'USER_VALIDATE';
+
+    public function __construct(Site $site)
+    {
+        parent::__construct(func_get_args());
+    }
+
+    public function getTemplate(int $contextId) : EmailTemplate
+    {
+        return PKPServices::get('emailTemplate')->getByKey($contextId, self::EMAIL_KEY);
+    }
+}

--- a/classes/mail/variables/ContextEmailVariable.inc.php
+++ b/classes/mail/variables/ContextEmailVariable.inc.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @file classes/mail/variables/ContextEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ContextEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents variables that are associated with a given context (journal or press)
+ */
+
+namespace PKP\mail\variables;
+
+use PKP\context\Context;
+use PKP\core\PKPApplication;
+use PKP\core\PKPRequest;
+
+class ContextEmailVariable extends Variable
+{
+    const CONTEXT_NAME = 'contextName';
+    const CONTEXT_URL = 'contextUrl';
+    const CONTACT_NAME = 'contactName';
+    const PRINCIPAL_CONTACT_SIGNATURE = 'principalContactSignature';
+    const CONTACT_EMAIL = 'contactEmail';
+    const PASSWORD_LOST_URL = 'passwordLostUrl';
+
+    protected Context $context;
+
+    protected PKPRequest $request;
+
+    public function __construct(Context $context)
+    {
+        $this->context = $context;
+        $this->request = PKPApplication::get()->getRequest();
+    }
+
+    /**
+     * @copydoc Variable::description()
+     */
+    protected static function description() : array
+    {
+        return
+        [
+            self::CONTACT_NAME => __('emailTemplate.variable.context.contactName'),
+            self::PRINCIPAL_CONTACT_SIGNATURE => __('emailTemplate.variable.context.principalContactSignature'),
+            self::CONTACT_EMAIL => __('emailTemplate.variable.context.contactEmail'),
+            self::PASSWORD_LOST_URL => __('emailTemplate.variable.context.passwordLostUrl'),
+        ];
+    }
+
+    /**
+     * @copydoc Variable::values()
+     */
+    protected function values() : array
+    {
+        return
+        [
+            self::CONTACT_NAME => $this->getContactName(),
+            self::PRINCIPAL_CONTACT_SIGNATURE => $this->getPrincipalContactSignature(),
+            self::CONTACT_EMAIL => $this->getContactEmail(),
+            self::PASSWORD_LOST_URL => $this->getPasswordLostUrl(),
+        ];
+    }
+
+    protected function getContextName() : array
+    {
+        return $this->context->getData('name');
+    }
+
+    protected function getContextUrl() : string
+    {
+        return $this->request->getDispatcher()->url($this->request, PKPApplication::ROUTE_PAGE, $this->context->getData('urlPath'));
+    }
+
+    protected function getContactName() : ?string
+    {
+        return $this->context->getData('contactName');
+    }
+
+    protected function getPrincipalContactSignature() : array
+    {
+        $signature = [];
+        foreach ($this->getContextName() as $localeKey => $localizedContextName) {
+            $signature[$localeKey] = $this->getContactName() . "\n" . $localizedContextName;
+        }
+        return $signature;
+    }
+
+    protected function getContactEmail() : string
+    {
+        return $this->context->getData('contactEmail');
+    }
+
+    /**
+     * URL to the lost password page
+     */
+    protected function getPasswordLostUrl() : string
+    {
+        return $this->request->getDispatcher()->url($this->request, PKPApplication::ROUTE_PAGE, $this->context->getData('urlPath'), 'login', 'lostPassword');
+    }
+}

--- a/classes/mail/variables/QueuedPaymentEmailVariable.inc.php
+++ b/classes/mail/variables/QueuedPaymentEmailVariable.inc.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @file classes/mail/variables/QueuedPaymentEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class QueuedPaymentEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents email template variables that are associated with payments
+ */
+
+namespace PKP\mail\variables;
+
+use Application;
+use PKP\core\PKPServices;
+use PKP\payment\QueuedPayment;
+
+class QueuedPaymentEmailVariable extends Variable
+{
+    const ITEM_NAME = 'itemName';
+    const ITEM_COST = 'itemCost';
+    const ITEM_CURRENCY_CODE = 'itemCurrencyCode';
+
+    protected QueuedPayment $queuedPayment;
+
+    public function __construct(QueuedPayment $queuedPayment)
+    {
+        $this->queuedPayment = $queuedPayment;
+    }
+
+    /**
+     * @copydoc Validation::description()
+     */
+    protected static function description() : array
+    {
+        return
+        [
+            self::ITEM_NAME => __('emailTemplate.variable.queuedPayment.itemName'),
+            self::ITEM_COST => __('emailTemplate.variable.queuedPayment.itemCost'),
+            self::ITEM_CURRENCY_CODE => __('emailTemplate.variable.queuedPayment.itemCurrencyCode'),
+        ];
+    }
+
+    /**
+     * @copydoc Validation::values()
+     */
+    protected function values() : array
+    {
+        return
+        [
+            self::ITEM_NAME => $this->getItemName(),
+            self::ITEM_COST => $this->getItemCost(),
+            self::ITEM_CURRENCY_CODE => $this->getItemCurrencyCode(),
+        ];
+    }
+
+    protected function getItemName() : string
+    {
+        $context = PKPServices::get('context')->get($this->queuedPayment->getContextId());
+        $paymentManager = Application::getPaymentManager($context);
+        return $paymentManager->getPaymentName($this->queuedPayment);
+    }
+
+    /**
+     * @return float|int|string|null
+     */
+    protected function getItemCost()
+    {
+        return $this->queuedPayment->getAmount();
+    }
+
+    protected function getItemCurrencyCode() : ?string
+    {
+        return $this->queuedPayment->getCurrencyCode();
+    }
+}

--- a/classes/mail/variables/RecipientEmailVariable.inc.php
+++ b/classes/mail/variables/RecipientEmailVariable.inc.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @file classes/mail/variables/RecipientEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class SenderEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents variables that are associated with an email recipient
+ */
+
+namespace PKP\mail\variables;
+
+use InvalidArgumentException;
+use PKP\i18n\PKPLocale;
+use PKP\user\User;
+
+class RecipientEmailVariable extends Variable
+{
+    const RECIPIENT_FULL_NAME = 'userFullName';
+    const RECIPIENT_USERNAME = 'username';
+
+    protected array $recipients;
+
+    public function __construct(array $recipient)
+    {
+        foreach ($recipient as $user)
+        {
+            if (!is_a($user, User::class))
+                throw new InvalidArgumentException('recipient array values should be an instances or ancestors of ' . User::class . ', ' . get_class($user) . ' is given');
+        }
+
+        $this->recipients = $recipient;
+    }
+
+    /**
+     * @copydoc Variable::description()
+     */
+    protected static function description() : array
+    {
+        return
+        [
+            self::RECIPIENT_FULL_NAME => __('emailTemplate.variable.recipient.userFullName'),
+            self::RECIPIENT_USERNAME => __('emailTemplate.variable.recipient.username'),
+        ];
+    }
+
+    /**
+     * @copydoc Variable::values()
+     */
+    protected function values() : array
+    {
+        return
+        [
+            self::RECIPIENT_FULL_NAME => $this->getRecipientsFullName(),
+            self::RECIPIENT_USERNAME => $this->getRecipientsUserName(),
+        ];
+    }
+
+    /**
+     * Array containing full names of recipients in all supported locales separated by a comma
+     * @return array [localeKey => fullName]
+     */
+    protected function getRecipientsFullName() : array
+    {
+        $fullNamesLocalized = [];
+        $supportedLocales = PKPLocale::getSupportedLocales();
+        foreach ($supportedLocales as $localeKey => $localeValue) {
+            $fullNames = array_map(function(User $user) use ($localeKey) {
+                return $user->getFullName(true, false, $localeKey);
+            }, $this->recipients);
+
+            $fullNamesLocalized[$localeKey] = join(__('common.listSeparator'), $fullNames);
+        }
+
+        return $fullNamesLocalized;
+    }
+
+    /**
+     * Usernames of recipients separated by a comma
+     */
+    protected function getRecipientsUserName() : string
+    {
+        $userNames = array_map(function (User $user) {
+            return $user->getData('username');
+        }, $this->recipients);
+
+        return join(__('common.listSeparator'), $userNames);
+    }
+}

--- a/classes/mail/variables/ReviewAssignmentEmailVariable.inc.php
+++ b/classes/mail/variables/ReviewAssignmentEmailVariable.inc.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file classes/mail/variables/ReviewAssignmentEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ReviewAssignmentEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents email template variables that are associated with a review assignment
+ */
+
+namespace PKP\mail\variables;
+
+use PKP\core\PKPApplication;
+use PKP\submission\reviewAssignment\ReviewAssignment;
+
+class ReviewAssignmentEmailVariable extends Variable
+{
+    const REVIEW_DUE_DATE = 'reviewDueDate';
+    const RESPONSE_DUE_DATE = 'responseDueDate';
+    const SUBMISSION_REVIEW_URL = 'submissionReviewUrl';
+
+    /** @var ReviewAssignment $reviewAssignment */
+    protected $reviewAssignment;
+
+    public function __construct(ReviewAssignment $reviewAssignment)
+    {
+        $this->reviewAssignment = $reviewAssignment;
+    }
+
+    /**
+     * @copydoc Variable::description()
+     */
+    protected static function description(): array
+    {
+        return
+        [
+            self::REVIEW_DUE_DATE => __('emailTemplate.variable.recipient.reviewDueDate'),
+            self::RESPONSE_DUE_DATE => __('emailTemplate.variable.recipient.responseDueDate'),
+            self::SUBMISSION_REVIEW_URL => __('emailTemplate.variable.recipient.submissionReviewUrl'),
+        ];
+    }
+
+    /**
+     * @copydoc Variable::values()
+     */
+    protected function values(): array
+    {
+        return
+        [
+            self::REVIEW_DUE_DATE => $this->getReviewDueDate(),
+            self::RESPONSE_DUE_DATE => $this->getResponseDueDate(),
+            self::SUBMISSION_REVIEW_URL => $this->getSubmissionUrl(),
+        ];
+    }
+
+    protected function getReviewDueDate() : string
+    {
+        return $this->reviewAssignment->getDateDue();
+    }
+
+    protected function getResponseDueDate() : string
+    {
+        return $this->reviewAssignment->getDateResponseDue();
+    }
+
+    /**
+     * URL of the submission for the assigned reviewer
+     */
+    protected function getSubmissionUrl() : string
+    {
+        $request = PKPApplication::get()->getRequest();
+        $dispatcher = $request->getDispatcher();
+        return $dispatcher->url(
+            $request,
+            PKPApplication::ROUTE_PAGE,
+            null,
+            'reviewer',
+            'submission',
+            null,
+            ['submissionId' => $this->reviewAssignment->getSubmissionId()]
+        );
+    }
+}

--- a/classes/mail/variables/SenderEmailVariable.inc.php
+++ b/classes/mail/variables/SenderEmailVariable.inc.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @file classes/mail/variables/SenderEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class SenderEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents variables that are associated with an email sender
+ */
+
+namespace PKP\mail\variables;
+
+use PKP\core\PKPString;
+use PKP\i18n\PKPLocale;
+use PKP\user\User;
+
+class SenderEmailVariable extends Variable
+{
+    const SENDER_NAME = 'senderName';
+    const SENDER_EMAIL = 'senderEmail';
+    const SENDER_CONTACT_SIGNATURE = 'signature';
+
+    protected User $sender;
+
+    public function __construct(User $sender)
+    {
+        $this->sender = $sender;
+    }
+
+    /**
+     * @copydoc Variable::description()
+     */
+    protected static function description(): array
+    {
+        return
+        [
+            self::SENDER_NAME => __('emailTemplate.variable.sender.senderName'),
+            self::SENDER_EMAIL => __('emailTemplate.variable.sender.senderEmail'),
+            self::SENDER_CONTACT_SIGNATURE => __('emailTemplate.variable.sender.signature'),
+        ];
+    }
+
+    /**
+     * @copydoc Variable::values()
+     */
+    protected function values(): array
+    {
+        return
+        [
+            self::SENDER_NAME => $this->getUserFullName(),
+            self::SENDER_EMAIL => $this->getUserEmail(),
+            self::SENDER_CONTACT_SIGNATURE => $this->getUserContactSignature(),
+        ];
+    }
+
+    /**
+     * Array of sender's full name in supported locales
+     */
+    protected function getUserFullName() : array
+    {
+        $fullNameLocalized = [];
+        $supportedLocales = PKPLocale::getSupportedLocales();
+        foreach ($supportedLocales as $localeKey => $localeValue) {
+            $fullNameLocalized[$localeKey] = $this->sender->getFullName(true, false, $localeKey);
+        }
+        return $fullNameLocalized;
+    }
+
+    /**
+     * Sender's email
+     */
+    protected function getUserEmail() : string
+    {
+        return $this->sender->getData('email');
+    }
+
+    /**
+     * Sender's contact signature
+     */
+    protected function getUserContactSignature() : array
+    {
+        $supportedLocales = PKPLocale::getSupportedLocales();
+        PKPLocale::requireComponents(LOCALE_COMPONENT_PKP_USER);
+        $signatureLocalized = [];
+        foreach ($supportedLocales as $localeKey => $localeValue) {
+            $signature = $this->sender->getSignature($localeKey);
+            if (!$signature) {
+                $signature = '';
+            } else {
+                $signature = PKPString::stripUnsafeHtml($signature);
+            }
+            $signatureLocalized[$localeKey] = $signature;
+        }
+
+        return $signatureLocalized;
+    }
+}

--- a/classes/mail/variables/SiteEmailVariable.inc.php
+++ b/classes/mail/variables/SiteEmailVariable.inc.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file classes/mail/variables/SiteEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class SiteEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents variables that are associated with a website
+ */
+
+namespace PKP\mail\variables;
+
+use PKP\site\Site;
+
+class SiteEmailVariable extends Variable
+{
+    const SITE_TITLE = 'siteTitle';
+    const SITE_CONTACT = 'siteContactName';
+
+    protected Site $site;
+
+    public function __construct(Site $site)
+    {
+        $this->site = $site;
+    }
+
+    /**
+     * @copydoc Variable::description()
+     */
+    protected static function description(): array
+    {
+        return
+        [
+            self::SITE_TITLE => __('emailTemplate.variable.site.siteTitle'),
+            self::SITE_CONTACT => __('emailTemplate.variable.site.siteContactName'),
+        ];
+    }
+
+    /**
+     * @copydoc Variable::values()
+     */
+    protected function values(): array
+    {
+       return
+       [
+           self::SITE_TITLE => $this->getSiteTitle(),
+           self::SITE_CONTACT => $this->getSiteContactName(),
+       ];
+    }
+
+    protected function getSiteTitle() : ?array
+    {
+        return $this->site->getData('title');
+    }
+
+    /**
+     * Name of a person indicated as website's primary contact in supported locales
+     */
+    protected function getSiteContactName() : ?array
+    {
+        return $this->site->getData('contactName');
+    }
+}

--- a/classes/mail/variables/StageAssignmentEmailVariable.inc.php
+++ b/classes/mail/variables/StageAssignmentEmailVariable.inc.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @file classes/mail/variables/StageAssignmentEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class StageAssignmentEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents email template variables that are associated with stage assignments
+ */
+
+namespace PKP\mail\variables;
+
+use PKP\db\DAORegistry;
+use PKP\i18n\PKPLocale;
+use PKP\stageAssignment\StageAssignment;
+
+class StageAssignmentEmailVariable extends Variable
+{
+    const DECISION_MAKING_EDITORS = 'editors';
+
+    protected StageAssignment $stageAssignment;
+
+    public function __construct(StageAssignment $stageAssignment)
+    {
+        $this->stageAssignment = $stageAssignment;
+    }
+
+    /**
+     * @copydoc Variable::description()
+     */
+    protected static function description(): array
+    {
+        return
+        [
+            self::DECISION_MAKING_EDITORS => __('emailTemplate.variable.stageAssignment.editors'),
+        ];
+    }
+
+    /**
+     * @copydoc Variable::values()
+     */
+    protected function values(): array
+    {
+        return
+        [
+            self::DECISION_MAKING_EDITORS => $this->getEditors(),
+        ];
+    }
+
+    /**
+     * Full names of editors associated with an assignment
+     */
+    protected function getEditors() : array
+    {
+        $editorsStrLocalized = [];
+        $supportedLocales = PKPLocale::getSupportedLocales();
+        $stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO');
+        $userDao = DAORegistry::getDAO('UserDAO');
+        $editorsStageAssignments = $stageAssignmentDao->getEditorsAssignedToStage($this->stageAssignment->getSubmissionId(), $this->stageAssignment->getStageId());
+        foreach ($supportedLocales as $localeKey => $localeValue) {
+            $editorsStr = '';
+            $i = 0;
+            foreach ($editorsStageAssignments as $editorsStageAssignment) {
+                if (!$editorsStageAssignment->getRecommendOnly()) {
+                    $editorFullName = $userDao->getUserFullName($editorsStageAssignment->getUserId());
+                    $editorsStr .= ($i == 0) ? $editorFullName : ', ' . $editorFullName;
+                    $i++;
+                }
+            }
+            $editorsStrLocalized[$localeKey] = $editorsStr;
+        }
+
+        return $editorsStrLocalized;
+    }
+}

--- a/classes/mail/variables/SubmissionEmailVariable.inc.php
+++ b/classes/mail/variables/SubmissionEmailVariable.inc.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * @file classes/mail/variables/SubmissionEmailVariable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class SubmissionEmailVariable
+ * @ingroup mail_variables
+ *
+ * @brief Represents variables associated with a submission that can be assigned to a template
+ */
+
+namespace PKP\mail\variables;
+
+use APP\article\Author;
+use PKP\core\PKPApplication;
+use PKP\i18n\PKPLocale;
+use PKP\publication\PKPPublication;
+use PKP\submission\PKPSubmission;
+
+class SubmissionEmailVariable extends Variable
+{
+    const SUBMISSION_TITLE = 'submissionTitle';
+    const SUBMISSION_ID = 'submissionId';
+    const SUBMISSION_ABSTRACT = 'submissionAbstract';
+    const AUTHORS = 'authors';
+    const AUTHORS_FULL = 'authorsFull';
+    const SUBMISSION_URL = 'submissionUrl';
+
+    protected PKPSubmission $submission;
+
+    protected PKPPublication $currentPublication;
+
+    /**
+     * @param PKPSubmission $submission
+     */
+    public function __construct(PKPSubmission $submission)
+    {
+        $this->submission = $submission;
+        // Submission's current publication should always be set
+        $this->currentPublication = $this->submission->getCurrentPublication();
+
+    }
+
+    /**
+     * @copydoc Variable::description()
+     */
+    protected static function description() : array
+    {
+        return
+        [
+            self::SUBMISSION_TITLE => __('emailTemplate.variable.submission.submissionTitle'),
+            self::SUBMISSION_ID => __('emailTemplate.variable.submission.submissionId'),
+            self::SUBMISSION_ABSTRACT => __('emailTemplate.variable.submission.submissionAbstract'),
+            self::AUTHORS => __('emailTemplate.variable.submission.authors'),
+            self::AUTHORS_FULL => __('emailTemplate.variable.submission.authorsFull'),
+            self::SUBMISSION_URL => __('emailTemplate.variable.submission.submissionUrl'),
+        ];
+    }
+
+    /**
+     * @copydoc Variable::values()
+     */
+    protected function values() : array
+    {
+        return
+        [
+            self::SUBMISSION_TITLE => $this->getPublicationTitle(),
+            self::SUBMISSION_ID => $this->getSubmissionId(),
+            self::SUBMISSION_ABSTRACT => $this->getPublicationAbstract(),
+            self::AUTHORS => $this->getAuthors(),
+            self::AUTHORS_FULL => $this->getAuthorsFull(),
+            self::SUBMISSION_URL => $this->getSubmissionUrl(),
+        ];
+    }
+
+    protected function getPublicationTitle() : array
+    {
+        $fullTitlesLocalized = [];
+        $supportedLocales = PKPLocale::getSupportedLocales();
+        foreach ($supportedLocales as $localeKey => $localeValue) {
+            $fullTitlesLocalized[$localeKey] = $this->currentPublication->getLocalizedFullTitle($localeKey);
+        }
+        return $fullTitlesLocalized;
+    }
+
+    protected function getSubmissionId() : int
+    {
+        return $this->submission->getId();
+    }
+
+    protected function getPublicationAbstract() : array
+    {
+        return $this->currentPublication->getData('abstract');
+    }
+
+    /**
+     * Shortened authors string
+     * @see PKPPublication::getShortAuthorString()
+     */
+    protected function getAuthors() : array
+    {
+        $authorStringLocalized = [];
+        $supportedLocales = PKPLocale::getSupportedLocales();
+        foreach ($supportedLocales as $localeKey => $localeValue) {
+            $authorStringLocalized[$localeKey] = $this->currentPublication->getShortAuthorString($localeKey);
+        }
+
+        return $authorStringLocalized;
+    }
+
+    /**
+     * List of authors as a string separated by a comma
+     */
+    protected function getAuthorsFull() : array
+    {
+        $authorStringLocalized = [];
+        $authors = $this->currentPublication->getData('authors');
+        $supportedLocales = PKPLocale::getSupportedLocales();
+        foreach ($supportedLocales as $localeKey => $localeValue) {
+            $fullNames = array_map(function(Author $author) use ($localeKey){
+                return $author->getFullName(true, false, $localeKey);
+            }, $authors);
+
+            $authorStringLocalized[$localeKey] = join(__('common.listSeparator'), $fullNames);
+        }
+
+        return $authorStringLocalized;
+    }
+
+    /**
+     * URL to a current workflow stage of the submission
+     */
+    protected function getSubmissionUrl() : string
+    {
+        $request = PKPApplication::get()->getRequest();
+        return $request->getDispatcher()->url($request, PKPApplication::ROUTE_PAGE, null, 'workflow', 'index', [$this->submission->getId(), $this->submission->getData('stageId')]);
+    }
+}

--- a/classes/mail/variables/SubmissionEmailVariable.inc.php
+++ b/classes/mail/variables/SubmissionEmailVariable.inc.php
@@ -15,7 +15,7 @@
 
 namespace PKP\mail\variables;
 
-use APP\article\Author;
+use PKP\submission\PKPAuthor as Author;
 use PKP\core\PKPApplication;
 use PKP\i18n\PKPLocale;
 use PKP\publication\PKPPublication;

--- a/classes/mail/variables/Variable.inc.php
+++ b/classes/mail/variables/Variable.inc.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file classes/mail/variables/Variable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class Variable
+ * @ingroup mail_variables
+ *
+ * @brief A base class for email template variables
+ */
+
+namespace PKP\mail\variables;
+
+use InvalidArgumentException;
+
+abstract class Variable
+{
+    /**
+     * Get descriptions of the variables provided by this class
+     * @return string[]
+     */
+    abstract protected static function description() : array;
+
+    /**
+     * Get the value of variables supported by this class
+     * @return string[]
+     */
+    abstract protected function values() : array;
+
+    /**
+     * Get description of all or specific variable
+     * @param string|null $variableConst
+     * @return string|string[]
+     */
+    static function getDescription(string $variableConst = null)
+    {
+        $description = static::description();
+        if (!is_null($variableConst)) {
+            if (!array_key_exists($variableConst, $description)) {
+                throw new InvalidArgumentException('Template variable \'' . $variableConst . '\' doesn\'t exist in ' . static::class);
+            }
+            return $description[$variableConst];
+        }
+        return $description;
+    }
+
+    /**
+     * Get value of all or specific variable
+     * @param string|null $variableConst
+     * @return string|string[]
+     */
+    function getValue(string $variableConst = null)
+    {
+        $values = static::values();
+        if (!is_null($variableConst)) {
+            if (!array_key_exists($variableConst, $values)) {
+                throw new InvalidArgumentException('Template variable \'' . $variableConst . '\' doesn\'t exist in ' . static::class);
+            }
+            return $values[$variableConst];
+        }
+
+        return $values;
+    }
+}

--- a/classes/observers/events/DiscussionMessageSent.inc.php
+++ b/classes/observers/events/DiscussionMessageSent.inc.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file classes/observers/events/DiscussionMessageSent.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class DiscussionMessageSent
+ * @ingroup observers_events
+ *
+ * @brief An event fired when a discussion message is created.
+ */
+
+namespace PKP\observers\events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use PKP\context\Context;
+use PKP\mail\mailables\FormEmailData;
+use PKP\query\Query;
+use PKP\submission\PKPSubmission;
+
+class DiscussionMessageSent
+{
+    use Dispatchable;
+
+    public Query $query;
+
+    public Context $context;
+
+    public PKPSubmission $submission;
+
+    // Request data entered by user
+    public FormEmailData $formEmailData;
+
+    public function __construct(Query $query, Context $context, PKPSubmission $submission, FormEmailData $formData)
+    {
+        $this->query = $query;
+        $this->context = $context;
+        $this->submission = $submission;
+        $this->formEmailData = $formData;
+    }
+}

--- a/classes/observers/events/MessageSendingContext.inc.php
+++ b/classes/observers/events/MessageSendingContext.inc.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file classes/observers/events/MessageSendingContext.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MessageSendingContext
+ * @ingroup observers_events
+ *
+ * @brief overrides Illuminate event which is fired just before sending email message from the journal/press
+ */
+
+namespace PKP\observers\events;
+
+use Illuminate\Mail\Events\MessageSending as IlluminateMessageSending;
+use PKP\context\Context;
+use Swift_Message;
+
+class MessageSendingContext extends IlluminateMessageSending
+{
+    public Context $context;
+
+    public function __construct(Context $context, Swift_Message $message, array $data = [])
+    {
+        parent::__construct($message, $data);
+        $this->context = $context;
+    }
+}

--- a/classes/observers/events/MessageSendingSite.inc.php
+++ b/classes/observers/events/MessageSendingSite.inc.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file classes/observers/events/MessageSendingSite.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MessageSendingSite
+ * @ingroup observers_events
+ *
+ * @brief overrides Illuminate event which is fired just before sending email message from the site
+ */
+
+namespace PKP\observers\events;
+
+use Illuminate\Mail\Events\MessageSending as IlluminateMessageSending;
+use PKP\site\Site;
+use Swift_Message;
+
+class MessageSendingSite extends IlluminateMessageSending
+{
+    public Site $site;
+
+    public function __construct(Site $site, Swift_Message $message, array $data = [])
+    {
+        parent::__construct($message, $data);
+        $this->site = $site;
+    }
+}

--- a/classes/observers/events/PublishedEvent.inc.php
+++ b/classes/observers/events/PublishedEvent.inc.php
@@ -8,9 +8,9 @@
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class PublishedEvent
- * @ingroup core
+ * @ingroup observers_events
  *
- * @brief Event fired when publication is being published
+ * @brief Event fired when publication is published
  */
 
 namespace PKP\observers\events;

--- a/classes/observers/events/UserRegisteredContext.inc.php
+++ b/classes/observers/events/UserRegisteredContext.inc.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file classes/observers/events/UserRegisteredContext.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class UserRegisteredContext
+ * @ingroup observers_events
+ *
+ * @brief An event fired when a user registers with a context
+ */
+
+namespace PKP\observers\events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use PKP\context\Context;
+use PKP\user\User;
+
+class UserRegisteredContext
+{
+    use Dispatchable;
+
+    public User $recipient;
+
+    public Context $context;
+
+    public function __construct(User $recipient, Context $context)
+    {
+        $this->recipient = $recipient;
+        $this->context = $context;
+    }
+}

--- a/classes/observers/events/UserRegisteredSite.inc.php
+++ b/classes/observers/events/UserRegisteredSite.inc.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file classes/observers/events/UserRegisteredSite.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class UserRegisteredSite
+ * @ingroup observers_events
+ *
+ * @brief An event fired when a user registers from the site-wide registration form
+ */
+
+namespace PKP\observers\events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use PKP\site\Site;
+use PKP\user\User;
+
+class UserRegisteredSite
+{
+    use Dispatchable;
+
+    public User $recipient;
+
+    public Site $site;
+
+    public function __construct(User $recipient, Site $site)
+    {
+        $this->recipient = $recipient;
+        $this->site = $site;
+    }
+}

--- a/classes/observers/listeners/EnvelopeSenderDefault.inc.php
+++ b/classes/observers/listeners/EnvelopeSenderDefault.inc.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @file classes/observers/listeners/EnvelopeSenderDefault.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class EnvelopeSenderDefault
+ * @ingroup observers_listeners
+ *
+ * @brief Sets the envelope sender if it's specified in the config
+ */
+
+namespace PKP\observers\listeners;
+
+use Illuminate\Events\Dispatcher;
+use PKP\config\Config;
+use PKP\observers\events\MessageSendingContext;
+use PKP\observers\events\MessageSendingSite;
+
+class EnvelopeSenderDefault
+{
+    /**
+     * Maps methods with correspondent events to listen
+     */
+    public function subscribe(Dispatcher $events) : void
+    {
+        $events->listen(
+            MessageSendingContext::class,
+            self::class . '@handleSenderContext'
+        );
+
+        $events->listen(
+            MessageSendingSite::class,
+            self::class . '@handleSenderSite'
+        );
+    }
+
+    /**
+     * @param \PKP\observers\events\MessageSendingContext $event
+     */
+    public function handleSenderContext(MessageSendingContext $event)
+    {
+        $this->defaultEnvelopeSender($event);
+    }
+
+    /**
+     * @param \PKP\observers\events\MessageSendingSite $event
+     */
+    public function handleSenderSite(MessageSendingSite $event)
+    {
+        $this->defaultEnvelopeSender($event);
+    }
+
+    /**
+     * @param MessageSendingContext|MessageSendingSite $event
+     */
+    public function defaultEnvelopeSender($event)
+    {
+        // Force default site-wide envelope sender if set
+        $configDefaultEnvelopeSender = Config::getVar('email', 'default_envelope_sender');
+        if (Config::getVar('email', 'force_default_envelope_sender') && $configDefaultEnvelopeSender) {
+            $event->message->setSender($configDefaultEnvelopeSender);
+            return;
+        }
+
+        // Don't provide further checks if envelope sender isn't allowed in the config
+        if (!Config::getVar('email', 'allow_envelope_sender')) {
+            return;
+        }
+
+        // Set the sender provided in the context settings
+        if (get_class($event) === MessageSendingContext::class && $sender = $event->context->getData('envelopeSender')) {
+            $event->message->setSender($sender);
+            return;
+        }
+
+        // Finally, provide default sender from the config
+        if (!$event->message->getSender() && $configDefaultEnvelopeSender) {
+            $event->message->setSender($configDefaultEnvelopeSender);
+        }
+    }
+}

--- a/classes/observers/listeners/MailDiscussionMessage.inc.php
+++ b/classes/observers/listeners/MailDiscussionMessage.inc.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file classes/observers/listeners/MailDiscussionUpdated.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class MailDiscussionUpdated
+ * @ingroup observers_listeners
+ *
+ * @brief Notify users when a discussion is updated
+ */
+
+namespace PKP\observers\listeners;
+
+use Illuminate\Support\Facades\Mail;
+use PKP\db\DAORegistry;
+use PKP\notification\NotificationSubscriptionSettingsDAO;
+use PKP\notification\PKPNotification;
+use PKP\observers\events\DiscussionMessageSent;
+
+class MailDiscussionMessage
+{
+    /**
+     * @param \PKP\observers\events\DiscussionMessageSent $event
+     */
+    public function handle(DiscussionMessageSent $event)
+    {
+        $notificationSubscriptionSettingsDao = DAORegistry::getDAO('NotificationSubscriptionSettingsDAO');
+
+        $users = $event->formEmailData->getRecipients($event->context->getId());
+        foreach ($users as $user) {
+            // Check if user is unsubscribed
+            $notificationSubscriptionSettings = $notificationSubscriptionSettingsDao->getNotificationSubscriptionSettings(
+                NotificationSubscriptionSettingsDAO::BLOCKED_EMAIL_NOTIFICATION_KEY,
+                $user->getId(),
+                (int) $event->context->getId()
+            );
+            if (in_array(PKPNotification::NOTIFICATION_TYPE_NEW_QUERY, $notificationSubscriptionSettings)) {
+                return;
+            }
+
+            $submission = $event->submission;
+            $sender = $event->formEmailData->getSender();
+
+            $mailable = new \PKP\mail\mailables\MailDiscussionMessage($event->context, $submission);
+            $emailTemplate = $mailable->getTemplate($event->context->getId());
+
+            $mailable->addVariables(array_merge(
+                [
+                    'siteTitle' => $mailable->viewData['contextName'],
+                ],
+                $event->formEmailData->getVariables($user->getId())
+            ));
+
+            $mailable
+                ->body($emailTemplate->getLocalizedData('body'))
+                ->subject($emailTemplate->getLocalizedData('subject'))
+                ->setSender($sender)
+                ->setRecipients([$user])
+                ->replyTo($event->context->getContactEmail(), $event->context->getContactName());
+
+            Mail::send($mailable);
+        }
+    }
+}

--- a/classes/observers/listeners/ValidateRegisteredEmail.inc.php
+++ b/classes/observers/listeners/ValidateRegisteredEmail.inc.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @file classes/observers/listeners/ValidateRegisteredEmail.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ValidateRegisteredEmail
+ * @ingroup observers_listeners
+ *
+ * @brief Send an email to a newly registered user asking them to validate their email address
+ */
+
+namespace PKP\observers\listeners;
+
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Mail;
+use PKP\config\Config;
+use PKP\core\PKPApplication;
+use PKP\security\AccessKeyManager;
+use PKP\observers\events\UserRegisteredContext;
+use PKP\observers\events\UserRegisteredSite;
+use PKP\mail\mailables\ValidateEmailContext as ContextMailable;
+use PKP\mail\mailables\ValidateEmailSite as SiteMailable;
+
+class ValidateRegisteredEmail
+{
+    /**
+     * Maps methods with correspondent events to listen
+     */
+    public function subscribe(Dispatcher $events) : void
+    {
+        $events->listen(
+            UserRegisteredContext::class,
+            self::class . '@handleContextRegistration'
+        );
+
+        $events->listen(
+            UserRegisteredSite::class,
+            self::class . '@handleSiteRegistration'
+        );
+    }
+
+    /**
+     * @param \PKP\observers\events\UserRegisteredContext
+     */
+    public function handleContextRegistration(UserRegisteredContext $event) : void
+    {
+        $this->manageEmail($event);
+    }
+
+    /**
+     * @param \PKP\observers\events\UserRegisteredSite $event
+     */
+    public function handleSiteRegistration(UserRegisteredSite $event) : void
+    {
+        $this->manageEmail($event);
+    }
+
+    /**
+     * Sends mail depending on a source - context or site registration
+     * @param UserRegisteredContext|UserRegisteredSite $event
+     */
+    protected function manageEmail($event) : void
+    {
+        if (!$this->emailValidationRequired()) return;
+
+        $accessKeyManager = new AccessKeyManager();
+        $accessKey = $accessKeyManager->createKey(
+            'RegisterContext',
+            $event->recipient->getId(),
+            null,
+            Config::getVar('email', 'validation_timeout')
+        );
+
+        // Create and compile email template
+        if (get_class($event) === UserRegisteredContext::class) {
+            $mailable = new ContextMailable($event->context);
+            $mailable->from($event->context->getData('supportEmail'), $event->context->getData('supportName'));
+            $mailable->addVariables([
+                'activateUrl' => PKPApplication::get()->getRequest()->url($event->context->getData('urlPath'), 'user', 'activateUser', [$event->recipient->getData('username'), $accessKey]),
+            ]);
+            $registerTemplate = $mailable->getTemplate($event->context->getId());
+        } else {
+            $mailable = new SiteMailable($event->site);
+            $mailable->from($event->site->getLocalizedContactEmail(), $event->site->getLocalizedContactName());
+            $mailable->addVariables([
+                'activateUrl' => PKPApplication::get()->getRequest()->url(null, 'user', 'activateUser', [$event->recipient->getData('username'), $accessKey]),
+                'contextName' => $event->site->getLocalizedTitle(),
+                'principalContactSignature' => $mailable->viewData['siteContactName'],
+            ]);
+            $registerTemplate = $mailable->getTemplate(PKPApplication::CONTEXT_SITE);
+        }
+
+        // Send mail
+        $mailable
+            ->body($registerTemplate->getLocalizedData('body'))
+            ->subject($registerTemplate->getLocalizedData('subject'))
+            ->setRecipients($event->recipient);
+
+        Mail::send($mailable);
+    }
+
+    protected function emailValidationRequired() : bool
+    {
+        return (bool) Config::getVar('email', 'require_validation');
+    }
+}

--- a/classes/publication/PKPPublication.inc.php
+++ b/classes/publication/PKPPublication.inc.php
@@ -198,9 +198,11 @@ class PKPPublication extends \PKP\core\DataObject
      *
      * Eg - Barnes, et al.
      *
+     * @param string|null $defaultLocale
+     *
      * @return string
      */
-    public function getShortAuthorString()
+    public function getShortAuthorString($defaultLocale = null)
     {
         $authors = $this->getData('authors');
 
@@ -208,14 +210,14 @@ class PKPPublication extends \PKP\core\DataObject
             return '';
         }
 
-        $str = $authors[0]->getLocalizedFamilyName();
+        $str = $authors[0]->getLocalizedFamilyName($defaultLocale);
         if (!$str) {
-            $str = $authors[0]->getLocalizedGivenName();
+            $str = $authors[0]->getLocalizedGivenName($defaultLocale);
         }
 
         if (count($authors) > 1) {
             AppLocale::requireComponents(LOCALE_COMPONENT_PKP_SUBMISSION);
-            return __('submission.shortAuthor', ['author' => $str]);
+            return __('submission.shortAuthor', ['author' => $str], $defaultLocale);
         }
 
         return $str;

--- a/classes/security/AccessKeyManager.inc.php
+++ b/classes/security/AccessKeyManager.inc.php
@@ -15,9 +15,10 @@
  * @brief Class defining operations for AccessKey management.
  */
 
-namespace PKP\db;
+namespace PKP\security;
 
-use PKP\security\AccessKey;
+use PKP\core\Core;
+use PKP\db\DAORegistry;
 
 class AccessKeyManager
 {

--- a/classes/submission/action/EditorAction.inc.php
+++ b/classes/submission/action/EditorAction.inc.php
@@ -22,7 +22,13 @@ use APP\notification\NotificationManager;
 use APP\submission\Submission;
 use APP\workflow\EditorDecisionActionsManager;
 
+use Illuminate\Mail\Mailable;
+use Illuminate\Support\Facades\Mail;
+use PKP\context\Context;
 use PKP\core\Core;
+use PKP\core\PKPApplication;
+use PKP\core\PKPRequest;
+use PKP\core\PKPServices;
 use PKP\db\DAORegistry;
 use PKP\log\PKPSubmissionEventLogEntry;
 
@@ -30,9 +36,15 @@ use PKP\log\PKPSubmissionEventLogEntry;
 import('classes.workflow.EditorDecisionActionsManager');
 
 use PKP\log\SubmissionLog;
+use PKP\mail\mailables\MailReviewerAssigned;
 use PKP\notification\PKPNotification;
+use PKP\notification\PKPNotificationManager;
 use PKP\plugins\HookRegistry;
+use PKP\security\AccessKeyManager;
 use PKP\submission\PKPSubmission;
+use PKP\submission\reviewAssignment\ReviewAssignment;
+use PKP\user\User;
+use Swift_TransportException;
 
 class EditorAction
 {
@@ -170,6 +182,28 @@ class EditorAction
 
             // Add log
             SubmissionLog::logEvent($request, $submission, PKPSubmissionEventLogEntry::SUBMISSION_LOG_REVIEW_ASSIGN, 'log.review.reviewerAssigned', ['reviewAssignmentId' => $reviewAssignment->getId(), 'reviewerName' => $reviewer->getFullName(), 'submissionId' => $submission->getId(), 'stageId' => $stageId, 'round' => $round]);
+
+            // Send mail
+            if (!$request->getUserVar('skipEmail')) {
+                $context = PKPServices::get('context')->get($submission->getData('contextId'));
+                $user = $request->getUser();
+                $emailTemplate = PKPServices::get('emailTemplate')->getByKey($submission->getData('contextId'), $request->getUserVar('template'));
+                $emailBody = $request->getUserVar('personalMessage');
+                $emailSubject = $emailTemplate->getLocalizedData('subject');
+                $mailable = $this->createMail($submission, $reviewAssignment, $reviewer, $user, $emailBody, $emailSubject, $context);
+
+                try {
+                    Mail::send($mailable);
+                } catch (Swift_TransportException $e) {
+                    $notificationMgr = new PKPNotificationManager();
+                    $notificationMgr->createTrivialNotification(
+                        $request->getUser()->getId(),
+                        PKPNotification::NOTIFICATION_TYPE_ERROR,
+                        ['contents' => __('email.compose.error')]
+                    );
+                    trigger_error($e->getMessage(), E_USER_WARNING);
+                }
+            }
         }
     }
 
@@ -240,6 +274,54 @@ class EditorAction
     public function incrementWorkflowStage($submission, $newStage)
     {
         Repo::submission()->edit($submission, ['stageId' => $newStage]);
+    }
+
+    protected function createMail(
+        PKPSubmission $submission,
+        ReviewAssignment $reviewAssignment,
+        User $reviewer,
+        User $sender,
+        string $emailBody,
+        string $emailSubject,
+        Context $context
+    ) : Mailable
+    {
+        $mailable = new MailReviewerAssigned($context, $submission, $reviewAssignment);
+
+        if ($context->getData('reviewerAccessKeysEnabled')) {
+            // Overwrite default submissionReviewUrl variable value
+            $accessKeyManager = new AccessKeyManager();
+            $expiryDays = ($context->getData('numWeeksPerReview') + 4) * 7;
+            $accessKey = $accessKeyManager->createKey($context->getId(), $reviewer->getId(), $reviewAssignment->getId(), $expiryDays);
+            $mailable->addVariables([
+                'submissionReviewUrl' => PKPApplication::get()->getDispatcher()->url(
+                    PKPApplication::get()->getRequest(),
+                    PKPApplication::ROUTE_PAGE,
+                    $context->getData('urlPath'),
+                    'reviewer',
+                    'submission',
+                    null,
+                    [
+                        'submissionId' => $reviewAssignment->getSubmissionId(),
+                        'reviewId' => $reviewAssignment->getId(),
+                        'key' => $accessKey,
+                    ]
+                )
+            ]);
+        }
+
+        $mailable
+            ->body($emailBody)
+            ->subject($emailSubject)
+            ->setSender($sender)
+            ->setRecipients([$reviewer]);
+
+        // Additional template variable
+        $mailable->addVariables([
+            'reviewerName' => $mailable->viewData['userFullName']
+        ]);
+
+        return $mailable;
     }
 }
 

--- a/classes/submission/action/EditorAction.inc.php
+++ b/classes/submission/action/EditorAction.inc.php
@@ -318,7 +318,8 @@ class EditorAction
 
         // Additional template variable
         $mailable->addVariables([
-            'reviewerName' => $mailable->viewData['userFullName']
+            'reviewerName' => $mailable->viewData['userFullName'],
+            'reviewerUserName' => $mailable->viewData['username'],
         ]);
 
         return $mailable;

--- a/classes/user/form/RegistrationForm.inc.php
+++ b/classes/user/form/RegistrationForm.inc.php
@@ -328,48 +328,7 @@ class RegistrationForm extends Form
         $interestManager = new InterestManager();
         $interestManager->setInterestsForUser($user, $this->getData('interests'));
 
-        if ($requireValidation) {
-            // Create an access key
-            $accessKeyManager = new AccessKeyManager();
-            $accessKey = $accessKeyManager->createKey('RegisterContext', $user->getId(), null, Config::getVar('email', 'validation_timeout'));
-
-            // Send email validation request to user
-            $mail = new MailTemplate('USER_VALIDATE');
-            $this->_setMailFrom($request, $mail);
-            $context = $request->getContext();
-            $contextPath = $context ? $context->getPath() : null;
-            $mail->assignParams([
-                'userFullName' => $user->getFullName(),
-                'contextName' => $context ? $context->getLocalizedName() : $site->getLocalizedTitle(),
-                'activateUrl' => $request->url($contextPath, 'user', 'activateUser', [$this->getData('username'), $accessKey])
-            ]);
-            $mail->addRecipient($user->getEmail(), $user->getFullName());
-            if (!$mail->send()) {
-                $notificationMgr = new NotificationManager();
-                $notificationMgr->createTrivialNotification($user->getId(), PKPNotification::NOTIFICATION_TYPE_ERROR, ['contents' => __('email.compose.error')]);
-            }
-            unset($mail);
-        }
         return $userId;
-    }
-
-    /**
-     * Set mail from address
-     *
-     * @param $request PKPRequest
-     * @param $mail MailTemplate
-     */
-    public function _setMailFrom($request, $mail)
-    {
-        $site = $request->getSite();
-        $context = $request->getContext();
-
-        // Set the sender based on the current context
-        if ($context && $context->getData('supportEmail')) {
-            $mail->setReplyTo($context->getData('supportEmail'), $context->getData('supportName'));
-        } else {
-            $mail->setReplyTo($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
-        }
     }
 }
 

--- a/controllers/grid/queries/QueriesGridHandler.inc.php
+++ b/controllers/grid/queries/QueriesGridHandler.inc.php
@@ -20,11 +20,14 @@ use PKP\controllers\grid\feature\OrderGridItemsFeature;
 use PKP\controllers\grid\GridColumn;
 use PKP\controllers\grid\GridHandler;
 use PKP\core\JSONMessage;
+use PKP\i18n\PKPLocale;
 use PKP\linkAction\LinkAction;
 use PKP\linkAction\request\AjaxModal;
 use PKP\linkAction\request\RemoteActionConfirmationModal;
+use PKP\mail\mailables\FormEmailData;
 use PKP\mail\SubmissionMailTemplate;
 use PKP\notification\PKPNotification;
+use PKP\observers\events\DiscussionMessageSent;
 use PKP\security\authorization\QueryAccessPolicy;
 
 use PKP\security\authorization\QueryWorkflowStageAccessPolicy;
@@ -594,6 +597,8 @@ class QueriesGridHandler extends GridHandler
         if (!$this->getAccessHelper()->getCanEdit($query->getId())) {
             return new JSONMessage(false);
         }
+        $queryDao = DAORegistry::getDAO('QueryDAO');
+        $oldParticipantIds = $queryDao->getParticipantIds($query->getId());
 
         import('lib.pkp.controllers.grid.queries.form.QueryForm');
         $queryForm = new QueryForm(
@@ -607,12 +612,12 @@ class QueriesGridHandler extends GridHandler
 
         if ($queryForm->validate()) {
             $queryForm->execute();
+            $notificationMgr = new NotificationManager();
 
             if ($this->getStageId() == WORKFLOW_STAGE_ID_EDITING ||
                 $this->getStageId() == WORKFLOW_STAGE_ID_PRODUCTION) {
 
                 // Update submission notifications
-                $notificationMgr = new NotificationManager();
                 $notificationMgr->updateNotification(
                     $request,
                     [
@@ -625,6 +630,59 @@ class QueriesGridHandler extends GridHandler
                     ASSOC_TYPE_SUBMISSION,
                     $this->getAssocId()
                 );
+            }
+
+            // Send notifications
+            PKPLocale::requireComponents(LOCALE_COMPONENT_PKP_COMMON);
+            $currentUser = $request->getUser();
+            $newParticipantIds = $queryForm->getData('users');
+            $added = array_diff($newParticipantIds, $oldParticipantIds);
+            // Don't notify the current user
+            if ($key = array_search($currentUser->getId(), $added)) {
+                unset($added[$key]);
+            }
+
+            $formData = new FormEmailData();
+            foreach ($added as $userId) {
+                $notification = $notificationMgr->createNotification(
+                    $request,
+                    $userId,
+                    PKPNotification::NOTIFICATION_TYPE_NEW_QUERY,
+                    $request->getContext()->getId(),
+                    ASSOC_TYPE_QUERY,
+                    $query->getId(),
+                    Notification::NOTIFICATION_LEVEL_TASK,
+                    null,
+                    true
+                );
+                $formData->addVariables([$userId => [
+                    'notificationContents' => $notificationMgr->getNotificationContents($request, $notification),
+                    'url' => $notificationMgr->getNotificationUrl($request, $notification),
+                    'unsubscribeLink' =>
+                        '<br /><a href=\'' .
+                        $notificationMgr->getUnsubscribeNotificationUrl($request, $notification) .
+                        '\'>' .
+                        __('notification.unsubscribeNotifications') .
+                        '</a>'
+                ]]);
+            }
+
+            $assocSubmission = Repo::submission()->get($query->getAssocId());
+
+            try {
+                event(new DiscussionMessageSent(
+                    $query,
+                    $request->getContext(),
+                    $assocSubmission,
+                    $formData->setRecipientIds($added)->setSenderId($request->getUser()->getId())
+                ));
+            } catch (Swift_TransportException $e) {
+                $notificationMgr->createTrivialNotification(
+                    $currentUser->getId(),
+                    PKPNotification::NOTIFICATION_TYPE_ERROR,
+                    ['contents' => __('email.compose.error')]
+                );
+                trigger_error($e->getMessage(), E_USER_WARNING);
             }
             return \PKP\db\DAO::getDataChangedEvent($query->getId());
         }

--- a/controllers/grid/users/reviewer/form/ReinstateReviewerForm.inc.php
+++ b/controllers/grid/users/reviewer/form/ReinstateReviewerForm.inc.php
@@ -52,9 +52,7 @@ class ReinstateReviewerForm extends ReviewerNotifyActionForm
      */
     public function execute(...$functionArgs)
     {
-        if (!parent::execute(...$functionArgs)) {
-            return false;
-        }
+        parent::execute(...$functionArgs);
 
         $request = Application::get()->getRequest();
         $submission = $this->getSubmission(); /** @var Submission $submission */

--- a/controllers/grid/users/reviewer/form/ReviewerNotifyActionForm.inc.php
+++ b/controllers/grid/users/reviewer/form/ReviewerNotifyActionForm.inc.php
@@ -13,11 +13,8 @@
  */
 
 use APP\facades\Repo;
-use APP\notification\NotificationManager;
 use PKP\form\Form;
 use PKP\mail\SubmissionMailTemplate;
-
-use PKP\notification\PKPNotification;
 
 abstract class ReviewerNotifyActionForm extends Form
 {
@@ -57,7 +54,6 @@ abstract class ReviewerNotifyActionForm extends Form
     public function initData()
     {
         $request = Application::get()->getRequest();
-        $context = $request->getContext();
         $submission = $this->getSubmission();
         $reviewAssignment = $this->getReviewAssignment();
         $reviewRound = $this->getReviewRound();
@@ -85,35 +81,6 @@ abstract class ReviewerNotifyActionForm extends Form
 
             $this->setData('personalMessage', $template->getBody());
         }
-    }
-
-    /**
-     * @copydoc Form::execute()
-     *
-     * @return bool whether or not the review assignment was modified successfully
-     */
-    public function execute(...$functionArgs)
-    {
-        $request = Application::get()->getRequest();
-        $submission = $this->getSubmission();
-        $reviewAssignment = $this->getReviewAssignment();
-
-        // Notify the reviewer via email.
-        $mail = new SubmissionMailTemplate($submission, $this->getEmailKey(), null, null, false);
-
-        if ($mail->isEnabled() && !$this->getData('skipEmail')) {
-            $reviewerId = (int) $this->getData('reviewerId');
-            $reviewer = Repo::user()->get($reviewerId);
-            $mail->addRecipient($reviewer->getEmail(), $reviewer->getFullName());
-            $mail->setBody($this->getData('personalMessage'));
-            $mail->assignParams();
-            if (!$mail->send($request)) {
-                $notificationMgr = new NotificationManager();
-                $notificationMgr->createTrivialNotification($request->getUser()->getId(), PKPNotification::NOTIFICATION_TYPE_ERROR, ['contents' => __('email.compose.error')]);
-            }
-        }
-        parent::execute(...$functionArgs);
-        return true;
     }
 
     /**

--- a/controllers/grid/users/reviewer/form/UnassignReviewerForm.inc.php
+++ b/controllers/grid/users/reviewer/form/UnassignReviewerForm.inc.php
@@ -51,9 +51,7 @@ class UnassignReviewerForm extends ReviewerNotifyActionForm
      */
     public function execute(...$functionArgs)
     {
-        if (!parent::execute(...$functionArgs)) {
-            return false;
-        }
+        parent::execute(...$functionArgs);
 
         $request = Application::get()->getRequest();
         $submission = $this->getSubmission();

--- a/locale/en_US/manager.po
+++ b/locale/en_US/manager.po
@@ -2090,3 +2090,54 @@ msgstr "Process failed to parse authors"
 
 msgid "plugins.importexport.publication.exportFailed"
 msgstr "Process failed to parse publications"
+
+msgid "emailTemplate.variable.context.passwordLostUrl"
+msgstr "The URL to a page where the user can recover a lost password"
+
+msgid "emailTemplate.variable.recipient.userFullName"
+msgstr "The full name of the recipient or all recipients"
+
+msgid "emailTemplate.variable.recipient.username"
+msgstr "The username of the recipient or all recipients"
+
+msgid "emailTemplate.variable.recipient.reviewDueDate"
+msgstr "Date when the reviewer should accept or decline the assignment"
+
+msgid "emailTemplate.variable.recipient.responseDueDate"
+msgstr "Date when the review should be completed"
+
+msgid "emailTemplate.variable.recipient.submissionReviewUrl"
+msgstr "The URL to the review assignment"
+
+msgid "emailTemplate.variable.sender.senderName"
+msgstr "The full name of the sender"
+
+msgid "emailTemplate.variable.sender.senderEmail"
+msgstr "The email address of the sender"
+
+msgid "emailTemplate.variable.sender.signature"
+msgstr "The email signature of the sender"
+
+msgid "emailTemplate.variable.site.siteContactName"
+msgstr "The full name of the website's primary contact"
+
+msgid "emailTemplate.variable.stageAssignment.editors"
+msgstr "The editors assigned to this submission who can make a decision"
+
+msgid "emailTemplate.variable.submission.submissionTitle"
+msgstr "The submission's title"
+
+msgid "emailTemplate.variable.submission.submissionId"
+msgstr "The submission's unique ID number"
+
+msgid "emailTemplate.variable.submission.submissionAbstract"
+msgstr "The submission's abstract"
+
+msgid "emailTemplate.variable.submission.authors"
+msgstr "Author names in a form of a shortened string"
+
+msgid "emailTemplate.variable.submission.authorsFull"
+msgstr "The full names of the authors"
+
+msgid "emailTemplate.variable.submission.submissionUrl"
+msgstr "The URL to the submission in the editorial backend"


### PR DESCRIPTION
Contains Illuminate Mail Service Provider integration, email template variables and several examples with Mailables: Reviewer assignment, unassignment and reinstate, as well as email validation. I squashed commits as there were ones that changed previous behaviour making it harder to review.