### PR TITLE
pkp/pkp-lib#4240 Remove unvalidated new accounts after expiry

### DIFF
--- a/classes/task/RemoveUnvalidatedExpiredUsers.inc.php
+++ b/classes/task/RemoveUnvalidatedExpiredUsers.inc.php
@@ -35,13 +35,13 @@ class RemoveUnvalidatedExpiredUsers extends ScheduledTask
      * @copydoc ScheduledTask::executeActions()
      */
     public function executeActions()
-    {
-        if ( ! Config::getVar('general', 'remove_expired_users') ) {
+    {   
+        $validationMaxDeadlineInDays = (int) Config::getVar('general', 'user_validation_period');
+
+        if ( $validationMaxDeadlineInDays <= 0 ) {
             
             return;
         }
-        
-        $validationMaxDeadlineInDays = Config::getVar('email', 'validation_timeout') ?? 14;
 
         $dateTillValid = Carbon::now()->startOfDay()->subDays($validationMaxDeadlineInDays);
 

--- a/classes/task/RemoveUnvalidatedExpiredUsers.inc.php
+++ b/classes/task/RemoveUnvalidatedExpiredUsers.inc.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file classes/task/RemoveUnvalidatedExpiredUser.inc.php
+ *
+ * Copyright (c) 2013-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class RemoveUnvalidatedExpiredUser
+ * @ingroup tasks
+ *
+ * @brief Class to remove all unvalidated and expired users after validation timeout
+ */
+
+namespace PKP\task;
+
+use Carbon\Carbon;
+use APP\facades\Repo;
+use PKP\config\Config;
+use PKP\scheduledTask\ScheduledTask;
+
+class RemoveUnvalidatedExpiredUsers extends ScheduledTask
+{
+    /**
+     * @copydoc ScheduledTask::getName()
+     */
+    public function getName()
+    {
+        return __('admin.scheduledTask.removeUnvalidatedExpiredUsers');
+    }
+
+
+    /**
+     * @copydoc ScheduledTask::executeActions()
+     */
+    public function executeActions()
+    {
+        if ( ! Config::getVar('general', 'remove_expired_users') ) {
+            
+            return;
+        }
+        
+        $validationMaxDeadlineInDays = Config::getVar('email', 'validation_timeout') ?? 14;
+
+        $dateTillValid = Carbon::now()->startOfDay()->subDays($validationMaxDeadlineInDays);
+
+        Repo::user()->deleteUnvalidatedExpiredUsers($dateTillValid);
+
+        return true;
+    }
+}
+
+if (!PKP_STRICT_MODE) {
+    class_alias('\PKP\task\RemoveUnvalidatedExpiredUsers', '\RemoveUnvalidatedExpiredUsers');
+}

--- a/classes/task/RemoveUnvalidatedExpiredUsers.inc.php
+++ b/classes/task/RemoveUnvalidatedExpiredUsers.inc.php
@@ -3,8 +3,8 @@
 /**
  * @file classes/task/RemoveUnvalidatedExpiredUser.inc.php
  *
- * Copyright (c) 2013-2021 Simon Fraser University
- * Copyright (c) 2003-2021 John Willinsky
+ * Copyright (c) 2022 Simon Fraser University
+ * Copyright (c) 2022 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class RemoveUnvalidatedExpiredUser

--- a/classes/user/DAO.inc.php
+++ b/classes/user/DAO.inc.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\DataObject;
 use PKP\identity\Identity;
+use Carbon\Carbon;
 
 class DAO extends \PKP\core\EntityDAO
 {
@@ -301,5 +302,23 @@ class DAO extends \PKP\core\EntityDAO
                 );
             }
         }
+    }
+
+    /**
+     * Delete unvalidated expired users
+     * 
+     * @param object<Carbon\Carbon> $dateTillValid      The dateTime till before which user will consider expired
+     * @param array                 $excludableUsersId  The users id to exclude form delete operation
+     * 
+     * @return int The number rows affected by DB operation
+     */
+    public function deleteUnvalidatedExpiredUsers(Carbon $dateTillValid, array $excludableUsersId = []) {
+
+        return DB::table('users')
+            ->whereNull('date_validated')
+            ->whereNull('date_last_login')
+            ->where('date_registered', '<', $dateTillValid)
+            ->when( !empty($excludableUsersId), fn($query) => $query->whereNotIn('id', $excludableUsersId) )
+            ->delete();
     }
 }

--- a/classes/user/DAO.inc.php
+++ b/classes/user/DAO.inc.php
@@ -23,6 +23,7 @@ use Illuminate\Support\LazyCollection;
 use PKP\core\DataObject;
 use PKP\identity\Identity;
 use Carbon\Carbon;
+use APP\facades\Repo;
 
 class DAO extends \PKP\core\EntityDAO
 {
@@ -321,7 +322,9 @@ class DAO extends \PKP\core\EntityDAO
             ->when( !empty($excludableUsersId), fn($query) => $query->whereNotIn('id', $excludableUsersId) )
             ->get();
 
-        $users->each(fn($user) => $this->delete($this->get($user->user_id, true)));
+        $userRepository = Repo::user();
+
+        $users->each(fn($user) => $userRepository->delete($userRepository->get($user->user_id, true)));
 
         return $users->count();
     }

--- a/classes/user/DAO.inc.php
+++ b/classes/user/DAO.inc.php
@@ -314,11 +314,15 @@ class DAO extends \PKP\core\EntityDAO
      */
     public function deleteUnvalidatedExpiredUsers(Carbon $dateTillValid, array $excludableUsersId = []) {
 
-        return DB::table('users')
+        $users = DB::table('users')
             ->whereNull('date_validated')
             ->whereNull('date_last_login')
             ->where('date_registered', '<', $dateTillValid)
             ->when( !empty($excludableUsersId), fn($query) => $query->whereNotIn('id', $excludableUsersId) )
-            ->delete();
+            ->get();
+
+        $users->each(fn($user) => $this->delete($this->get($user->user_id, true)));
+
+        return $users->count();
     }
 }

--- a/classes/user/Repository.inc.php
+++ b/classes/user/Repository.inc.php
@@ -21,6 +21,7 @@ use PKP\context\Context;
 use PKP\db\DAORegistry;
 use PKP\plugins\HookRegistry;
 use PKP\security\Role;
+use Carbon\Carbon;
 
 class Repository
 {
@@ -392,5 +393,18 @@ class Repository
         $contextUser->setData('email', $context->getData('contactEmail'));
         $contextUser->setData('givenName', array_fill_keys($supportedLocales, $context->getData('contactName')));
         return $contextUser;
+    }
+
+    /**
+     * Delete unvalidated expired users
+     * 
+     * @param object<Carbon\Carbon> $dateTillValid      The dateTime till before which user will consider expired
+     * @param array                 $excludableUsersId  The users id to exclude form delete operation
+     * 
+     * @return int The number rows affected by DB operation
+     */
+    public function deleteUnvalidatedExpiredUsers(Carbon $dateTillValid, array $excludableUsersId = []) {
+
+        return $this->dao->deleteUnvalidatedExpiredUsers($dateTillValid, $excludableUsersId);
     }
 }

--- a/locale/en_US/admin.po
+++ b/locale/en_US/admin.po
@@ -164,6 +164,9 @@ msgstr "Editorial Report Notification"
 msgid "admin.scheduledTask.subscriptionExpiryReminder"
 msgstr "Subscription expiry reminder"
 
+msgid "admin.scheduledTask.removeUnvalidatedExpiredUsers"
+msgstr "Remove unvalidated expired users"
+
 msgid "admin.server.apacheVersion"
 msgstr "Apache version"
 


### PR DESCRIPTION
This PR aims to resolve the issue pkp/pkp-lib#4240 by adding the feature that will allow automatic removal of unvalidated expired users . The removal process as follows : 

- User has not validated
- User has never logged in since registration
- the difference between registration and task running has passed what is set for `validation_timeout` in the config file
