### PR TITLE
pkp/pkp-lib#7848 moveLocaleKeysToLib matches multiple keys

### DIFF
--- a/tools/moveLocaleKeysToLib.php
+++ b/tools/moveLocaleKeysToLib.php
@@ -106,11 +106,10 @@ class MoveLocaleKeysToLib extends \PKP\cliTool\CommandLineTool
             $changedSourceLines = [];
             $newTargetLines = [];
             $isMovingLine = false;
-            $fullMsgidMatch = 'msgid "' . $this->msgidMatch;
 
             $lines = explode("\n", file_get_contents($localeSourceFile));
             foreach ($lines as $i => $line) {
-                if (substr($line, 0, strlen($fullMsgidMatch)) === $fullMsgidMatch) {
+                if ($line === "msgid \"$this->msgidMatch\"") {
                     $isMovingLine = true;
                 } elseif (trim($line) === '#, fuzzy' || substr($line, 0, 5) === 'msgid') {
                     $isMovingLine = false;


### PR DESCRIPTION
Fixed as suggested by @asmecher