### PR TITLE
pkp/pkp-lib#7282 Forcing IsoCodesFactory to use PKPLocale::getLocale()

### DIFF
--- a/classes/components/forms/context/PKPContextForm.inc.php
+++ b/classes/components/forms/context/PKPContextForm.inc.php
@@ -45,7 +45,8 @@ class PKPContextForm extends FormComponent
         $this->locales = $locales;
         $this->method = $context ? 'PUT' : 'POST';
 
-        $isoCodes = new IsoCodesFactory();
+        $isoCodes = app(IsoCodesFactory::class);
+
         $countries = [];
         foreach ($isoCodes->getCountries() as $country) {
             $countries[] = [
@@ -53,6 +54,7 @@ class PKPContextForm extends FormComponent
                 'label' => $country->getLocalName()
             ];
         }
+
         usort($countries, function ($a, $b) {
             return strcmp($a['label'], $b['label']);
         });

--- a/classes/components/forms/context/PKPMastheadForm.inc.php
+++ b/classes/components/forms/context/PKPMastheadForm.inc.php
@@ -43,7 +43,7 @@ class PKPMastheadForm extends FormComponent
         $this->action = $action;
         $this->locales = $locales;
 
-        $isoCodes = new IsoCodesFactory();
+        $isoCodes = app(IsoCodesFactory::class);
         $countries = [];
         foreach ($isoCodes->getCountries() as $country) {
             $countries[] = [

--- a/classes/components/forms/context/PKPPaymentSettingsForm.inc.php
+++ b/classes/components/forms/context/PKPPaymentSettingsForm.inc.php
@@ -18,6 +18,8 @@ use PKP\components\forms\FieldOptions;
 use PKP\components\forms\FieldSelect;
 use PKP\components\forms\FormComponent;
 
+use Sokil\IsoCodes\IsoCodesFactory;
+
 define('FORM_PAYMENT_SETTINGS', 'paymentSettings');
 
 class PKPPaymentSettingsForm extends FormComponent
@@ -41,7 +43,7 @@ class PKPPaymentSettingsForm extends FormComponent
         $this->locales = $locales;
 
         $currencies = [];
-        $isoCodes = new \Sokil\IsoCodes\IsoCodesFactory();
+        $isoCodes = app(IsoCodesFactory::class);
         foreach ($isoCodes->getCurrencies() as $currency) {
             $currencies[] = [
                 'value' => $currency->getLetterCode(),

--- a/classes/core/PKPContainer.inc.php
+++ b/classes/core/PKPContainer.inc.php
@@ -23,6 +23,9 @@ use Illuminate\Container\Container;
 use Illuminate\Log\LogServiceProvider;
 use Illuminate\Support\Facades\Facade;
 use PKP\config\Config;
+use PKP\i18n\PKPLocale;
+use Sokil\IsoCodes\IsoCodesFactory;
+use Sokil\IsoCodes\TranslationDriver\GettextExtensionDriver;
 use Throwable;
 
 class PKPContainer extends Container
@@ -75,6 +78,13 @@ class PKPContainer extends Container
                     echo (string) $e;
                 }
             };
+        });
+
+        // This singleton is necessary to keep user selected language across the application
+        $this->singleton(IsoCodesFactory::class, function () {
+            $driver = new GettextExtensionDriver();
+            $driver->setLocale(PKPLocale::getLocale());
+            return new IsoCodesFactory(null, $driver);
         });
 
         Facade::setFacadeApplication($this);
@@ -222,6 +232,7 @@ class PKPContainer extends Container
 
     /**
      * Retrieves default mailer driver depending on the configuration
+     *
      * @throws Exception
      */
     protected static function getDefaultMailer(): string

--- a/classes/user/form/ContactForm.inc.php
+++ b/classes/user/form/ContactForm.inc.php
@@ -21,6 +21,8 @@ use APP\facades\Repo;
 use APP\i18n\AppLocale;
 use APP\template\TemplateManager;
 
+use Sokil\IsoCodes\IsoCodesFactory;
+
 class ContactForm extends BaseProfileForm
 {
     /**
@@ -49,7 +51,7 @@ class ContactForm extends BaseProfileForm
     public function fetch($request, $template = null, $display = false)
     {
         $site = $request->getSite();
-        $isoCodes = new \Sokil\IsoCodes\IsoCodesFactory();
+        $isoCodes = app(IsoCodesFactory::class);
         $countries = [];
         foreach ($isoCodes->getCountries() as $country) {
             $countries[$country->getAlpha2()] = $country->getLocalName();

--- a/classes/user/form/RegistrationForm.inc.php
+++ b/classes/user/form/RegistrationForm.inc.php
@@ -22,19 +22,17 @@ use APP\core\Application;
 use APP\facades\Repo;
 use APP\i18n\AppLocale;
 use APP\notification\form\NotificationSettingsForm;
-use APP\notification\NotificationManager;
 use APP\template\TemplateManager;
 use PKP\config\Config;
 use PKP\core\Core;
 use PKP\db\DAORegistry;
 use PKP\form\Form;
-use PKP\mail\MailTemplate;
-use PKP\notification\PKPNotification;
-use PKP\security\AccessKeyManager;
 use PKP\security\Role;
 use PKP\security\Validation;
 use PKP\session\SessionManager;
 use PKP\user\InterestManager;
+
+use Sokil\IsoCodes\IsoCodesFactory;
 
 class RegistrationForm extends Form
 {
@@ -114,7 +112,8 @@ class RegistrationForm extends Form
             $templateMgr->assign('recaptchaPublicKey', Config::getVar('captcha', 'recaptcha_public_key'));
         }
 
-        $isoCodes = new \Sokil\IsoCodes\IsoCodesFactory();
+        $isoCodes = app(IsoCodesFactory::class);
+
         $countries = [];
         foreach ($isoCodes->getCountries() as $country) {
             $countries[$country->getAlpha2()] = $country->getLocalName();

--- a/classes/validation/ValidatorFactory.inc.php
+++ b/classes/validation/ValidatorFactory.inc.php
@@ -124,14 +124,14 @@ class ValidatorFactory
 
         // Add custom validation rule for currency
         $validation->extend('currency', function ($attribute, $value, $parameters, $validator) {
-            $isoCodes = new IsoCodesFactory();
+            $isoCodes = app(IsoCodesFactory::class);
             $currency = $isoCodes->getCurrencies()->getByLetterCode((string) $value);
             return isset($currency);
         });
 
         // Add custom validation rule for country
         $validation->extend('country', function ($attribute, $value, $parameters, $validator) {
-            $isoCodes = new IsoCodesFactory();
+            $isoCodes = app(IsoCodesFactory::class);
             $country = $isoCodes->getCountries()->getByAlpha2((string) $value);
             return isset($country);
         });

--- a/controllers/grid/settings/user/form/UserDetailsForm.inc.php
+++ b/controllers/grid/settings/user/form/UserDetailsForm.inc.php
@@ -22,6 +22,7 @@ use PKP\identity\Identity;
 use PKP\mail\MailTemplate;
 use PKP\notification\PKPNotification;
 use PKP\user\InterestManager;
+use Sokil\IsoCodes\IsoCodesFactory;
 
 class UserDetailsForm extends UserForm
 {
@@ -173,7 +174,7 @@ class UserDetailsForm extends UserForm
     public function display($request = null, $template = null)
     {
         $site = $request->getSite();
-        $isoCodes = new \Sokil\IsoCodes\IsoCodesFactory();
+        $isoCodes = app(IsoCodesFactory::class);
         $countries = [];
         foreach ($isoCodes->getCountries() as $country) {
             $countries[$country->getAlpha2()] = $country->getLocalName();

--- a/controllers/grid/users/author/form/PKPAuthorForm.inc.php
+++ b/controllers/grid/users/author/form/PKPAuthorForm.inc.php
@@ -21,6 +21,7 @@ use APP\publication\Publication;
 use APP\template\TemplateManager;
 use PKP\form\Form;
 use PKP\security\Role;
+use Sokil\IsoCodes\IsoCodesFactory;
 
 class PKPAuthorForm extends Form
 {
@@ -150,7 +151,7 @@ class PKPAuthorForm extends Form
         $userGroupDao = DAORegistry::getDAO('UserGroupDAO'); /** @var UserGroupDAO $userGroupDao */
         $authorUserGroups = $userGroupDao->getByRoleId($request->getContext()->getId(), Role::ROLE_ID_AUTHOR);
         $publication = $this->getPublication();
-        $isoCodes = new \Sokil\IsoCodes\IsoCodesFactory();
+        $isoCodes = app(IsoCodesFactory::class);
         $countries = [];
         foreach ($isoCodes->getCountries() as $country) {
             $countries[$country->getAlpha2()] = $country->getLocalName();


### PR DESCRIPTION
`sokil/php-isocodes` uses the `LANGUAGE` env variable to handle the i18n inside GettextExtensionDriver.

This pull request forces the `IsoCodesFactory` to use the data from `PKPLocale::getLocale()` on the GettextExtensionDriver.