### PR TITLE
pkp/pkp-lib#7546 fix getLocalizedGivenName and getLocalizedFamilyName

### DIFF
--- a/classes/identity/Identity.inc.php
+++ b/classes/identity/Identity.inc.php
@@ -116,8 +116,8 @@ class Identity extends DataObject {
 	 * Get the localized given name
 	 * @return string
 	 */
-	function getLocalizedGivenName($defaultLocale = null) {
-		return $this->getLocalizedData(IDENTITY_SETTING_GIVENNAME, $defaultLocale);
+	function getLocalizedGivenName() {
+		return $this->getLocalizedData(IDENTITY_SETTING_GIVENNAME);
 	}
 
 	/**
@@ -141,25 +141,16 @@ class Identity extends DataObject {
 	/**
 	 * Get the localized family name
 	 * Return family name for the locale first name exists in
-	 * @param $defaultLocale string
 	 * @return string
 	 */
-	function getLocalizedFamilyName($defaultLocale = null) {
-		// Prioritize the current locale, then the default locale.
-		$localePriorityList = [AppLocale::getLocale()];
-		if (!is_null($defaultLocale)) {
-			$localePriorityList[] = $defaultLocale;
+	function getLocalizedFamilyName() {
+		$locale = AppLocale::getLocale();
+		$givenName = $this->getGivenName($locale);
+		// Only use the family name if a given name exists (to avoid mixing locale data)
+		if (!empty($givenName)) {
+			return $this->getFamilyName($locale);
 		}
-
-		foreach ($localePriorityList as $locale) {
-			$givenName = $this->getGivenName($locale);
-			// Only use the family name if a given name exists (to avoid mixing locale data)
-			if (!empty($givenName)) {
-				return $this->getFamilyName($locale);
-			}
-		}
-
-		// Fall back on the site locale if nothing else was found. (May mix locale data.)
+		// Fall back on the site locale.
 		$site = Application::get()->getRequest()->getSite();
 		$locale = $site->getPrimaryLocale();
 		return $this->getFamilyName($locale);

--- a/classes/notification/managerDelegate/EditorialReportNotificationManager.inc.php
+++ b/classes/notification/managerDelegate/EditorialReportNotificationManager.inc.php
@@ -260,7 +260,7 @@ class EditorialReportNotificationManager extends NotificationManagerDelegate {
 	 */
 	private function _getMessageParams(User $user) : array
 	{
-		return $this->_params + ['name' => htmlspecialchars($user->getLocalizedGivenName($this->_context->getPrimaryLocale()))];
+		return $this->_params + ['name' => htmlspecialchars($user->getLocalizedData(IDENTITY_SETTING_GIVENNAME, $this->_context->getPrimaryLocale()))];
 	}
 
 	/**

--- a/classes/submission/PKPAuthor.inc.php
+++ b/classes/submission/PKPAuthor.inc.php
@@ -55,19 +55,23 @@ class PKPAuthor extends Identity {
 	/**
 	 * @copydoc Identity::getLocalizedGivenName()
 	 */
-	function getLocalizedGivenName($defaultLocale = null) {
-		if (!isset($defaultLocale)) $defaultLocale = $this->getSubmissionLocale();
-
-		return parent::getLocalizedGivenName($defaultLocale);
+	function getLocalizedGivenName() {
+		return $this->getLocalizedData(IDENTITY_SETTING_GIVENNAME);
 	}
 
 	/**
 	 * @copydoc Identity::getLocalizedFamilyName()
 	 */
-	function getLocalizedFamilyName($defaultLocale = null) {
-		if (!isset($defaultLocale)) $defaultLocale = $this->getSubmissionLocale();
-
-		return parent::getLocalizedFamilyName($defaultLocale);
+	function getLocalizedFamilyName() {
+		// Prioritize the current locale, then the default locale.
+		$locale = AppLocale::getLocale();
+		$givenName = $this->getGivenName($locale);
+		// Only use the family name if a given name exists (to avoid mixing locale data)
+		if (!empty($givenName)) {
+			return $this->getFamilyName($locale);
+		}
+		// Fall back on the submission locale.
+		return $this->getFamilyName($this->getSubmissionLocale());
 	}
 
 	/**


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/7546

The functions getLocalized... generally and thus also getLocalizedGiven/FamilyName do not need the locale/preferred locale parameter -- the data in the current UI locale is returned. Sometimes there is a need to get the data in a specific locale, e.g. to get the submission and authors data in the submission locale. This can be done either using 1) the getLocalizedData function (with the preferred locale as parameter) -- if one would like to get the data in the fall back locale if the preferred locale does not exist, or 2) getData function (with the preferred locale as parameter) -- if data in strictly preferred locale is needed. Thus, the preferred locale parameter is here removed from getLocalizedGiven/FamilyName functions. Everywhere in the code and through all applications they are used/called without the parameter, except in the one place corrected here.
Also, the PKPAuthor::getLocalizedGiven/FamilyName functions should not call the parent getLocalizedData method but its own.