### PR TITLE
pkp#2169 Mailing Address should not be required in settings

### DIFF
--- a/classes/components/forms/context/PKPContactForm.inc.php
+++ b/classes/components/forms/context/PKPContactForm.inc.php
@@ -70,7 +70,7 @@ class PKPContactForm extends FormComponent
             ]))
             ->addField(new FieldTextarea('mailingAddress', [
                 'label' => __('common.mailingAddress'),
-                'isRequired' => true,
+                'isRequired' => false,
                 'size' => 'small',
                 'groupId' => 'principal',
                 'value' => $context->getData('mailingAddress'),


### PR DESCRIPTION
fix to issue https://github.com/pkp/pkp-lib/issues/2169 which make the `Mailing address` as a non required field in the `Settings => Contact` section for `main` branch.