### PR TITLE
pkp/pkp-lib#6983 On password change, invalidate other sessions

### DIFF
--- a/classes/session/SessionDAO.inc.php
+++ b/classes/session/SessionDAO.inc.php
@@ -203,7 +203,7 @@ class SessionDAO extends DAO
      * @return void
      */
     public function deleteUserSessions(int $userId, string $excludableSessionId = null) 
-	{
+    {
         DB::table('sessions')
             ->where('user_id', $userId)
             ->when($excludableSessionId, fn($query) => $query->where('session_id', '<>', $excludableSessionId))

--- a/classes/session/SessionDAO.inc.php
+++ b/classes/session/SessionDAO.inc.php
@@ -18,6 +18,7 @@
 namespace PKP\session;
 
 use PKP\db\DAO;
+use Illuminate\Support\Facades\DB;
 
 class SessionDAO extends DAO
 {
@@ -191,6 +192,22 @@ class SessionDAO extends DAO
         $result = $this->retrieve('SELECT COUNT(*) AS row_count FROM sessions WHERE session_id = ?', [$sessionId]);
         $row = $result->current();
         return $row ? (bool) $row->row_count : false;
+    }
+
+	/**
+     * Delete given user's all sessions or except for the given session id
+     *
+     * @param int                   $userId     The target user id for whom to invalidate sessions
+     * @param mixed<string|null>    $sessionId  The specific session id which need to be excluded from invalidation process for targated user
+     *
+     * @return void
+     */
+    public function deleteUserSessions(int $userId, string $excludableSessionId = null) 
+	{
+        DB::table('sessions')
+            ->where('user_id', $userId)
+            ->when($excludableSessionId, fn($query) => $query->where('session_id', '<>', $excludableSessionId))
+            ->delete();
     }
 }
 

--- a/classes/session/SessionManager.inc.php
+++ b/classes/session/SessionManager.inc.php
@@ -19,6 +19,8 @@ use PKP\config\Config;
 use PKP\core\PKPRequest;
 use PKP\core\Registry;
 use PKP\db\DAORegistry;
+use PKP\session\Session;
+use PKP\session\SessionDAO;
 
 class SessionManager
 {
@@ -138,6 +140,31 @@ class SessionManager
         }
 
         return $instance;
+    }
+
+	/**
+     * Invalidate given user's all sessions or except for the given session id
+     *
+     * @param int                   $userId     The target user id for whom to invalidate sessions
+     * @param mixed<string|null>    $sessionId  The specific session id which need to be excluded from invalidation process for targated user
+     * 
+     * @return bool
+     */
+    public function invalidateSessions(int $userId, string $excludableSessionId = null): bool 
+	{
+        $this->getSessionDao()->deleteUserSessions($userId, $excludableSessionId);
+
+        return true;
+    }
+
+	/**
+     * Get the Session DAO instance associated with the current request
+	 * 
+	 * @return SessionDao
+     */
+    public function getSessionDao(): SessionDao
+	{
+        return $this->sessionDao;
     }
 
     /**

--- a/classes/session/SessionManager.inc.php
+++ b/classes/session/SessionManager.inc.php
@@ -151,7 +151,7 @@ class SessionManager
      * @return bool
      */
     public function invalidateSessions(int $userId, string $excludableSessionId = null): bool 
-	{
+    {
         $this->getSessionDao()->deleteUserSessions($userId, $excludableSessionId);
 
         return true;
@@ -163,7 +163,7 @@ class SessionManager
 	 * @return SessionDao
      */
     public function getSessionDao(): SessionDao
-	{
+    {
         return $this->sessionDao;
     }
 

--- a/controllers/grid/settings/user/form/UserDetailsForm.inc.php
+++ b/controllers/grid/settings/user/form/UserDetailsForm.inc.php
@@ -27,6 +27,7 @@ use PKP\mail\MailTemplate;
 use PKP\notification\PKPNotification;
 use PKP\security\Validation;
 use PKP\user\InterestManager;
+use PKP\session\SessionManager;
 
 class UserDetailsForm extends UserForm
 {
@@ -319,6 +320,14 @@ class UserDetailsForm extends UserForm
                 } else {
                     $this->user->setPassword(Validation::encryptCredentials($this->user->getUsername(), $this->getData('password')));
                 }
+
+                $sessionManager = SessionManager::getManager();
+                $sessionManager->invalidateSessions(
+                    $this->user->getId(),
+                    (int) $this->user->getId() === (int) $request->getUser()->getId()
+                        ? $sessionManager->getUserSession()->getId()
+                        : null
+                );
             }
 
             if (isset($auth)) {

--- a/controllers/tab/user/ProfileTabHandler.inc.php
+++ b/controllers/tab/user/ProfileTabHandler.inc.php
@@ -29,6 +29,7 @@ use PKP\user\form\ContactForm;
 use PKP\user\form\IdentityForm;
 use PKP\user\form\PublicProfileForm;
 use PKP\user\form\RolesForm;
+use PKP\session\SessionManager;
 
 class ProfileTabHandler extends Handler
 {
@@ -300,15 +301,25 @@ class ProfileTabHandler extends Handler
     public function savePassword($args, $request)
     {
         $this->setupTemplate($request);
-        $passwordForm = new ChangePasswordForm($request->getUser(), $request->getSite());
+
+		$user = $request->getUser();
+
+        $passwordForm = new ChangePasswordForm($user, $request->getSite());
         $passwordForm->readInputData();
 
         if ($passwordForm->validate()) {
+
             $passwordForm->execute();
+
+			$sessionManager = SessionManager::getManager();
+            $sessionManager->invalidateSessions($user->getId(), $sessionManager->getUserSession()->getId());
+
             $notificationMgr = new NotificationManager();
-            $notificationMgr->createTrivialNotification($request->getUser()->getId());
-            return new JSONMessage(true);
+            $notificationMgr->createTrivialNotification($user->getId());
+            
+			return new JSONMessage(true);
         }
+		
         return new JSONMessage(true, $passwordForm->fetch($request));
     }
 

--- a/controllers/tab/user/ProfileTabHandler.inc.php
+++ b/controllers/tab/user/ProfileTabHandler.inc.php
@@ -302,7 +302,7 @@ class ProfileTabHandler extends Handler
     {
         $this->setupTemplate($request);
 
-		$user = $request->getUser();
+        $user = $request->getUser();
 
         $passwordForm = new ChangePasswordForm($user, $request->getSite());
         $passwordForm->readInputData();
@@ -311,13 +311,13 @@ class ProfileTabHandler extends Handler
 
             $passwordForm->execute();
 
-			$sessionManager = SessionManager::getManager();
+            $sessionManager = SessionManager::getManager();
             $sessionManager->invalidateSessions($user->getId(), $sessionManager->getUserSession()->getId());
 
             $notificationMgr = new NotificationManager();
             $notificationMgr->createTrivialNotification($user->getId());
             
-			return new JSONMessage(true);
+            return new JSONMessage(true);
         }
 		
         return new JSONMessage(true, $passwordForm->fetch($request));

--- a/pages/login/LoginHandler.inc.php
+++ b/pages/login/LoginHandler.inc.php
@@ -273,6 +273,8 @@ class LoginHandler extends Handler
                 $user->setPassword(Validation::encryptCredentials($user->getUsername(), $newPassword));
             }
 
+			SessionManager::getManager()->invalidateSessions($user->getId());
+
             $user->setMustChangePassword(1);
             Repo::user()->edit($user);
 
@@ -338,6 +340,9 @@ class LoginHandler extends Handler
         if ($passwordForm->validate()) {
             if ($passwordForm->execute()) {
                 $user = Validation::login($passwordForm->getData('username'), $passwordForm->getData('password'), $reason);
+
+				$sessionManager = SessionManager::getManager();
+            	$sessionManager->invalidateSessions($user->getId(), $sessionManager->getUserSession()->getId());
             }
             $this->sendHome($request);
         } else {

--- a/pages/login/LoginHandler.inc.php
+++ b/pages/login/LoginHandler.inc.php
@@ -273,7 +273,7 @@ class LoginHandler extends Handler
                 $user->setPassword(Validation::encryptCredentials($user->getUsername(), $newPassword));
             }
 
-			SessionManager::getManager()->invalidateSessions($user->getId());
+            SessionManager::getManager()->invalidateSessions($user->getId());
 
             $user->setMustChangePassword(1);
             Repo::user()->edit($user);
@@ -341,8 +341,8 @@ class LoginHandler extends Handler
             if ($passwordForm->execute()) {
                 $user = Validation::login($passwordForm->getData('username'), $passwordForm->getData('password'), $reason);
 
-				$sessionManager = SessionManager::getManager();
-            	$sessionManager->invalidateSessions($user->getId(), $sessionManager->getUserSession()->getId());
+                $sessionManager = SessionManager::getManager();
+                $sessionManager->invalidateSessions($user->getId(), $sessionManager->getUserSession()->getId());
             }
             $this->sendHome($request);
         } else {


### PR DESCRIPTION
This RP aims to fix issue https://github.com/pkp/pkp-lib/issues/6983 . By this enhancement , users will be force logged out from any other devices except the current one when update the password successfully . This takes into the consideration of cases as

1. User password update .
2. User password update by admin/journal manager from journal settings
3. user password reset
4. user password force update on login as password updated or reset