### PR TITLE
pkp/pkp-lib#7453 Activitiy Log fails to load when certain values are null due to insufficient error handling in lib/pkp/classes/services/PKPSubmissionFileService.inc.php

### DIFF
--- a/classes/services/PKPSubmissionFileService.inc.php
+++ b/classes/services/PKPSubmissionFileService.inc.php
@@ -768,15 +768,16 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 			case SUBMISSION_FILE_INTERNAL_REVIEW_REVISION:
 				$reviewRoundDao = DAORegistry::getDAO('ReviewRoundDAO'); /* @var $reviewRoundDao ReviewRoundDAO */
 				$reviewRound = $reviewRoundDao->getBySubmissionFileId($submissionFile->getId());
+				if (is_null($reviewRound)) return null;
 				return $reviewRound->getStageId();
 			case SUBMISSION_FILE_QUERY:
+				if ($submissionFile->getData('assocType') != ASSOC_TYPE_NOTE) return null;
 				$noteDao = DAORegistry::getDAO('NoteDAO'); /* @var $noteDao NoteDAO */
 				$note = $noteDao->getById($submissionFile->getData('assocId'));
-				if (!$note) {
-					return null;
-				}
+				if (!$note)  return null;
 				$queryDao = DAORegistry::getDAO('QueryDAO'); /* @var $queryDao QueryDAO */
 				$query = $queryDao->getById($note->getAssocId());
+				if ($query == null or $query->getAssocType() != ASSOC_TYPE_QUERY) return null;
 				return $query ? $query->getStageId() : null;
 		}
 		throw new \Exception('Could not determine the workflow stage id from submission file ' . $submissionFile->getId() . ' with file stage ' . $submissionFile->getData('fileStage'));


### PR DESCRIPTION
Issue
- https://github.com/pkp/pkp-lib/issues/7563

Commment
- These changes are applied to main branch [comment](https://github.com/pkp/pkp-lib/issues/7563#issuecomment-1177307890)  

