### PR TITLE
pkp#7651 PKPXMLParser class missing namespace import

### DIFF
--- a/classes/navigationMenu/NavigationMenuItemDAO.inc.php
+++ b/classes/navigationMenu/NavigationMenuItemDAO.inc.php
@@ -20,6 +20,7 @@ namespace PKP\navigationMenu;
 use PKP\db\DAORegistry;
 use PKP\db\DAOResultFactory;
 use PKP\xml\XMLNode;
+use PKP\xml\PKPXMLParser;
 
 class NavigationMenuItemDAO extends \PKP\db\DAO
 {


### PR DESCRIPTION
Issue pkp#7651 fixing through `PSR-4` standard class namespace import . 