### PR TITLE
pkp/pkp-lib#6782 do not use installation migrations in the upgrade

### DIFF
--- a/Jobs/Statistics/CompileMonthlyMetrics.php
+++ b/Jobs/Statistics/CompileMonthlyMetrics.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file Jobs/Statistics/CompileMonthlyMetrics.php
+ *
+ * Copyright (c) 2022 Simon Fraser University
+ * Copyright (c) 2022 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class CompileMonthlyMetrics
+ * @ingroup jobs
+ *
+ * @brief Compile and store monthly usage stats from the daily records.
+ */
+
+namespace PKP\Jobs\Statistics;
+
+use APP\core\Services;
+use PKP\site\Site;
+use PKP\Support\Jobs\BaseJob;
+
+class CompileMonthlyMetrics extends BaseJob
+{
+    /**
+     * The number of times the job may be attempted.
+     */
+    public $tries = 1;
+
+    /**
+     * The month the usage metrics should be aggregated by, in format YYYYMM.
+     */
+    protected string $month;
+
+    protected Site $site;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param string $month In format YYYYMM
+     */
+    public function __construct(string $month, Site $site)
+    {
+        parent::__construct();
+        $this->month = $month;
+        $this->site = $site;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $currentMonth = date('Ym');
+        $lastMonth = date('Ym', strtotime('last month'));
+
+        $geoService = Services::get('geoStats');
+        $geoService->deleteMonthlyMetrics($this->month);
+        $geoService->addMonthlyMetrics($this->month);
+        if (!$this->site->getData('keepDailyUsageStats') && $this->month != $currentMonth && $this->month != $lastMonth) {
+            $geoService->deleteDailyMetrics($this->month);
+        }
+
+        $counterService = Services::get('sushiStats');
+        $counterService->deleteMonthlyMetrics($this->month);
+        $counterService->addMonthlyMetrics($this->month);
+        if (!$this->site->getData('keepDailyUsageStats') && $this->month != $currentMonth && $this->month != $lastMonth) {
+            $counterService->deleteDailyMetrics($this->month);
+        }
+    }
+}

--- a/classes/migration/upgrade/v3_4_0/I6895_CreateNewInstitutionsTables.php
+++ b/classes/migration/upgrade/v3_4_0/I6895_CreateNewInstitutionsTables.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_4_0/I6895_CreateNewInstitutionsTables.php
+ *
+ * Copyright (c) 2022 Simon Fraser University
+ * Copyright (c) 2022 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I6895_CreateNewInstitutionsTables
+ * @brief Describe database table structures.
+ */
+
+namespace PKP\migration\upgrade\v3_4_0;
+
+use APP\core\Application;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema as Schema;
+use PKP\install\DowngradeNotSupportedException;
+use PKP\migration\Migration;
+
+class I6895_CreateNewInstitutionsTables extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        // Institutions.
+        Schema::create('institutions', function (Blueprint $table) {
+            $table->bigInteger('institution_id')->autoIncrement();
+            $table->bigInteger('context_id');
+            $table->string('ror', 255)->nullable();
+            $table->softDeletes('deleted_at', 0);
+            $contextDao = Application::getContextDAO();
+            $table->foreign('context_id')->references($contextDao->primaryKeyColumn)->on($contextDao->tableName)->onDelete('cascade');
+        });
+
+        // Locale-specific institution data
+        Schema::create('institution_settings', function (Blueprint $table) {
+            $table->bigInteger('institution_id');
+            $table->string('locale', 14)->default('');
+            $table->string('setting_name', 255);
+            $table->mediumText('setting_value')->nullable();
+            $table->foreign('institution_id')->references('institution_id')->on('institutions')->onDelete('cascade');
+            $table->index(['institution_id'], 'institution_settings_institution_id');
+            $table->unique(['institution_id', 'locale', 'setting_name'], 'institution_settings_pkey');
+        });
+
+        // Institution IPs and IP ranges.
+        Schema::create('institution_ip', function (Blueprint $table) {
+            $table->bigInteger('institution_ip_id')->autoIncrement();
+            $table->bigInteger('institution_id');
+            $table->string('ip_string', 40);
+            $table->bigInteger('ip_start');
+            $table->bigInteger('ip_end')->nullable();
+            $table->foreign('institution_id')->references('institution_id')->on('institutions')->onDelete('cascade');
+            $table->index(['institution_id'], 'institution_ip_institution_id');
+            $table->index(['ip_start'], 'institution_ip_start');
+            $table->index(['ip_end'], 'institution_ip_end');
+        });
+
+        if (Schema::hasTable('institutional_subscriptions') && Schema::hasColumn('institutional_subscriptions', 'institution_id')) {
+            Schema::table('institutional_subscriptions', function (Blueprint $table) {
+                $table->foreign('institution_id')->references('institution_id')->on('institutions');
+            });
+        }
+    }
+
+    /**
+     * Reverse the downgrades
+     *
+     * @throws DowngradeNotSupportedException
+     */
+    public function down(): void
+    {
+        throw new DowngradeNotSupportedException();
+    }
+}

--- a/classes/task/PKPUsageStatsLoader.php
+++ b/classes/task/PKPUsageStatsLoader.php
@@ -17,7 +17,6 @@ namespace PKP\task;
 
 use APP\core\Application;
 use APP\core\Services;
-use APP\Jobs\Statistics\CompileMonthlyMetrics;
 use APP\Jobs\Statistics\CompileUsageStatsFromTemporaryRecords;
 use APP\statistics\StatisticsHelper;
 use APP\statistics\TemporaryItemInvestigationsDAO;
@@ -28,6 +27,7 @@ use Exception;
 use PKP\core\Core;
 use PKP\db\DAORegistry;
 use PKP\file\FileManager;
+use PKP\Jobs\Statistics\CompileMonthlyMetrics;
 use PKP\plugins\Hook;
 use PKP\scheduledTask\ScheduledTaskHelper;
 use PKP\statistics\TemporaryInstitutionsDAO;


### PR DESCRIPTION
The installation migrations scripts for new institutions tables that were used in the upgrade are copied into the folder classes/migration/upgrade/v3_4_0/ and now used from there...