### PR TITLE
pkp/pkp-lib#7379 permit userId of 1 to be merged

### DIFF
--- a/controllers/grid/settings/user/UserGridRow.inc.php
+++ b/controllers/grid/settings/user/UserGridRow.inc.php
@@ -186,8 +186,11 @@ class UserGridRow extends GridRow
                     );
                 }
 
-                // do not allow the deletion of the admin account.
-                if ($rowId > 1 && $canAdminister) {
+		// do not allow the deletion of your own account.
+		if (
+			$request->getUser()->getId() != $this->getId() and
+			$canAdminister
+		) {
                     $this->addAction(
                         new LinkAction(
                             'mergeUser',


### PR DESCRIPTION
This PR removes the userId of 1 restriction, but still ensures that a user cannot merge themselves, and that the regular rules of Validation apply (users with roles of site admin cannot be merged).