### PR TITLE
Fixes problem with retrieving publications in alphabetically ordered category when changing language in version 3.3.0

### DIFF
--- a/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
@@ -277,14 +277,14 @@ abstract class PKPSubmissionQueryBuilder implements EntityQueryBuilderInterface 
 			$locale = \AppLocale::getLocale();
 			$this->columns[] = Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)');
 			$q->leftJoin('publications as publication_tlp', 's.current_publication_id', '=', 'publication_tlp.publication_id')
-				->leftJoin('publication_settings as publication_tlps', function($join) use ($locale) {
+				->leftJoin('publication_settings as publication_tlps', function (object $join) use ($locale) {
 					$join->on('publication_tlp.publication_id', '=', 'publication_tlps.publication_id');
 					$join->on('publication_tlps.setting_name', '=', Capsule::raw("'title'"));
 					$join->on('publication_tlps.setting_value', '!=', Capsule::raw("''"));
 					$join->on('publication_tlps.locale', '=', Capsule::raw("'{$locale}'"));
 				});
 			$q->leftJoin('publications as publication_tlpl', 's.current_publication_id', '=', 'publication_tlpl.publication_id')
-				->leftJoin('publication_settings as publication_tlpsl', function($join){
+				->leftJoin('publication_settings as publication_tlpsl', function (object $join){
 					$join->on('publication_tlp.publication_id', '=', 'publication_tlpsl.publication_id');
 					$join->on('publication_tlpsl.setting_name', '=', Capsule::raw("'title'"));
 					$join->on('publication_tlpsl.locale', '=', Capsule::raw('s.locale'));

--- a/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
@@ -279,15 +279,15 @@ abstract class PKPSubmissionQueryBuilder implements EntityQueryBuilderInterface 
 			$q->leftJoin('publications as publication_tlp', 's.current_publication_id', '=', 'publication_tlp.publication_id')
 				->leftJoin('publication_settings as publication_tlps', function (object $join) use ($locale) {
 					$join->on('publication_tlp.publication_id', '=', 'publication_tlps.publication_id');
-					$join->on('publication_tlps.setting_name', '=', Capsule::raw("'title'"));
-					$join->on('publication_tlps.setting_value', '!=', Capsule::raw("''"));
-					$join->on('publication_tlps.locale', '=', Capsule::raw("'{$locale}'"));
+					$join->where('publication_tlps.setting_name', '=', 'title');
+					$join->where('publication_tlps.setting_value', '!=', '');
+					$join->where('publication_tlps.locale', '=', $locale);
 				});
 			$q->leftJoin('publications as publication_tlpl', 's.current_publication_id', '=', 'publication_tlpl.publication_id')
 				->leftJoin('publication_settings as publication_tlpsl', function (object $join) {
 					$join->on('publication_tlp.publication_id', '=', 'publication_tlpsl.publication_id');
-					$join->on('publication_tlpsl.setting_name', '=', Capsule::raw("'title'"));
-					$join->on('publication_tlpsl.locale', '=', Capsule::raw('s.locale'));
+					$join->where('publication_tlpsl.setting_name', '=', 'title');
+					$join->on('publication_tlpsl.locale', '=', 's.locale');
 				});
 			$q->groupBy(Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)'));
 		}

--- a/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
@@ -284,7 +284,7 @@ abstract class PKPSubmissionQueryBuilder implements EntityQueryBuilderInterface 
 					$join->on('publication_tlps.locale', '=', Capsule::raw("'{$locale}'"));
 				});
 			$q->leftJoin('publications as publication_tlpl', 's.current_publication_id', '=', 'publication_tlpl.publication_id')
-				->leftJoin('publication_settings as publication_tlpsl', function (object $join){
+				->leftJoin('publication_settings as publication_tlpsl', function (object $join) {
 					$join->on('publication_tlp.publication_id', '=', 'publication_tlpsl.publication_id');
 					$join->on('publication_tlpsl.setting_name', '=', Capsule::raw("'title'"));
 					$join->on('publication_tlpsl.locale', '=', Capsule::raw('s.locale'));

--- a/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
@@ -90,7 +90,7 @@ abstract class PKPSubmissionQueryBuilder implements EntityQueryBuilderInterface 
 		} elseif ($column === 'dateLastActivity') {
 			$this->orderColumn = 's.date_last_activity';
 		} elseif ($column === 'title') {
-			$this->orderColumn = Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)');
+			$this->orderColumn = Capsule::raw('publication_with_translation.setting_value');
 		} elseif ($column === 'seq') {
 			$this->orderColumn = 'po.seq';
 		} elseif ($column === ORDERBY_DATE_PUBLISHED) {
@@ -273,18 +273,37 @@ abstract class PKPSubmissionQueryBuilder implements EntityQueryBuilderInterface 
 		}
 
 		// order by title
-		if (is_object($this->orderColumn) && $this->orderColumn->getValue() === 'COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)') {
-			$locale = \AppLocale::getLocale();
-			$this->columns[] = Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)');
+		if (is_object($this->orderColumn) && $this->orderColumn->getValue() === 'publication_with_translation.setting_value') {
+			$currentLocale = \AppLocale::getLocale();
+			$primaryLocale = Capsule::raw('s.locale');
+			
+			$this->columns[] = Capsule::raw('publication_with_translation.setting_value');
 			$q->leftJoin('publications as publication_tlp', 's.current_publication_id', '=', 'publication_tlp.publication_id')
-				->leftJoin('publication_settings as publication_tlps', 'publication_tlp.publication_id', '=', 'publication_tlps.publication_id')
-				->where('publication_tlps.setting_name', '=', 'title')
-				->where('publication_tlps.locale', '=', $locale);
-			$q->leftJoin('publications as publication_tlpl', 's.current_publication_id', '=', 'publication_tlpl.publication_id')
-				->leftJoin('publication_settings as publication_tlpsl', 'publication_tlp.publication_id', '=', 'publication_tlpsl.publication_id')
-				->where('publication_tlpsl.setting_name', '=', 'title')
-				->where('publication_tlpsl.locale', '=', Capsule::raw('s.locale'));
-			$q->groupBy(Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)'));
+				->leftJoin('publication_settings as publication_with_translation', 'publication_tlp.publication_id', '=', 'publication_with_translation.publication_id')
+				->leftJoin('publication_settings as publication_without_translation', 'publication_tlp.publication_id', '=', 'publication_without_translation.publication_id')
+				->where(function ($q) use ($primaryLocale,$currentLocale){
+					$q->where(function ($q) use ($primaryLocale,$currentLocale){
+						$q->where('publication_with_translation.setting_name', '=', 'title');
+						$q->where('publication_with_translation.locale', '=', $currentLocale);
+						$q->where('publication_with_translation.setting_value', '!=', '');
+						$q->where('publication_without_translation.setting_name', '=', 'title');
+						$q->where('publication_without_translation.locale', '=', $currentLocale);
+					});
+					$q->orWhere(function ($q) use ($primaryLocale,$currentLocale){
+						$q->where('publication_with_translation.setting_name', '=', 'title');
+						$q->where('publication_with_translation.locale', '=', $primaryLocale);
+						$q->where('publication_without_translation.setting_name', '=', 'title');
+						$q->where('publication_without_translation.locale', '=', $primaryLocale);
+						$q->whereNotIn('publication_without_translation.publication_id',function($query) use ($currentLocale){
+							$query->select('publication_id')
+							->from('publication_settings as p')
+							->where('p.setting_name', '=', 'title')
+							->where('p.setting_value', '!=', '')
+							->where('p.locale', '=', $currentLocale);
+						});
+					});
+				});
+			$q->groupBy('publication_with_translation.setting_value');
 		}
 
 		// order by publication sequence

--- a/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/PKPSubmissionQueryBuilder.inc.php
@@ -90,7 +90,7 @@ abstract class PKPSubmissionQueryBuilder implements EntityQueryBuilderInterface 
 		} elseif ($column === 'dateLastActivity') {
 			$this->orderColumn = 's.date_last_activity';
 		} elseif ($column === 'title') {
-			$this->orderColumn = Capsule::raw('publication_with_translation.setting_value');
+			$this->orderColumn = Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)');
 		} elseif ($column === 'seq') {
 			$this->orderColumn = 'po.seq';
 		} elseif ($column === ORDERBY_DATE_PUBLISHED) {
@@ -273,37 +273,23 @@ abstract class PKPSubmissionQueryBuilder implements EntityQueryBuilderInterface 
 		}
 
 		// order by title
-		if (is_object($this->orderColumn) && $this->orderColumn->getValue() === 'publication_with_translation.setting_value') {
-			$currentLocale = \AppLocale::getLocale();
-			$primaryLocale = Capsule::raw('s.locale');
-			
-			$this->columns[] = Capsule::raw('publication_with_translation.setting_value');
+		if (is_object($this->orderColumn) && $this->orderColumn->getValue() === 'COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)') {
+			$locale = \AppLocale::getLocale();
+			$this->columns[] = Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)');
 			$q->leftJoin('publications as publication_tlp', 's.current_publication_id', '=', 'publication_tlp.publication_id')
-				->leftJoin('publication_settings as publication_with_translation', 'publication_tlp.publication_id', '=', 'publication_with_translation.publication_id')
-				->leftJoin('publication_settings as publication_without_translation', 'publication_tlp.publication_id', '=', 'publication_without_translation.publication_id')
-				->where(function ($q) use ($primaryLocale,$currentLocale){
-					$q->where(function ($q) use ($primaryLocale,$currentLocale){
-						$q->where('publication_with_translation.setting_name', '=', 'title');
-						$q->where('publication_with_translation.locale', '=', $currentLocale);
-						$q->where('publication_with_translation.setting_value', '!=', '');
-						$q->where('publication_without_translation.setting_name', '=', 'title');
-						$q->where('publication_without_translation.locale', '=', $currentLocale);
-					});
-					$q->orWhere(function ($q) use ($primaryLocale,$currentLocale){
-						$q->where('publication_with_translation.setting_name', '=', 'title');
-						$q->where('publication_with_translation.locale', '=', $primaryLocale);
-						$q->where('publication_without_translation.setting_name', '=', 'title');
-						$q->where('publication_without_translation.locale', '=', $primaryLocale);
-						$q->whereNotIn('publication_without_translation.publication_id',function($query) use ($currentLocale){
-							$query->select('publication_id')
-							->from('publication_settings as p')
-							->where('p.setting_name', '=', 'title')
-							->where('p.setting_value', '!=', '')
-							->where('p.locale', '=', $currentLocale);
-						});
-					});
+				->leftJoin('publication_settings as publication_tlps', function($join) use ($locale) {
+					$join->on('publication_tlp.publication_id', '=', 'publication_tlps.publication_id');
+					$join->on('publication_tlps.setting_name', '=', Capsule::raw("'title'"));
+					$join->on('publication_tlps.setting_value', '!=', Capsule::raw("''"));
+					$join->on('publication_tlps.locale', '=', Capsule::raw("'{$locale}'"));
 				});
-			$q->groupBy('publication_with_translation.setting_value');
+			$q->leftJoin('publications as publication_tlpl', 's.current_publication_id', '=', 'publication_tlpl.publication_id')
+				->leftJoin('publication_settings as publication_tlpsl', function($join){
+					$join->on('publication_tlp.publication_id', '=', 'publication_tlpsl.publication_id');
+					$join->on('publication_tlpsl.setting_name', '=', Capsule::raw("'title'"));
+					$join->on('publication_tlpsl.locale', '=', Capsule::raw('s.locale'));
+				});
+			$q->groupBy(Capsule::raw('COALESCE(publication_tlps.setting_value, publication_tlpsl.setting_value)'));
 		}
 
 		// order by publication sequence


### PR DESCRIPTION
This PR is to correct the categories sorting by title, because when choosing the current locale and the publications did not have a translated title, it was not presented in the category same having title in primary locale.

More about the problem, can know in [forum](https://forum.pkp.sfu.ca/t/category-does-not-list-all-articles-when-sorting-by-title-is-selected/69168).