### PR TITLE
pkp/pkp-lib#2169 Mailing Address should not be required in settings

### DIFF
--- a/classes/components/forms/context/PKPContactForm.inc.php
+++ b/classes/components/forms/context/PKPContactForm.inc.php
@@ -66,7 +66,7 @@ class PKPContactForm extends FormComponent {
 			]))
 			->addField(new FieldTextarea('mailingAddress', [
 				'label' => __('common.mailingAddress'),
-				'isRequired' => true,
+				'isRequired' => false,
 				'size' => 'small',
 				'groupId' => 'principal',
 				'value' => $context->getData('mailingAddress'),


### PR DESCRIPTION
fix to issue pkp/pkp-lib#2169 which make the `Mailing address` as a non required field in the `Settings => Contact` section . 