### PR TITLE
Incorrect docblock type hint in HookRegistry::register

### DIFF
--- a/classes/plugins/HookRegistry.inc.php
+++ b/classes/plugins/HookRegistry.inc.php
@@ -77,7 +77,7 @@ class HookRegistry
      * Register a hook against the given hook name.
      *
      * @param string $hookName Name of hook to register against
-     * @param object $callback Callback pseudotype
+     * @param object|array $callback Callback pseudo-type
      * @param int $hookSequence Optional hook sequence specifier HOOK_SEQUENCE_...
      */
     public static function register($hookName, $callback, $hookSequence = HOOK_SEQUENCE_NORMAL)


### PR DESCRIPTION
Stop your IDE from screaming at this union type.