### PR TITLE
Include DB port in the installer connection params

### DIFF
--- a/classes/install/PKPInstall.php
+++ b/classes/install/PKPInstall.php
@@ -89,6 +89,7 @@ class PKPInstall extends Installer
             'driver' => $driver,
             'host' => $this->getParam('databaseHost'),
             'port' => $this->getParam('databasePort'),
+            'unix_socket' => $this->getParam('unixSocket'),
             'database' => $this->getParam('databaseName'),
             'username' => $this->getParam('databaseUsername'),
             'password' => $this->getParam('databasePassword'),

--- a/classes/install/PKPInstall.php
+++ b/classes/install/PKPInstall.php
@@ -88,6 +88,7 @@ class PKPInstall extends Installer
         $config['connections'][$driver] = [
             'driver' => $driver,
             'host' => $this->getParam('databaseHost'),
+            'port' => $this->getParam('databasePort'),
             'database' => $this->getParam('databaseName'),
             'username' => $this->getParam('databaseUsername'),
             'password' => $this->getParam('databasePassword'),

--- a/classes/plugins/PluginHelper.php
+++ b/classes/plugins/PluginHelper.php
@@ -179,6 +179,7 @@ class PluginHelper
             'connectionCharset' => Config::getVar('i18n', 'connection_charset'),
             'databaseDriver' => Config::getVar('database', 'driver'),
             'databaseHost' => Config::getVar('database', 'host'),
+            'databasePort' => Config::getVar('database', 'port'),
             'databaseUsername' => Config::getVar('database', 'username'),
             'databasePassword' => Config::getVar('database', 'password'),
             'databaseName' => Config::getVar('database', 'name')

--- a/classes/plugins/PluginHelper.php
+++ b/classes/plugins/PluginHelper.php
@@ -180,6 +180,7 @@ class PluginHelper
             'databaseDriver' => Config::getVar('database', 'driver'),
             'databaseHost' => Config::getVar('database', 'host'),
             'databasePort' => Config::getVar('database', 'port'),
+            'unixSocket' => Config::getVar('database', 'unix_socket'),
             'databaseUsername' => Config::getVar('database', 'username'),
             'databasePassword' => Config::getVar('database', 'password'),
             'databaseName' => Config::getVar('database', 'name')


### PR DESCRIPTION
I have noticed a problem while trying to install a plugin in a journal using Plugin Gallery. In my case, the database is open at a different port than the default one.