### PR TITLE
pkp/pkp-lib#7651 Fatal error when trying to load PKPXMLParser

### DIFF
--- a/classes/navigationMenu/NavigationMenuItemDAO.inc.php
+++ b/classes/navigationMenu/NavigationMenuItemDAO.inc.php
@@ -14,6 +14,7 @@
  * @brief Operations for retrieving and modifying NavigationMenuItem objects. NMI = NavigationMenuItem
  */
 
+import('lib.pkp.classes.xml.PKPXMLParser');
 import('lib.pkp.classes.navigationMenu.NavigationMenu');
 import('lib.pkp.classes.navigationMenu.NavigationMenuItem');
 

--- a/plugins/generic/acron/PKPAcronPlugin.inc.php
+++ b/plugins/generic/acron/PKPAcronPlugin.inc.php
@@ -15,6 +15,7 @@
  * hook implementation.
  */
 
+import('lib.pkp.classes.xml.PKPXMLParser');
 import('lib.pkp.classes.plugins.GenericPlugin');
 import('lib.pkp.classes.scheduledTask.ScheduledTaskHelper');
 


### PR DESCRIPTION
fix to issue pkp#7651 through non `PSR-4` standard `import` function .