### PR TITLE
#7805 download .tar.gz files results in wrong file extension for downloaded file

### DIFF
--- a/classes/services/PKPFileService.inc.php
+++ b/classes/services/PKPFileService.inc.php
@@ -181,9 +181,10 @@ class PKPFileService
      */
     public function formatFilename($path, $filename)
     {
-        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        preg_match("/(\\.\\w{1,3})?\\.\\w+$/", $path, $extension); #extended matching which also captures .tar.gz extensions
+        $extension = substr($extension[0], 1); # Remove leading dot
         $newFilename = $filename;
-        if (!empty($extension) && substr($newFilename, (strlen($extension) * -1)) != $extension) {
+        if (!empty($extension) && strcasecmp(substr($newFilename, (strlen($extension) * -1)), $extension) != 0) {
             $newFilename .= '.' . $extension;
         }
 

--- a/classes/services/PKPFileService.inc.php
+++ b/classes/services/PKPFileService.inc.php
@@ -181,13 +181,14 @@ class PKPFileService
      */
     public function formatFilename($path, $filename)
     {
-        preg_match("/(\\.\\w{1,3})?\\.\\w+$/", $path, $extension); #extended matching which also captures .tar.gz extensions
-        $extension = substr($extension[0], 1); # Remove leading dot
         $newFilename = $filename;
-        if (!empty($extension) && strcasecmp(substr($newFilename, (strlen($extension) * -1)), $extension) != 0) {
-            $newFilename .= '.' . $extension;
+        # pattern extended to also capture captures .tar.gz extensions
+        if (preg_match('/(\\.\\w{1,3})?\\.\\w+$/', $path, $extension)) {
+            # If $newFilename has no/not the correct extension: Append extension
+            if (strcasecmp(substr($newFilename, (strlen($extension[0]) * -1)), $extension[0]) != 0) {
+                $newFilename .= $extension[0];
+            }
         }
-
         HookRegistry::call('File::formatFilename', [&$newFilename, $path, $filename]);
 
         return $newFilename;


### PR DESCRIPTION
**The Problem**

We ran into some issues with downloading `.tar.gz` files attached to a submission on our OJS 3.4 testing installation (main branch on ojs github):
OJS saves its files to disk in the `files` folder with a hashed name, something like `9be4568f2a.tar.gz`. The Problem arises when the filename extension in the database table `submission_file_settings.setting_value` differs from the extension in the hashed file on disk: This leads the system to extract the file extension from the hashed actual file and append it to `submission_file_settings.setting_value` for the downloaded file. The problem is that with `.tar.gz` extensions, only `.gz` This can lead to situations like this: 
1. We upload a file called "test.tar.gz"
2. For whatever reason, someone decides to rename the file in the OJS system to `test` (omitting the extension), which is written to `submission_file_settings.setting_value`
3. When downloading the file, we get `test.gz`, since OJS takes the extension after the the last dot from the file on disk (`9be4568f2a.tar.gz`)

**Our suggested fix**

We modified the `formatFilename()` function in `lib/pkp/classes/services/PKPFileService.inc.php`:

*Original code block*:
```
 public function formatFilename($path, $filename) {
             $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
             $newFilename = $filename;
             if (!empty($extension) && substr($newFilename, (strlen($extension) * -1)) != $extension) {
                 $newFilename .= '.' . $extension;
             }
             HookRegistry::call('File::formatFilename', [&$newFilename, $path, $filename]);

             return $newFilename;
}
```
*Fixed code Block:*
```
 public function formatFilename($path, $filename) {
        preg_match("/(\\.\\w{1,3})?\\.\\w+$/", $path, $extension); #extended matching which also captures .tar.gz extensions
        $extension = substr($extension[0], 1); # Remove leading dot
        $newFilename =$filename;
        if (!empty($extension) && strcasecmp(substr($newFilename, (strlen($extension) * -1)), $extension) != 0) {
            $newFilename .= '.' . $extension;
        }

        HookRegistry::call('File::formatFilename', [&$newFilename, $path, $filename]);

        return $newFilename;
}
```

The regular expression matches both `.tar.gz` and appends it to the downloaded file name `$newFilename`.