### PR TITLE
pkp/pkp-lib#7651 Fatal error when trying to load PKPXMLParser

### DIFF
--- a/classes/cliTool/ScheduledTaskTool.inc.php
+++ b/classes/cliTool/ScheduledTaskTool.inc.php
@@ -17,6 +17,7 @@
 /** Default XML tasks file to parse if none is specified */
 define('TASKS_REGISTRY_FILE', 'registry/scheduledTasks.xml');
 
+import('lib.pkp.classes.xml.PKPXMLParser');
 import('lib.pkp.classes.scheduledTask.ScheduledTask');
 import('lib.pkp.classes.scheduledTask.ScheduledTaskHelper');
 import('lib.pkp.classes.scheduledTask.ScheduledTaskDAO');

--- a/classes/components/forms/context/PKPContactForm.inc.php
+++ b/classes/components/forms/context/PKPContactForm.inc.php
@@ -66,7 +66,7 @@ class PKPContactForm extends FormComponent {
 			]))
 			->addField(new FieldTextarea('mailingAddress', [
 				'label' => __('common.mailingAddress'),
-				'isRequired' => true,
+				'isRequired' => false,
 				'size' => 'small',
 				'groupId' => 'principal',
 				'value' => $context->getData('mailingAddress'),

--- a/classes/controlledVocab/ControlledVocabDAO.inc.php
+++ b/classes/controlledVocab/ControlledVocabDAO.inc.php
@@ -14,6 +14,7 @@
  * @brief Operations for retrieving and modifying ControlledVocab objects.
  */
 
+import('lib.pkp.classes.xml.PKPXMLParser');
 import('lib.pkp.classes.controlledVocab.ControlledVocab');
 
 class ControlledVocabDAO extends DAO {

--- a/classes/db/SettingsDAO.inc.php
+++ b/classes/db/SettingsDAO.inc.php
@@ -13,6 +13,8 @@
  * @brief Operations for retrieving and modifying settings.
  */
 
+import('lib.pkp.classes.xml.PKPXMLParser');
+ 
 abstract class SettingsDAO extends DAO {
 	/**
 	 * Retrieve (and newly cache) all settings.

--- a/classes/install/Installer.inc.php
+++ b/classes/install/Installer.inc.php
@@ -24,6 +24,7 @@ define('INSTALLER_ERROR_DB', 2);
 // Default data
 define('INSTALLER_DEFAULT_LOCALE', 'en_US');
 
+import('lib.pkp.classes.xml.PKPXMLParser');
 import('lib.pkp.classes.db.DBDataXMLParser');
 import('lib.pkp.classes.site.Version');
 import('lib.pkp.classes.site.VersionDAO');

--- a/classes/navigationMenu/NavigationMenuDAO.inc.php
+++ b/classes/navigationMenu/NavigationMenuDAO.inc.php
@@ -14,7 +14,7 @@
  * @brief Operations for retrieving and modifying NavigationMenu objects.
  */
 
-
+import('lib.pkp.classes.xml.PKPXMLParser');
 import('lib.pkp.classes.navigationMenu.NavigationMenu');
 
 class NavigationMenuDAO extends DAO {

--- a/classes/plugins/PluginSettingsDAO.inc.php
+++ b/classes/plugins/PluginSettingsDAO.inc.php
@@ -14,6 +14,8 @@
  * @brief Operations for retrieving and modifying plugin settings.
  */
 
+import('lib.pkp.classes.xml.PKPXMLParser');
+
 class PluginSettingsDAO extends DAO {
 
 	/**

--- a/plugins/generic/acron/PKPAcronPlugin.inc.php
+++ b/plugins/generic/acron/PKPAcronPlugin.inc.php
@@ -15,6 +15,7 @@
  * hook implementation.
  */
 
+import('lib.pkp.classes.xml.PKPXMLParser');
 import('lib.pkp.classes.plugins.GenericPlugin');
 import('lib.pkp.classes.scheduledTask.ScheduledTaskHelper');
 


### PR DESCRIPTION
issue pkp/pkp-lib#7651 fix for mentioned classed in issue and other missing classes through non `PSR-4` standard `import` method . 