### PR TITLE
Fixing Metadata keywords tag

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -263,7 +263,7 @@ class PKPTemplateManager extends Smarty
                 if ($currentContext) {
                     $customHeaders = $currentContext->getLocalizedData('customHeaders');
                     if (!empty($customHeaders)) {
-                        $this->addHeader('customHeaders', $customHeaders);
+                        $this->addHeader('customHeaders', '<meta name="keywords" content="' . $customHeaders) . '">';
                     }
                 }
             }


### PR DESCRIPTION
OJS is printing the keywords content instead of adding it to the head tag.
To check it go to:
_Distribution settings > search indexing > Custom tags_
 then go to frontend pages to find the printed keywords at the top of the page.