### PR TITLE
Submission files upgrade step optimization

### DIFF
--- a/classes/migration/upgrade/PKPv3_3_0UpgradeMigration.inc.php
+++ b/classes/migration/upgrade/PKPv3_3_0UpgradeMigration.inc.php
@@ -396,7 +396,7 @@ class PKPv3_3_0UpgradeMigration extends \PKP\migration\Migration
             // Update revision data in event logs
             $eventLogIds = DB::table('event_log_settings')
                 ->where('setting_name', '=', 'fileId')
-                ->where('setting_value', '=', $row->file_id)
+                ->where('setting_value', '=', strval($row->file_id))
                 ->pluck('log_id');
             DB::table('event_log_settings')
                 ->whereIn('log_id', $eventLogIds)


### PR DESCRIPTION
Mysql is not using the event_log_settings_name_value index, slowing the Submission files upgrade step, due to the type of the setting_value field.

Server version: 10.5.12-MariaDB
PHP 7.4.6 (cli)