### PR TITLE
pkp/pkp-lib#7716: Hide DB password in the administration "system info" page 

### DIFF
--- a/templates/admin/systemInfo.tpl
+++ b/templates/admin/systemInfo.tpl
@@ -96,24 +96,15 @@
 						<td colspan="2" class="app--admin__systemInfoGroup">{$category}</td>
 					</tr>
 					{foreach from=$settings item="value" key="name"}
-						{if $category == "database"}
-							{if $name != "password"}
+					
 								<tr>
 									<td>{$name|escape}</td>
-									<td>{$value|escape}</td>
+									{if $value == "password"}
+										<td>**************</td>
+									{else}
+										<td>{$value|escape}</td>
+									{/if}
 								</tr>
-							{else}
-								<tr>
-									<td>{$name|escape}</td>
-									<td>**************</td>
-								</tr>
-							{/if}
-						{else}
-							 <tr>
-								 <td>{$name|escape}</td>
-								 <td>{$value|escape}</td>
-							</tr>
-						{/if}
 					{/foreach}
 				</tbody>
 			{/foreach}

--- a/templates/admin/systemInfo.tpl
+++ b/templates/admin/systemInfo.tpl
@@ -96,7 +96,6 @@
 						<td colspan="2" class="app--admin__systemInfoGroup">{$category}</td>
 					</tr>
 					{foreach from=$settings item="value" key="name"}
-					
 								<tr>
 									<td>{$name|escape}</td>
 									{if $value == "password"}

--- a/templates/admin/systemInfo.tpl
+++ b/templates/admin/systemInfo.tpl
@@ -96,10 +96,24 @@
 						<td colspan="2" class="app--admin__systemInfoGroup">{$category}</td>
 					</tr>
 					{foreach from=$settings item="value" key="name"}
-						<tr>
-							<td>{$name|escape}</td>
-							<td>{$value|escape}</td>
-						</tr>
+						{if $category == "database"}
+							{if $name != "password"}
+								<tr>
+									<td>{$name|escape}</td>
+									<td>{$value|escape}</td>
+								</tr>
+							{else}
+								<tr>
+									<td>{$name|escape}</td>
+									<td>**************</td>
+								</tr>
+							{/if}
+						{else}
+							 <tr>
+								 <td>{$name|escape}</td>
+								 <td>{$value|escape}</td>
+							</tr>
+						{/if}
 					{/foreach}
 				</tbody>
 			{/foreach}


### PR DESCRIPTION
Resolves #7716 . It explicitly checks the category for database before checking the name. This way, redacting any new passwords added to OJS Configuration can be done on a case by case basis.