### PR TITLE
pkp/pkp-lib#6778 Whitespace around author names should be trimmed 

### DIFF
--- a/controllers/grid/users/author/form/PKPAuthorForm.inc.php
+++ b/controllers/grid/users/author/form/PKPAuthorForm.inc.php
@@ -189,7 +189,7 @@ class PKPAuthorForm extends Form {
 			if ($publication->getId() !== $author->getData('publicationId')) fatalError('Invalid author!');
 		}
 
-		$author->setGivenName($this->getData('givenName'), null);
+		$author->setGivenName(array_map('trim',$this->getData('givenName')), null);
 		$author->setFamilyName($this->getData('familyName'), null);
 		$author->setPreferredPublicName($this->getData('preferredPublicName'), null);
 		$author->setAffiliation($this->getData('affiliation'), null); // localized


### PR DESCRIPTION
This uses array map to trim white space from each given name. This is a simple fix to #6778 . Tested on English only, and on English and German with an empty German name and a name with whites paces for both English and German. 

I am unsure if it should be a bug to be able to choose to not put a name for each different language, or if it should automatically assign the default name to each locale that is in use?