### PR TITLE
pkp/pkp-lib#6983 On password change, invalidate other sessions

### DIFF
--- a/classes/session/SessionDAO.inc.php
+++ b/classes/session/SessionDAO.inc.php
@@ -16,6 +16,7 @@
 
 
 import('lib.pkp.classes.session.Session');
+use Illuminate\Support\Facades\DB;
 
 class SessionDAO extends DAO {
 
@@ -169,6 +170,22 @@ class SessionDAO extends DAO {
 		$row = $result->current();
 		return $row ? (boolean) $row->row_count : false;
 	}
+
+	/**
+     * Delete given user's all sessions or except for the given session id
+     *
+     * @param int                   $userId
+     * @param mixed<string|null>    $sessionId
+     *
+     * @return void
+     */
+    public function deleteUserSessions(int $userId, string $excludableSessionId = null) {
+
+        DB::table('sessions')
+            ->where('user_id', $userId)
+            ->when($excludableSessionId, fn($query) => $query->where('session_id', '<>', $excludableSessionId))
+            ->delete();
+    }
 }
 
 

--- a/classes/session/SessionManager.inc.php
+++ b/classes/session/SessionManager.inc.php
@@ -133,6 +133,29 @@ class SessionManager {
 	}
 
 	/**
+     * Invalidate given user's all sessions or except for the given session id
+     *
+     * @param int       			$userId
+     * @param mixed<string|null>    $sessionId
+     * 
+     * @return bool
+     */
+    public function invalidateSessions(int $userId, string $excludableSessionId = null) {
+
+        $this->getSessionDao()->deleteUserSessions($userId, $excludableSessionId);
+
+        return true;
+    }
+
+	/**
+     * Get the Session DAO instance
+	 * @return SessionDao
+     */
+    public function getSessionDao() {
+        return $this->sessionDao;
+    }
+
+	/**
 	 * Get the session associated with the current request.
 	 * @return Session
 	 */

--- a/controllers/grid/settings/user/form/UserDetailsForm.inc.php
+++ b/controllers/grid/settings/user/form/UserDetailsForm.inc.php
@@ -14,6 +14,7 @@
  */
 
 import('lib.pkp.controllers.grid.settings.user.form.UserForm');
+import('lib.pkp.classes.session.SessionManager');
 
 class UserDetailsForm extends UserForm {
 
@@ -300,6 +301,14 @@ class UserDetailsForm extends UserForm {
 				} else {
 					$this->user->setPassword(Validation::encryptCredentials($this->user->getUsername(), $this->getData('password')));
 				}
+
+				$sessionManager = SessionManager::getManager();
+                $sessionManager->invalidateSessions(
+                    $this->user->getId(),
+                    (int) $this->user->getId() === (int) $request->getUser()->getId()
+                        ? $sessionManager->getUserSession()->getId()
+                        : null
+                );
 			}
 
 			if (isset($auth)) {

--- a/controllers/tab/user/ProfileTabHandler.inc.php
+++ b/controllers/tab/user/ProfileTabHandler.inc.php
@@ -20,7 +20,7 @@
 
 import('classes.handler.Handler');
 import('lib.pkp.classes.core.JSONMessage');
-
+import('lib.pkp.classes.session.SessionManager');
 class ProfileTabHandler extends Handler {
 
 	//
@@ -262,15 +262,24 @@ class ProfileTabHandler extends Handler {
 	 * @return JSONMessage JSON-formatted response
 	 */
 	function savePassword($args, $request) {
+		
 		$this->setupTemplate($request);
+
+		$user = $request->getUser();
+
 		import('lib.pkp.classes.user.form.ChangePasswordForm');
-		$passwordForm = new ChangePasswordForm($request->getUser(), $request->getSite());
+		$passwordForm = new ChangePasswordForm($user, $request->getSite());
 		$passwordForm->readInputData();
 
 		if ($passwordForm->validate()) {
+
 			$passwordForm->execute();
+
+			$sessionManager = SessionManager::getManager();
+            $sessionManager->invalidateSessions($user->getId(), $sessionManager->getUserSession()->getId());
+
 			$notificationMgr = new NotificationManager();
-			$notificationMgr->createTrivialNotification($request->getUser()->getId());
+			$notificationMgr->createTrivialNotification($user->getId());
 			return new JSONMessage(true);
 
 		}

--- a/pages/login/LoginHandler.inc.php
+++ b/pages/login/LoginHandler.inc.php
@@ -15,6 +15,7 @@
 
 
 import('classes.handler.Handler');
+import('lib.pkp.classes.session.SessionManager');
 
 class LoginHandler extends Handler {
 	/**
@@ -237,6 +238,8 @@ class LoginHandler extends Handler {
 				$user->setPassword(Validation::encryptCredentials($user->getUsername(), $newPassword));
 			}
 
+			SessionManager::getManager()->invalidateSessions($user->getId());
+
 			$user->setMustChangePassword(1);
 			$userDao->updateObject($user);
 
@@ -304,6 +307,9 @@ class LoginHandler extends Handler {
 		if ($passwordForm->validate()) {
 			if ($passwordForm->execute()) {
 				$user = Validation::login($passwordForm->getData('username'), $passwordForm->getData('password'), $reason);
+				
+				$sessionManager = SessionManager::getManager();
+            	$sessionManager->invalidateSessions($user->getId(), $sessionManager->getUserSession()->getId());
 			}
 			$this->sendHome($request);
 		} else {


### PR DESCRIPTION
This RP aims to fix issue https://github.com/pkp/pkp-lib/issues/6983 . By this enhancement , users will be force logged out from any other devices except the current one when update the password successfully . This takes into the consideration of cases as 

1. User password update .
2. User password update by admin/journal manager from journal settings 
3. user password reset 
4. user password force update on login as password updated or reset 