### PR TITLE
pkp/pkp-lib#6209 Multiple use of id="setup-button" in website settings

### DIFF
--- a/templates/management/website.tpl
+++ b/templates/management/website.tpl
@@ -30,7 +30,7 @@
 						@set="set"
 					/>
 				</tab>
-				<tab id="setup" label="{translate key="navigation.setup"}">
+				<tab id="appearance-setup" label="{translate key="navigation.setup"}">
 					<pkp-form
 						v-bind="components.{$smarty.const.FORM_APPEARANCE_SETUP}"
 						@set="set"
@@ -45,7 +45,7 @@
 				{call_hook name="Template::Settings::website::appearance"}
 			</tabs>
 		</tab>
-		<tab id="configuration-setup" label="{translate key="navigation.setup"}">
+		<tab id="setup" label="{translate key="navigation.setup"}">
 			{help file="settings/website-settings" section="setup" class="pkp_help_tab"}
 			<tabs :is-side-tabs="true" :track-history="true">
 				<tab id="information" label="{translate key="manager.website.information"}">

--- a/templates/management/website.tpl
+++ b/templates/management/website.tpl
@@ -30,7 +30,7 @@
 						@set="set"
 					/>
 				</tab>
-				<tab id="appearance-setup" label="{translate key="navigation.setup"}">
+				<tab id="setup" label="{translate key="navigation.setup"}">
 					<pkp-form
 						v-bind="components.{$smarty.const.FORM_APPEARANCE_SETUP}"
 						@set="set"
@@ -45,7 +45,7 @@
 				{call_hook name="Template::Settings::website::appearance"}
 			</tabs>
 		</tab>
-		<tab id="setup" label="{translate key="navigation.setup"}">
+		<tab id="configuration-setup" label="{translate key="navigation.setup"}">
 			{help file="settings/website-settings" section="setup" class="pkp_help_tab"}
 			<tabs :is-side-tabs="true" :track-history="true">
 				<tab id="information" label="{translate key="manager.website.information"}">

--- a/templates/management/website.tpl
+++ b/templates/management/website.tpl
@@ -30,7 +30,7 @@
 						@set="set"
 					/>
 				</tab>
-				<tab id="setup" label="{translate key="navigation.setup"}">
+				<tab id="appearance-setup" label="{translate key="navigation.setup"}">
 					<pkp-form
 						v-bind="components.{$smarty.const.FORM_APPEARANCE_SETUP}"
 						@set="set"
@@ -45,7 +45,7 @@
 				{call_hook name="Template::Settings::website::appearance"}
 			</tabs>
 		</tab>
-		<tab id="configuration" label="{translate key="navigation.setup"}">
+		<tab id="setup" label="{translate key="navigation.setup"}">
 			{help file="settings/website-settings" section="setup" class="pkp_help_tab"}
 			<tabs :is-side-tabs="true" :track-history="true">
 				<tab id="information" label="{translate key="manager.website.information"}">

--- a/templates/management/website.tpl
+++ b/templates/management/website.tpl
@@ -45,7 +45,7 @@
 				{call_hook name="Template::Settings::website::appearance"}
 			</tabs>
 		</tab>
-		<tab id="setup" label="{translate key="navigation.setup"}">
+		<tab id="configuration" label="{translate key="navigation.setup"}">
 			{help file="settings/website-settings" section="setup" class="pkp_help_tab"}
 			<tabs :is-side-tabs="true" :track-history="true">
 				<tab id="information" label="{translate key="manager.website.information"}">


### PR DESCRIPTION
fix to issue pkp/pkp-lib#6209 which eliminate the multiple use of duplicate `id="setup-button"` in website settings .