### PR TITLE
pkp/pkp-lib#7654 Don't get the context object from the request

### DIFF
--- a/classes/notification/managerDelegate/PKPEditingProductionStatusNotificationManager.inc.php
+++ b/classes/notification/managerDelegate/PKPEditingProductionStatusNotificationManager.inc.php
@@ -74,13 +74,12 @@ class PKPEditingProductionStatusNotificationManager extends NotificationManagerD
 	 * @copydoc NotificationManagerDelegate::updateNotification()
 	 */
 	public function updateNotification($request, $userIds, $assocType, $assocId) {
-		$context = $request->getContext();
-		$contextId = $context->getId();
 
 		assert($assocType == ASSOC_TYPE_SUBMISSION);
 		$submissionId = $assocId;
 		$submissionDao = DAORegistry::getDAO('SubmissionDAO'); /* @var $submissionDao SubmissionDAO */
 		$submission = $submissionDao->getById($submissionId);
+		$contextId = $submission->getContextId();
 
 		$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO'); /* @var $stageAssignmentDao StageAssignmentDAO */
 		$editorStageAssignments = $stageAssignmentDao->getEditorsAssignedToStage($submissionId, $submission->getStageId());


### PR DESCRIPTION
...when deleting a submission (e.g. for site-wide requests)