### PR TITLE
pkp/pkp-lib#7506 Unable to Upload/Select Files from Copyediting stage (fix ineffective)

### DIFF
--- a/controllers/grid/files/SubmissionFilesCategoryGridDataProvider.inc.php
+++ b/controllers/grid/files/SubmissionFilesCategoryGridDataProvider.inc.php
@@ -138,9 +138,8 @@ class SubmissionFilesCategoryGridDataProvider extends CategoryGridDataProvider
                     }
                     $noteDao = DAORegistry::getDAO('NoteDAO'); /** @var NoteDAO $noteDao */
                     $note = $noteDao->getById($submissionFile->getData('assocId'));
-                    assert($note && $note->getAssocType() == ASSOC_TYPE_QUERY);
                     $queryDao = DAORegistry::getDAO('QueryDAO'); /** @var QueryDAO $queryDao */
-                    if ($note) {
+                    if ($note && $note->getAssocType() == ASSOC_TYPE_QUERY) {
                         $query = $queryDao->getById($note->getAssocId());
                     }
                     if ($query && $query->getStageId() == $stageId) {


### PR DESCRIPTION
Unable to Upload/Select Files from Copyediting stage (fix ineffective) - this change extends the previous fix [https://github.com/pkp/ojs/pull/2396] to also guard the $note->GetAssocId() method call from the case where $note == null - ie. when there is an orphan note in the db

PS. p6steve is my GitHub ID - Steve Roe - steve@henleycloudconsulting.co.uk is my ID on PKP Community