### PR TITLE
Fix problem with creation of submission file revision in review rounds

### DIFF
--- a/controllers/wizard/fileUpload/PKPFileUploadWizardHandler.inc.php
+++ b/controllers/wizard/fileUpload/PKPFileUploadWizardHandler.inc.php
@@ -71,7 +71,7 @@ class PKPFileUploadWizardHandler extends Handler {
 		// we don't need to validate in another places.
 		$fileStage = (int) $request->getUserVar('fileStage');
 		if ($fileStage) {
-			$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO'); /* @var $submissionFileDao SubmissionFileDAO */
+			$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO'); 
 			$fileStages = $submissionFileDao->getAllFileStages();
 			if (!in_array($fileStage, $fileStages)) {
 				return false;
@@ -429,7 +429,7 @@ class PKPFileUploadWizardHandler extends Handler {
                     $submissionFileDao->assignRevisionToReviewRound($submissionFile->getFileId(), $submissionFile->getRevision(), $reviewRound);
                 }
 
-				if ($submissionFile->getFileStage() == SUBMISSION_FILE_REVIEW_REVISION & !is_null($reviewRound)) {
+				if ($submissionFile->getFileStage() == SUBMISSION_FILE_REVIEW_REVISION && !is_null($reviewRound)) {
 					// Get a list of author user IDs
 					$authorUserIds = array();
 					$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO'); /* @var $stageAssignmentDao StageAssignmentDAO */

--- a/controllers/wizard/fileUpload/PKPFileUploadWizardHandler.inc.php
+++ b/controllers/wizard/fileUpload/PKPFileUploadWizardHandler.inc.php
@@ -422,12 +422,14 @@ class PKPFileUploadWizardHandler extends Handler {
 			case SUBMISSION_FILE_REVIEW_ATTACHMENT:
 			case SUBMISSION_FILE_REVIEW_REVISION:
 				// Add the uploaded review file to the review round.
-                if ($reviewRound = $this->getReviewRound()) {
+				$reviewRound = $this->getReviewRound();
+
+                if (!is_null($reviewRound)) {
                     $submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO'); /* @var $submissionFileDao SubmissionFileDAO */
                     $submissionFileDao->assignRevisionToReviewRound($submissionFile->getFileId(), $submissionFile->getRevision(), $reviewRound);
                 }
 
-				if ($submissionFile->getFileStage() == SUBMISSION_FILE_REVIEW_REVISION & $reviewRound) {
+				if ($submissionFile->getFileStage() == SUBMISSION_FILE_REVIEW_REVISION & !is_null($reviewRound)) {
 					// Get a list of author user IDs
 					$authorUserIds = array();
 					$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO'); /* @var $stageAssignmentDao StageAssignmentDAO */

--- a/controllers/wizard/fileUpload/PKPFileUploadWizardHandler.inc.php
+++ b/controllers/wizard/fileUpload/PKPFileUploadWizardHandler.inc.php
@@ -422,11 +422,12 @@ class PKPFileUploadWizardHandler extends Handler {
 			case SUBMISSION_FILE_REVIEW_ATTACHMENT:
 			case SUBMISSION_FILE_REVIEW_REVISION:
 				// Add the uploaded review file to the review round.
-				$reviewRound = $this->getReviewRound();
-				$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO'); /* @var $submissionFileDao SubmissionFileDAO */
-				$submissionFileDao->assignRevisionToReviewRound($submissionFile->getFileId(), $submissionFile->getRevision(), $reviewRound);
+                if ($reviewRound = $this->getReviewRound()) {
+                    $submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO'); /* @var $submissionFileDao SubmissionFileDAO */
+                    $submissionFileDao->assignRevisionToReviewRound($submissionFile->getFileId(), $submissionFile->getRevision(), $reviewRound);
+                }
 
-				if ($submissionFile->getFileStage() == SUBMISSION_FILE_REVIEW_REVISION) {
+				if ($submissionFile->getFileStage() == SUBMISSION_FILE_REVIEW_REVISION & $reviewRound) {
 					// Get a list of author user IDs
 					$authorUserIds = array();
 					$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO'); /* @var $stageAssignmentDao StageAssignmentDAO */


### PR DESCRIPTION
Fixes file resubmission in review rounds

Here are the PKP forum threads about the error:
https://forum.pkp.sfu.ca/t/can-not-create-a-revision-of-an-existing-document-http-error/68244
https://forum.pkp.sfu.ca/t/php-fatal-error-uncaught-error-call-to-a-member-function-getsubmissionid-on-null-pkp-classes-submission-submissionfiledao-inc-php-456/65176

Signed-off-by: AlineLepidus <aline@lepidus.com.br>
Signed-off-by: carloslepidus <carlos@lepidus.com.br>