### PR TITLE
pkp/pkp-lib#6209 Multiple use of id="setup-button" in website settings

### DIFF
--- a/templates/management/website.tpl
+++ b/templates/management/website.tpl
@@ -30,7 +30,7 @@
 						@set="set"
 					/>
 				</tab>
-				<tab id="setup" label="{translate key="navigation.setup"}">
+				<tab id="appearance-setup" label="{translate key="navigation.setup"}">
 					<pkp-form
 						v-bind="components.{$smarty.const.FORM_APPEARANCE_SETUP}"
 						@set="set"


### PR DESCRIPTION
fix to issue https://github.com/pkp/pkp-lib/issues/6209 which eliminate the multiple use of `duplicate id="setup-button"` in website settings for `main` branch .