### PR TITLE
pkp/pkp-lib#5192 Removing unnecessary aria-labels from sidebar and breadcrumb elements

### DIFF
--- a/templates/frontend/components/breadcrumbs.tpl
+++ b/templates/frontend/components/breadcrumbs.tpl
@@ -14,7 +14,7 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
 
-<nav class="cmp_breadcrumbs" role="navigation" aria-label="{translate key="navigation.breadcrumbLabel"}">
+<nav class="cmp_breadcrumbs" role="navigation">
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">

--- a/templates/frontend/components/breadcrumbs_announcement.tpl
+++ b/templates/frontend/components/breadcrumbs_announcement.tpl
@@ -11,7 +11,7 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
 
-<nav class="cmp_breadcrumbs cmp_breadcrumbs_announcement" role="navigation" aria-label="{translate key="navigation.breadcrumbLabel"}">
+<nav class="cmp_breadcrumbs cmp_breadcrumbs_announcement" role="navigation">
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">

--- a/templates/frontend/components/breadcrumbs_catalog.tpl
+++ b/templates/frontend/components/breadcrumbs_catalog.tpl
@@ -15,7 +15,7 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
 
-<nav class="cmp_breadcrumbs cmp_breadcrumbs_catalog" role="navigation" aria-label="{translate key="navigation.breadcrumbLabel"}">
+<nav class="cmp_breadcrumbs cmp_breadcrumbs_catalog" role="navigation">
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">

--- a/templates/frontend/components/footer.tpl
+++ b/templates/frontend/components/footer.tpl
@@ -18,7 +18,7 @@
 	{if empty($isFullWidth)}
 		{capture assign="sidebarCode"}{call_hook name="Templates::Common::Sidebar"}{/capture}
 		{if $sidebarCode}
-			<div class="pkp_structure_sidebar left" role="complementary" aria-label="{translate|escape key="common.navigation.sidebar"}">
+			<div class="pkp_structure_sidebar left" role="complementary">
 				{$sidebarCode}
 			</div><!-- pkp_sidebar.left -->
 		{/if}


### PR DESCRIPTION
- Removed `arial-label` parameter from the sidebar component
- Removed `arial-label `parameter from the breadcrumb component

Related to issue #5192 

Note: The locale key will remain for now since other themes are still using it. We will be able to remove the key as soon we fix the bootstrap and the  healthscience themes.