### PR TITLE
incomplete_count calculation does not account for cancelled review assignment (fix for issue #8189)

### DIFF
--- a/classes/user/Collector.php
+++ b/classes/user/Collector.php
@@ -514,7 +514,7 @@ class Collector implements CollectorInterface
                 ->groupBy('ra.reviewer_id')
                 ->select('ra.reviewer_id')
                 ->selectRaw('MAX(ra.date_assigned) AS last_assigned')
-                ->selectRaw('COUNT(CASE WHEN ra.date_completed IS NULL AND ra.declined = 0 THEN 1 END) AS incomplete_count')
+                ->selectRaw('COUNT(CASE WHEN ra.date_completed IS NULL AND ra.declined = 0 AND ra.cancelled = 0 THEN 1 END) AS incomplete_count')
                 ->selectRaw('COUNT(CASE WHEN ra.date_completed IS NOT NULL AND ra.declined = 0 THEN 1 END) AS complete_count')
                 ->selectRaw('SUM(ra.declined) AS declined_count')
                 ->selectRaw('SUM(ra.cancelled) AS cancelled_count')


### PR DESCRIPTION
this patch has been tested on our sandbox and deployed to our production server for academic-publishing.org (approx 400 visitors / day)