### PR TITLE
pkp/pkp-lib#7425 Get mailable class names

### DIFF
--- a/classes/core/Core.inc.php
+++ b/classes/core/Core.inc.php
@@ -24,8 +24,11 @@ define('PKP_LIB_PATH', 'lib' . DIRECTORY_SEPARATOR . 'pkp');
 define('COUNTER_USER_AGENTS_FILE', Core::getBaseDir() . DIRECTORY_SEPARATOR . PKP_LIB_PATH . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'counterBots' . DIRECTORY_SEPARATOR . 'generated' . DIRECTORY_SEPARATOR . 'COUNTER_Robots_list.txt');
 
 use APP\core\Application;
+use Illuminate\Support\Str;
 use PKP\cache\CacheManager;
 use PKP\config\Config;
+use Symfony\Component\Finder\Finder;
+use SplFileInfo;
 
 class Core
 {
@@ -550,5 +553,28 @@ class Core
         }
 
         return $component;
+    }
+
+    /**
+     * Extract the class name from the given file path.
+     *
+     * @param  SplFileInfo $file info about a file extract class name from
+     * @return string fully qualified class name
+     * @see Finder
+     */
+    public static function classFromFile(SplFileInfo $file): string
+    {
+        $pathFromBase = trim(Str::replaceFirst(base_path(), '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+        $libPath = 'lib' . DIRECTORY_SEPARATOR . 'pkp' . DIRECTORY_SEPARATOR;
+        $namespace = Str::startsWith($pathFromBase, $libPath) ? 'PKP\\' : 'APP\\';
+
+        $path = $pathFromBase;
+        if ($namespace === 'PKP\\') {
+            $path = Str::replaceFirst($libPath, '', $path);
+        }
+        if (Str::startsWith($path, 'classes')) {
+            $path = Str::replaceFirst('classes' . DIRECTORY_SEPARATOR, '', $path);
+        }
+        return $namespace . str_replace('/', '\\', Str::replaceLast('.inc.php', '', $path));
     }
 }

--- a/classes/mail/Configurable.inc.php
+++ b/classes/mail/Configurable.inc.php
@@ -25,9 +25,11 @@ trait Configurable
      */
     public static function getName(): string
     {
-        return !is_null(static::$name)
-            ? __(static::$name)
-            : throw new Exception('Configurable mailable created without a name.');
+        if (is_null(static::$name)) {
+            throw new Exception('Configurable mailable created without a name.');
+        }
+
+        return __(static::$name);
     }
 
     /**
@@ -36,8 +38,10 @@ trait Configurable
      */
     public static function getDescription(): string
     {
-        return !is_null(static::$description)
-            ? __(static::$description)
-            : throw new Exception('Configurable mailable created without a description.');
+        if (is_null(static::$description)) {
+            throw new Exception('Configurable mailable created without a description.');
+        }
+
+        return __(static::$description);
     }
 }

--- a/classes/mail/Configurable.inc.php
+++ b/classes/mail/Configurable.inc.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file mail/Configurable.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class Configurable
+ * @ingroup mail
+ *
+ * @brief trait to support Mailable's name and description displayed in the UI
+ */
+
+namespace PKP\mail;
+
+use Exception;
+
+trait Configurable
+{
+    /**
+     * Retrieve localized Mailable's name
+     * @throws Exception
+     */
+    public static function getName(): string
+    {
+        return !is_null(static::$name)
+            ? __(static::$name)
+            : throw new Exception('Configurable mailable created without a name.');
+    }
+
+    /**
+     * Retrieve localized Mailable's description
+     * @throws Exception
+     */
+    public static function getDescription(): string
+    {
+        return !is_null(static::$description)
+            ? __(static::$description)
+            : throw new Exception('Configurable mailable created without a description.');
+    }
+}

--- a/classes/mail/FormEmailData.inc.php
+++ b/classes/mail/FormEmailData.inc.php
@@ -1,19 +1,19 @@
 <?php
 
 /**
- * @file mail/mailables/FormEmailData.inc.php
+ * @file mail/FormEmailData.inc.php
  *
  * Copyright (c) 2014-2021 Simon Fraser University
  * Copyright (c) 2000-2021 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class FormEmailData
- * @ingroup mail_mailables
+ * @ingroup mail
  *
  * @brief Serves to transfer data from the form/request to mailable
  */
 
-namespace PKP\mail\mailables;
+namespace PKP\mail;
 
 use Illuminate\Support\LazyCollection;
 use App\facades\Repo;

--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -17,7 +17,6 @@ namespace PKP\mail;
 
 use APP\core\Application;
 
-use APP\core\Services;
 use APP\i18n\AppLocale;
 use PKP\core\PKPApplication;
 use PKP\facades\Repo;

--- a/classes/mail/Mailable.inc.php
+++ b/classes/mail/Mailable.inc.php
@@ -32,8 +32,6 @@ use Exception;
 use Illuminate\Mail\Mailable as IlluminateMailable;
 use InvalidArgumentException;
 use PKP\context\Context;
-use PKP\mail\mailables\Recipient;
-use PKP\mail\mailables\Sender;
 use APP\mail\variables\ContextEmailVariable;
 use PKP\mail\variables\QueuedPaymentEmailVariable;
 use PKP\mail\variables\RecipientEmailVariable;
@@ -73,6 +71,15 @@ class Mailable extends IlluminateMailable
      * can be organized when shown in the UI.
      */
     protected static array $groupIds = [self::GROUP_OTHER];
+
+    // Locale key, name of the Mailable displayed in the UI
+    protected static ?string $name = null;
+
+    // Locale key, description of the Mailable displayed in the UI
+    protected static ?string $description = null;
+
+    // Whether Mailable supports additional templates, besides the default
+    public static bool $supportsTemplates = false;
 
     public function __construct(array $args = [])
     {

--- a/classes/mail/Recipient.inc.php
+++ b/classes/mail/Recipient.inc.php
@@ -1,27 +1,27 @@
 <?php
 
 /**
- * @file mail/mailables/Recipient.inc.php
+ * @file mail/Recipient.inc.php
  *
  * Copyright (c) 2014-2021 Simon Fraser University
  * Copyright (c) 2000-2021 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class Recipient
- * @ingroup mail_mailables
+ * @ingroup mail
  *
  * @brief mailable's trait to support User recipients
  */
 
-namespace PKP\mail\mailables;
+namespace PKP\mail;
 
 use BadMethodCallException;
 use InvalidArgumentException;
-use PKP\mail\Mailable;
 use PKP\mail\variables\RecipientEmailVariable;
 use PKP\user\User;
 
-trait Recipient {
+trait Recipient
+{
 
     /**
      * @copydoc Illuminate\Mail\Mailable::setAddress()

--- a/classes/mail/Sender.inc.php
+++ b/classes/mail/Sender.inc.php
@@ -1,22 +1,21 @@
 <?php
 
 /**
- * @file mail/mailables/Sender.inc.php
+ * @file mail/Sender.inc.php
  *
  * Copyright (c) 2014-2021 Simon Fraser University
  * Copyright (c) 2000-2021 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class Sender
- * @ingroup mail_mailables
+ * @ingroup mail
  *
  * @brief mailable's trait to support User sender
  */
 
-namespace PKP\mail\mailables;
+namespace PKP\mail;
 
 use BadMethodCallException;
-use PKP\mail\Mailable;
 use PKP\mail\variables\SenderEmailVariable;
 use PKP\user\User;
 

--- a/classes/mail/mailables/MailDiscussionMessage.inc.php
+++ b/classes/mail/mailables/MailDiscussionMessage.inc.php
@@ -18,15 +18,23 @@ namespace PKP\mail\mailables;
 use PKP\context\Context;
 use PKP\emailTemplate\EmailTemplate;
 use PKP\facades\Repo;
+use PKP\mail\Configurable;
 use PKP\mail\Mailable;
 use PKP\submission\PKPSubmission;
+use PKP\mail\Recipient;
+use PKP\mail\Sender;
 
 class MailDiscussionMessage extends Mailable
 {
     use Recipient;
     use Sender;
+    use Configurable;
 
     public const EMAIL_KEY = 'NOTIFICATION';
+
+    protected static ?string $name = 'mailable.mailDiscussionMessage.name';
+
+    protected static ?string $description = 'mailable.mailDiscussionMessage.description';
 
     protected static array $groupIds = [self::GROUP_SUBMISSION, self::GROUP_REVIEW, self::GROUP_COPYEDITING, self::GROUP_PRODUCTION];
 

--- a/classes/mail/mailables/MailReviewerAssigned.inc.php
+++ b/classes/mail/mailables/MailReviewerAssigned.inc.php
@@ -16,14 +16,24 @@
 namespace PKP\mail\mailables;
 
 use PKP\context\Context;
+use PKP\mail\Configurable;
 use PKP\mail\Mailable;
 use PKP\submission\PKPSubmission;
 use PKP\submission\reviewAssignment\ReviewAssignment;
+use PKP\mail\Recipient;
+use PKP\mail\Sender;
 
 class MailReviewerAssigned extends Mailable
 {
     use Recipient;
     use Sender;
+    use Configurable;
+
+    protected static ?string $name = 'mailable.mailReviewerAssigned.name';
+
+    protected static ?string $description = 'mailable.mailReviewerAssigned.description';
+
+    public static bool $supportsTemplates = true;
 
     protected static array $groupIds = [self::GROUP_REVIEW];
 

--- a/classes/mail/mailables/MailReviewerReinstated.inc.php
+++ b/classes/mail/mailables/MailReviewerReinstated.inc.php
@@ -16,14 +16,24 @@
 namespace PKP\mail\mailables;
 
 use PKP\context\Context;
+use PKP\mail\Configurable;
 use PKP\mail\Mailable;
 use PKP\submission\PKPSubmission;
 use PKP\submission\reviewAssignment\ReviewAssignment;
+use PKP\mail\Recipient;
+use PKP\mail\Sender;
 
 class MailReviewerReinstated extends Mailable
 {
     use Recipient;
     use Sender;
+    use Configurable;
+
+    protected static ?string $name = 'mailable.mailReviewerReinstate.name';
+
+    protected static ?string $description = 'mailable.mailReviewerReinstate.description';
+
+    public static bool $supportsTemplates = true;
 
     protected static array $groupIds = [self::GROUP_REVIEW];
 

--- a/classes/mail/mailables/MailReviewerUnassigned.inc.php
+++ b/classes/mail/mailables/MailReviewerUnassigned.inc.php
@@ -16,7 +16,10 @@
 namespace PKP\mail\mailables;
 
 use PKP\context\Context;
+use PKP\mail\Configurable;
 use PKP\mail\Mailable;
+use PKP\mail\Recipient;
+use PKP\mail\Sender;
 use PKP\submission\PKPSubmission;
 use PKP\submission\reviewAssignment\ReviewAssignment;
 
@@ -24,6 +27,13 @@ class MailReviewerUnassigned extends Mailable
 {
     use Recipient;
     use Sender;
+    use Configurable;
+
+    protected static ?string $name = 'mailable.mailReviewerUnassigned.name';
+
+    protected static ?string $description = 'mailable.mailReviewerUnassigned.description';
+
+    public static bool $supportsTemplates = true;
 
     protected static array $groupIds = [self::GROUP_REVIEW];
 

--- a/classes/mail/mailables/ValidateEmailContext.inc.php
+++ b/classes/mail/mailables/ValidateEmailContext.inc.php
@@ -19,12 +19,17 @@ use PKP\context\Context;
 use PKP\facades\Repo;
 use PKP\mail\Mailable;
 use PKP\emailTemplate\EmailTemplate;
+use PKP\mail\Recipient;
 
 class ValidateEmailContext extends Mailable
 {
     use Recipient;
 
     public const EMAIL_KEY = 'USER_VALIDATE';
+
+    protected static ?string $name = 'mailable.validateEmailContext.name';
+
+    protected static ?string $description = 'mailable.validateEmailContext.description';
 
     public function __construct(Context $context)
     {

--- a/classes/mail/mailables/ValidateEmailSite.inc.php
+++ b/classes/mail/mailables/ValidateEmailSite.inc.php
@@ -19,12 +19,17 @@ use PKP\facades\Repo;
 use PKP\mail\Mailable;
 use PKP\emailTemplate\EmailTemplate;
 use PKP\site\Site;
+use PKP\mail\Recipient;
 
 class ValidateEmailSite extends Mailable
 {
     use Recipient;
 
     public const EMAIL_KEY = 'USER_VALIDATE';
+
+    protected static ?string $name = 'mailable.validateEmailSite.name';
+
+    protected static ?string $description = 'mailable.validateEmailSite.description';
 
     public function __construct(Site $site)
     {

--- a/classes/observers/events/DiscussionMessageSent.inc.php
+++ b/classes/observers/events/DiscussionMessageSent.inc.php
@@ -17,7 +17,7 @@ namespace PKP\observers\events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use PKP\context\Context;
-use PKP\mail\mailables\FormEmailData;
+use PKP\mail\FormEmailData;
 use PKP\query\Query;
 use PKP\submission\PKPSubmission;
 

--- a/classes/observers/listeners/MailDiscussionMessage.inc.php
+++ b/classes/observers/listeners/MailDiscussionMessage.inc.php
@@ -1,13 +1,13 @@
 <?php
 
 /**
- * @file classes/observers/listeners/MailDiscussionUpdated.inc.php
+ * @file classes/observers/listeners/MailDiscussionMessage.inc.php
  *
  * Copyright (c) 2014-2021 Simon Fraser University
  * Copyright (c) 2000-2021 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
- * @class MailDiscussionUpdated
+ * @class MailDiscussionMessage
  * @ingroup observers_listeners
  *
  * @brief Notify users when a discussion is updated
@@ -50,7 +50,7 @@ class MailDiscussionMessage
 
             $mailable->addVariables(array_merge(
                 [
-                    'siteTitle' => $mailable->viewData['contextName'],
+                    'siteTitle' => $mailable->viewData['journalName'],
                 ],
                 $event->formEmailData->getVariables($user->getId())
             ));

--- a/controllers/grid/queries/QueriesGridHandler.inc.php
+++ b/controllers/grid/queries/QueriesGridHandler.inc.php
@@ -24,7 +24,7 @@ use PKP\i18n\PKPLocale;
 use PKP\linkAction\LinkAction;
 use PKP\linkAction\request\AjaxModal;
 use PKP\linkAction\request\RemoteActionConfirmationModal;
-use PKP\mail\mailables\FormEmailData;
+use PKP\mail\FormEmailData;
 use PKP\mail\SubmissionMailTemplate;
 use PKP\notification\PKPNotification;
 use PKP\observers\events\DiscussionMessageSent;

--- a/locale/en_US/manager.po
+++ b/locale/en_US/manager.po
@@ -2141,3 +2141,34 @@ msgstr "The full names of the authors"
 
 msgid "emailTemplate.variable.submission.submissionUrl"
 msgstr "The URL to the submission in the editorial backend"
+
+msgid "mailable.mailDiscussionMessage.name"
+msgstr "New Discussion Message"
+
+msgid "mailable.mailDiscussionMessage.description"
+msgstr "This email is automatically sent to discussion participants when a new message is added to the discussion."
+
+msgid "mailable.mailReviewerAssigned.name"
+msgstr "Reviewer Assigned"
+
+msgid "mailable.mailReviewerAssigned.description"
+msgstr "This email is sent when a reviewer is assigned to a submission."
+
+msgid "mailable.mailReviewerReinstate.name"
+msgstr "Reviewer Reinstated"
+
+msgid "mailable.mailReviewerReinstate.description"
+msgstr "This email is sent when a reviewer that was unassigned is reinstated by an editor."
+
+msgid "mailable.mailReviewerUnassigned.name"
+msgstr "Reviewer Unassigned"
+
+msgid "mailable.mailReviewerUnassigned.description"
+msgstr "This email is sent when an editor unassigns a reviewer."
+
+msgid "mailable.validateEmailSite.name"
+msgstr "Validate Email (Site)"
+
+msgid "mailable.validateEmailSite.description"
+msgstr "This email is automatically sent to a new user when they register with the site when the settings require the email address to be validated."
+


### PR DESCRIPTION
- move non-mailable classes from correspondent dir
- fix mailable's journal name variable retrieval
- cache events & mailables
- add name and description to mailables