### PR TITLE
pkp/pkp-lib#8240 Consider parent object ID in DAO exists and get func…

### DIFF
--- a/api/v1/institutions/PKPInstitutionHandler.php
+++ b/api/v1/institutions/PKPInstitutionHandler.php
@@ -104,7 +104,7 @@ class PKPInstitutionHandler extends APIHandler
      */
     public function get(SlimHttpRequest $slimRequest, APIResponse $response, array $args): APIResponse
     {
-        if (!Repo::institution()->existsInContext((int) $args['institutionId'], $this->getRequest()->getContext()->getId())) {
+        if (!Repo::institution()->exists((int) $args['institutionId'], $this->getRequest()->getContext()->getId())) {
             return $response->withStatus(404)->withJsonError('api.institutions.404.institutionNotFound');
         }
         $institution = Repo::institution()->get((int) $args['institutionId']);
@@ -183,7 +183,7 @@ class PKPInstitutionHandler extends APIHandler
         $request = $this->getRequest();
         $context = $request->getContext();
 
-        if (!Repo::institution()->existsInContext((int) $args['institutionId'], $context->getId())) {
+        if (!Repo::institution()->exists((int) $args['institutionId'], $context->getId())) {
             return $response->withStatus(404)->withJsonError('api.institutions.404.institutionNotFound');
         }
 
@@ -214,7 +214,7 @@ class PKPInstitutionHandler extends APIHandler
      */
     public function delete(SlimHttpRequest $slimRequest, APIResponse $response, array $args): APIResponse
     {
-        if (!Repo::institution()->existsInContext((int) $args['institutionId'], $this->getRequest()->getContext()->getId())) {
+        if (!Repo::institution()->exists((int) $args['institutionId'], $this->getRequest()->getContext()->getId())) {
             return $response->withStatus(404)->withJsonError('api.institutions.404.institutionNotFound');
         }
 

--- a/classes/announcement/DAO.php
+++ b/classes/announcement/DAO.php
@@ -14,6 +14,7 @@
 namespace PKP\announcement;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 
@@ -50,11 +51,24 @@ class DAO extends EntityDAO
     }
 
     /**
-     * @copydoc EntityDAO::get()
+     * Check if an announcement exists with this ID
+     */
+    public function exists(int $id): bool
+    {
+        return DB::table($this->table)
+            ->where($this->primaryKeyColumn, '=', $id)
+            ->exists();
+    }
+
+    /**
+     * Get an announcement by its ID
      */
     public function get(int $id): ?Announcement
     {
-        return parent::get($id);
+        $row = DB::table($this->table)
+            ->where($this->primaryKeyColumn, $id)
+            ->first();
+        return $row ? $this->fromRow($row) : null;
     }
 
     /**

--- a/classes/announcement/DAO.php
+++ b/classes/announcement/DAO.php
@@ -51,7 +51,7 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Check if an announcement exists with this ID
+     * Check if an announcement exists
      */
     public function exists(int $id): bool
     {
@@ -61,7 +61,7 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get an announcement by its ID
+     * Get an announcement
      */
     public function get(int $id): ?Announcement
     {

--- a/classes/announcement/Repository.php
+++ b/classes/announcement/Repository.php
@@ -57,6 +57,12 @@ class Repository
         return $this->dao->get($id);
     }
 
+    /** @copydoc DAO::exists() */
+    public function exists(int $id): bool
+    {
+        return $this->dao->exists($id);
+    }
+
     /** @copydoc DAO::getCollector() */
     public function getCollector(): Collector
     {

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -68,7 +68,10 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get an author by its ID, and optionaly by its publication ID
+     * Get an author.
+     *
+     * Optionally, pass the publication ID to only get an author
+     * if it exists and is assigned to that publication.
      */
     public function get(int $id, int $publicationId = null): ?Author
     {
@@ -86,7 +89,10 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Check if an author exists with this ID, and optional publication ID
+     * Check if an author exists.
+     *
+     * Optionally, pass the publication ID to check if the author
+     * exists and is assigned to that publication.
      */
     public function exists(int $id, int $publicationId = null): bool
     {

--- a/classes/author/Repository.php
+++ b/classes/author/Repository.php
@@ -57,9 +57,15 @@ class Repository
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?Author
+    public function get(int $id, int $publicationId = null): ?Author
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $publicationId);
+    }
+
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $publicationId = null): bool
+    {
+        return $this->dao->exists($id, $publicationId);
     }
 
     /** @copydoc DAO::getCollector() */

--- a/classes/category/DAO.php
+++ b/classes/category/DAO.php
@@ -17,9 +17,12 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\traits\HasParent;
 
 class DAO extends EntityDAO
 {
+    use HasParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = \PKP\services\PKPSchemaService::SCHEMA_CATEGORY;
 
@@ -42,19 +45,19 @@ class DAO extends EntityDAO
     ];
 
     /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'context_id';
+    }
+
+    /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): Category
     {
         return app(Category::class);
-    }
-
-    /**
-     * @copydoc EntityDAO::get()
-     */
-    public function get(int $id): ?Category
-    {
-        return parent::get($id);
     }
 
     /**

--- a/classes/category/DAO.php
+++ b/classes/category/DAO.php
@@ -17,11 +17,11 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 
 class DAO extends EntityDAO
 {
-    use HasParent;
+    use EntityWithParent;
 
     /** @copydoc EntityDAO::$schema */
     public $schema = \PKP\services\PKPSchemaService::SCHEMA_CATEGORY;
@@ -45,7 +45,7 @@ class DAO extends EntityDAO
     ];
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/category/Repository.php
+++ b/classes/category/Repository.php
@@ -51,9 +51,15 @@ class Repository
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?Category
+    public function get(int $id, int $contextId = null): ?Category
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $contextId);
+    }
+
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $contextId = null): bool
+    {
+        return $this->dao->exists($id, $contextId);
     }
 
     /** @copydoc DAO::getCollector() */

--- a/classes/core/EntityDAO.php
+++ b/classes/core/EntityDAO.php
@@ -74,27 +74,6 @@ abstract class EntityDAO
     }
 
     /**
-     * Check if an object exists with this id
-     */
-    public function exists(int $id): bool
-    {
-        return DB::table($this->table)
-            ->where($this->primaryKeyColumn, '=', $id)
-            ->exists();
-    }
-
-    /**
-     * Get an object by its ID
-     */
-    public function get(int $id): ?DataObject
-    {
-        $row = DB::table($this->table)
-            ->where($this->primaryKeyColumn, $id)
-            ->first();
-        return $row ? $this->fromRow($row) : null;
-    }
-
-    /**
      * Convert a row from the database query into a DataObject
      */
     public function fromRow(object $row): DataObject

--- a/classes/core/traits/EntityWithParent.php
+++ b/classes/core/traits/EntityWithParent.php
@@ -1,16 +1,16 @@
 <?php
 
 /**
- * @file classes/core/traits/HasParent.php
+ * @file classes/core/traits/EntityWithParent.php
  *
  * Copyright (c) 2022 Simon Fraser University
  * Copyright (c) 2022 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
- * @class HasParent
+ * @class EntityWithParent
  * @ingroup core_traits
  *
- * @brief HasParent trait.
+ * @brief A trait for DAO classes that can be used with entities that have a parent entity. For example, a Submission always has a parent Context.
  *
  */
 
@@ -20,7 +20,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use PKP\core\DataObject;
 
-trait HasParent
+trait EntityWithParent
 {
     /**
      * Get the parent object ID column name
@@ -28,7 +28,15 @@ trait HasParent
     abstract public function getParentColumn(): string;
 
     /**
-     * Check if an object exists with this ID, and optional parent ID
+     * @copydoc EntityDAO::fromRow()
+     */
+    abstract public function fromRow(object $row): DataObject;
+
+    /**
+     * Check if an object exists.
+     *
+     * Optionally, pass the ID of a parent entity to check if the object
+     * exists and is assigned to that parent.
      */
     public function exists(int $id, int $parentId = null): bool
     {
@@ -39,7 +47,10 @@ trait HasParent
     }
 
     /**
-     * Get an object by its ID, and optionaly by its parent ID
+     * Get an object.
+     *
+     * Optionally, pass the ID of a parent entity to only get an object
+     * if it exists and is assigned to that parent.
      */
     public function get(int $id, int $parentId = null): ?DataObject
     {

--- a/classes/core/traits/HasParent.php
+++ b/classes/core/traits/HasParent.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @file classes/core/traits/HasParent.php
+ *
+ * Copyright (c) 2022 Simon Fraser University
+ * Copyright (c) 2022 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class HasParent
+ * @ingroup core_traits
+ *
+ * @brief HasParent trait.
+ *
+ */
+
+namespace PKP\core\traits;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use PKP\core\DataObject;
+
+trait HasParent
+{
+    /**
+     * Get the parent object ID column name
+     */
+    abstract public function getParentColumn(): string;
+
+    /**
+     * Check if an object exists with this ID, and optional parent ID
+     */
+    public function exists(int $id, int $parentId = null): bool
+    {
+        return DB::table($this->table)
+            ->where($this->primaryKeyColumn, '=', $id)
+            ->when($parentId !== null, fn (Builder $query, int $parentId) => $query->where($this->getParentColumn(), $parentId))
+            ->exists();
+    }
+
+    /**
+     * Get an object by its ID, and optionaly by its parent ID
+     */
+    public function get(int $id, int $parentId = null): ?DataObject
+    {
+        $row = DB::table($this->table)
+            ->where($this->primaryKeyColumn, $id)
+            ->when($parentId !== null, fn (Builder $query, int $parentId) => $query->where($this->getParentColumn(), $parentId))
+            ->first();
+        return $row ? $this->fromRow($row) : null;
+    }
+}

--- a/classes/decision/DAO.php
+++ b/classes/decision/DAO.php
@@ -19,9 +19,12 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\traits\HasParent;
 
 class DAO extends EntityDAO
 {
+    use HasParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = \PKP\services\PKPSchemaService::SCHEMA_DECISION;
 
@@ -47,19 +50,19 @@ class DAO extends EntityDAO
     ];
 
     /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'submission_id';
+    }
+
+    /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): Decision
     {
         return App::make(Decision::class);
-    }
-
-    /**
-     * @copydoc EntityDAO::get()
-     */
-    public function get(int $id): ?Decision
-    {
-        return parent::get($id);
     }
 
     /**

--- a/classes/decision/DAO.php
+++ b/classes/decision/DAO.php
@@ -19,11 +19,11 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 
 class DAO extends EntityDAO
 {
-    use HasParent;
+    use EntityWithParent;
 
     /** @copydoc EntityDAO::$schema */
     public $schema = \PKP\services\PKPSchemaService::SCHEMA_DECISION;
@@ -50,7 +50,7 @@ class DAO extends EntityDAO
     ];
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/decision/Repository.php
+++ b/classes/decision/Repository.php
@@ -70,9 +70,15 @@ abstract class Repository
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?Decision
+    public function get(int $id, int $submissionId = null): ?Decision
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $submissionId);
+    }
+
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $submissionId = null): bool
+    {
+        return $this->dao->exists($id, $submissionId);
     }
 
     /** @copydoc DAO::getCollector() */

--- a/classes/doi/DAO.php
+++ b/classes/doi/DAO.php
@@ -23,12 +23,12 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\context\Context;
 use PKP\core\EntityDAO;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 use PKP\services\PKPSchemaService;
 
 abstract class DAO extends EntityDAO
 {
-    use HasParent;
+    use EntityWithParent;
 
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_DOI;
@@ -51,7 +51,7 @@ abstract class DAO extends EntityDAO
     ];
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/doi/DAO.php
+++ b/classes/doi/DAO.php
@@ -22,10 +22,14 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\context\Context;
+use PKP\core\EntityDAO;
+use PKP\core\traits\HasParent;
 use PKP\services\PKPSchemaService;
 
-abstract class DAO extends \PKP\core\EntityDAO
+abstract class DAO extends EntityDAO
 {
+    use HasParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_DOI;
 
@@ -47,20 +51,19 @@ abstract class DAO extends \PKP\core\EntityDAO
     ];
 
     /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'context_id';
+    }
+
+    /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): Doi
     {
         return App::make(Doi::class);
-    }
-
-    /**
-     * @copydoc EntityDAO::get()
-     */
-    public function get(int $id): ?Doi
-    {
-        $doi = parent::get($id);
-        return $doi;
     }
 
     /**

--- a/classes/doi/Repository.php
+++ b/classes/doi/Repository.php
@@ -71,10 +71,16 @@ abstract class Repository
         return $doi;
     }
 
-    /** @copydoc::get() */
-    public function get(int $id): ?Doi
+    /** @copydoc DAO::get() */
+    public function get(int $id, int $contextId = null): ?Doi
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $contextId);
+    }
+
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $contextId = null): bool
+    {
+        return $this->dao->exists($id, $contextId);
     }
 
     /** @copydoc DAO::getCollector */

--- a/classes/emailTemplate/DAO.php
+++ b/classes/emailTemplate/DAO.php
@@ -53,6 +53,14 @@ class DAO extends EntityDAO
     ];
 
     /**
+     * Get the parent object ID column name
+     */
+    public function getParentColumn(): string
+    {
+        return 'context_id';
+    }
+
+    /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): EmailTemplate
@@ -109,26 +117,6 @@ class DAO extends EntityDAO
 
         // Remove template from mailable_templates table
         DB::table('mailable_templates')->where('email_id', $emailTemplate->getId())->delete();
-    }
-
-    /**
-     * @copydoc EntityDAO::get()
-     *
-     * @throws Exception
-     */
-    public function get(int $id): ?EmailTemplate
-    {
-        throw new Exception(__METHOD__ . ' is not supported. Email templates should be referenced by key instead of id.');
-    }
-
-    /**
-     * Do not use this method.
-     *
-     * @throws Exception
-     */
-    public function getIds()
-    {
-        throw new Exception(__METHOD__ . ' is not supported. Email templates should be referenced by key instead of id.');
     }
 
     /**

--- a/classes/emailTemplate/Repository.php
+++ b/classes/emailTemplate/Repository.php
@@ -47,7 +47,7 @@ class Repository
         return $object;
     }
 
-    /** @copydoc DAO::get() */
+    /** @copydoc DAO::getByKey() */
     public function getByKey(int $contextId, string $key): ?EmailTemplate
     {
         return $this->dao->getByKey($contextId, $key);

--- a/classes/galley/DAO.php
+++ b/classes/galley/DAO.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\traits\HasParent;
 use PKP\db\DAOResultFactory;
 use PKP\identity\Identity;
 use PKP\services\PKPSchemaService;
@@ -28,6 +29,8 @@ use PKP\submission\RepresentationDAOInterface;
 
 class DAO extends EntityDAO implements RepresentationDAOInterface
 {
+    use HasParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_GALLEY;
 
@@ -54,14 +57,17 @@ class DAO extends EntityDAO implements RepresentationDAOInterface
         'doiId' => 'doi_id',
     ];
 
+    /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'publication_id';
+    }
+
     public function newDataObject(): Galley
     {
         return app(Galley::class);
-    }
-
-    public function get(int $id): ?Galley
-    {
-        return parent::get($id);
     }
 
     public function getByUrlPath(string $urlPath, Publication $publication): ?Galley

--- a/classes/galley/DAO.php
+++ b/classes/galley/DAO.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 use PKP\db\DAOResultFactory;
 use PKP\identity\Identity;
 use PKP\services\PKPSchemaService;
@@ -29,7 +29,7 @@ use PKP\submission\RepresentationDAOInterface;
 
 class DAO extends EntityDAO implements RepresentationDAOInterface
 {
-    use HasParent;
+    use EntityWithParent;
 
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_GALLEY;
@@ -58,7 +58,7 @@ class DAO extends EntityDAO implements RepresentationDAOInterface
     ];
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/galley/Repository.php
+++ b/classes/galley/Repository.php
@@ -52,9 +52,15 @@ class Repository
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?Galley
+    public function get(int $id, int $publicationId = null): ?Galley
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $publicationId);
+    }
+
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $publicationId = null): bool
+    {
+        return $this->dao->exists($id, $publicationId);
     }
 
     /**

--- a/classes/institution/DAO.php
+++ b/classes/institution/DAO.php
@@ -23,12 +23,12 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 use PKP\core\SoftDeleteTrait;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 use PKP\services\PKPSchemaService;
 
 class DAO extends EntityDAO
 {
-    use HasParent;
+    use EntityWithParent;
     use SoftDeleteTrait;
 
     /** @copydoc EntityDAO::$schema */
@@ -52,7 +52,7 @@ class DAO extends EntityDAO
     ];
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/institution/DAO.php
+++ b/classes/institution/DAO.php
@@ -23,10 +23,12 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 use PKP\core\SoftDeleteTrait;
+use PKP\core\traits\HasParent;
 use PKP\services\PKPSchemaService;
 
 class DAO extends EntityDAO
 {
+    use HasParent;
     use SoftDeleteTrait;
 
     /** @copydoc EntityDAO::$schema */
@@ -50,22 +52,19 @@ class DAO extends EntityDAO
     ];
 
     /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'context_id';
+    }
+
+    /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): Institution
     {
         return App::make(Institution::class);
-    }
-
-    /**
-     * Check if an institution exists with this ID and context ID
-     */
-    public function existsInContext(int $institutionId, int $contextId): bool
-    {
-        return DB::table($this->table)
-            ->where($this->primaryKeyColumn, '=', $institutionId)
-            ->where('context_id', '=', $contextId)
-            ->exists();
     }
 
     /**
@@ -77,14 +76,6 @@ class DAO extends EntityDAO
             ->getQueryBuilder()
             ->select('i.' . $this->primaryKeyColumn)
             ->count();
-    }
-
-    /**
-     * @copydoc EntityDAO::get()
-     */
-    public function get(int $institutionId): ?Institution
-    {
-        return parent::get($institutionId);
     }
 
     /**

--- a/classes/institution/Repository.php
+++ b/classes/institution/Repository.php
@@ -47,23 +47,15 @@ class Repository
     }
 
     /** @copydoc DAO::exists() */
-    public function exists(int $id): bool
+    public function exists(int $id, int $contextId = null): bool
     {
-        return $this->dao->exists($id);
-    }
-
-    /**
-     * Checks if an institution with the given ID and context ID exists.
-     */
-    public function existsInContext(int $id, int $contextId): bool
-    {
-        return $this->dao->existsInContext($id, $contextId);
+        return $this->dao->exists($id, $contextId);
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?Institution
+    public function get(int $id, int $contextId = null): ?Institution
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $contextId);
     }
 
     /** @copydoc DAO::getSoftDeleted() */

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\citation\CitationDAO;
 use PKP\core\EntityDAO;
+use PKP\core\traits\HasParent;
 use PKP\services\PKPSchemaService;
 use PKP\submission\SubmissionAgencyDAO;
 use PKP\submission\SubmissionDisciplineDAO;
@@ -30,6 +31,8 @@ use PKP\submission\SubmissionSubjectDAO;
 
 class DAO extends EntityDAO
 {
+    use HasParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_PUBLICATION;
 
@@ -83,19 +86,19 @@ class DAO extends EntityDAO
     }
 
     /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'submission_id';
+    }
+
+    /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): Publication
     {
         return app(Publication::class);
-    }
-
-    /**
-     * @copydoc EntityDAO::get()
-     */
-    public function get(int $id): ?Publication
-    {
-        return parent::get($id);
     }
 
     /**
@@ -269,19 +272,6 @@ class DAO extends EntityDAO
 
         return $q->select('p.publication_id')
             ->pluck('p.publication_id');
-    }
-
-    /**
-     * Check if a publication exists in a submission
-     */
-    public function existsInSubmission(int $publicationId, ?int $submissionId = null): bool
-    {
-        $q = DB::table($this->table);
-        $q->where($this->primaryKeyColumn, '=', $publicationId);
-        if ($submissionId) {
-            $q->where('submission_id', '=', $submissionId);
-        }
-        return $q->exists();
     }
 
     /**

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\citation\CitationDAO;
 use PKP\core\EntityDAO;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 use PKP\services\PKPSchemaService;
 use PKP\submission\SubmissionAgencyDAO;
 use PKP\submission\SubmissionDisciplineDAO;
@@ -31,7 +31,7 @@ use PKP\submission\SubmissionSubjectDAO;
 
 class DAO extends EntityDAO
 {
-    use HasParent;
+    use EntityWithParent;
 
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_PUBLICATION;
@@ -86,7 +86,7 @@ class DAO extends EntityDAO
     }
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/publication/Repository.php
+++ b/classes/publication/Repository.php
@@ -23,6 +23,7 @@ use APP\publication\DAO;
 use APP\publication\Publication;
 use APP\submission\Submission;
 use Illuminate\Support\Enumerable;
+use Illuminate\Support\LazyCollection;
 use PKP\core\Core;
 use PKP\db\DAORegistry;
 use PKP\file\TemporaryFileManager;
@@ -31,12 +32,11 @@ use PKP\log\SubmissionLog;
 use PKP\observers\events\PublishedEvent;
 use PKP\observers\events\UnpublishedEvent;
 use PKP\plugins\Hook;
-use PKP\userGroup\UserGroup;
 use PKP\services\PKPSchemaService;
 use PKP\submission\Genre;
 use PKP\submission\PKPSubmission;
+use PKP\userGroup\UserGroup;
 use PKP\validation\ValidatorFactory;
-use Illuminate\Support\LazyCollection;
 
 abstract class Repository
 {
@@ -69,16 +69,16 @@ abstract class Repository
         return $object;
     }
 
-    /** @copydoc DAO::existsInSubmission() */
-    public function existsInSubmission(int $id, int $submissionId): bool
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $submissionId = null): bool
     {
-        return $this->dao->existsInSubmission($id, $submissionId);
+        return $this->dao->exists($id, $submissionId);
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?Publication
+    public function get(int $id, int $submissionId = null): ?Publication
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $submissionId);
     }
 
     /** @copydoc DAO::getCollector() */

--- a/classes/submission/DAO.php
+++ b/classes/submission/DAO.php
@@ -22,11 +22,14 @@ use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\traits\HasParent;
 use PKP\db\DAORegistry;
 use PKP\services\PKPSchemaService;
 
 class DAO extends EntityDAO
 {
+    use HasParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_SUBMISSION;
 
@@ -54,29 +57,19 @@ class DAO extends EntityDAO
     ];
 
     /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'context_id';
+    }
+
+    /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): Submission
     {
         return app(Submission::class);
-    }
-
-    /**
-     * Check if a submission exists
-     */
-    public function exists(int $id): bool
-    {
-        return DB::table($this->table)
-            ->where($this->primaryKeyColumn, '=', $id)
-            ->exists();
-    }
-
-    /**
-     * @copydoc EntityDAO::get()
-     */
-    public function get(int $id): ?Submission
-    {
-        return parent::get($id);
     }
 
     /**

--- a/classes/submission/DAO.php
+++ b/classes/submission/DAO.php
@@ -22,13 +22,13 @@ use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 use PKP\db\DAORegistry;
 use PKP\services\PKPSchemaService;
 
 class DAO extends EntityDAO
 {
-    use HasParent;
+    use EntityWithParent;
 
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_SUBMISSION;
@@ -57,7 +57,7 @@ class DAO extends EntityDAO
     ];
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/submission/Repository.php
+++ b/classes/submission/Repository.php
@@ -27,9 +27,9 @@ use PKP\core\Core;
 use PKP\db\DAORegistry;
 use PKP\doi\exceptions\DoiActionException;
 use PKP\plugins\Hook;
+use PKP\security\Role;
 use PKP\services\PKPSchemaService;
 use PKP\validation\ValidatorFactory;
-use PKP\security\Role;
 
 abstract class Repository
 {
@@ -65,16 +65,17 @@ abstract class Repository
     }
 
     /** @copydoc DAO::exists() */
-    public function exists(int $id): bool
+    public function exists(int $id, int $contextId = null): bool
     {
-        return $this->dao->exists($id);
+        return $this->dao->exists($id, $contextId);
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?Submission
+    public function get(int $id, int $contextId = null): ?Submission
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $contextId);
     }
+
     /** @copydoc DAO::getCollector() */
     public function getCollector(): Collector
     {

--- a/classes/submissionFile/DAO.php
+++ b/classes/submissionFile/DAO.php
@@ -19,6 +19,7 @@ namespace PKP\submissionFile;
 
 use APP\core\Application;
 use Exception;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
@@ -59,6 +60,14 @@ class DAO extends EntityDAO implements PKPPubIdPluginDAO
     ];
 
     /**
+     * Get the parent object ID column name
+     */
+    public function getParentColumn(): string
+    {
+        return 'submission_id';
+    }
+
+    /**
      * Instantiate a new SubmissionFile
      */
     public function newDataObject(): SubmissionFile
@@ -67,17 +76,29 @@ class DAO extends EntityDAO implements PKPPubIdPluginDAO
     }
 
     /**
-     * @copydoc EntityDAO::get()
+     * Get an submission file by its ID, and optionaly by its submission ID
      */
-    public function get(int $id): ?SubmissionFile
+    public function get(int $id, int $submissionId = null): ?SubmissionFile
     {
         $query = new Collector($this);
         $row = $query
             ->getQueryBuilder()
             ->where($this->primaryKeyColumn, '=', $id)
+            ->when($submissionId !== null, fn (Builder $query, int $submissionId) => $query->where('sf.submission_id', $submissionId))
             ->first();
 
         return $row ? $this->fromRow($row) : null;
+    }
+
+    /**
+     * Check if a submission file exists with this ID, and optional submission ID
+     */
+    public function exists(int $id, int $submissionId = null): bool
+    {
+        return DB::table($this->table)
+            ->where($this->primaryKeyColumn, '=', $id)
+            ->when($submissionId !== null, fn (Builder $query, int $submissionId) => $query->where($this->getParentColumn(), $submissionId))
+            ->exists();
     }
 
     /**

--- a/classes/submissionFile/DAO.php
+++ b/classes/submissionFile/DAO.php
@@ -76,7 +76,10 @@ class DAO extends EntityDAO implements PKPPubIdPluginDAO
     }
 
     /**
-     * Get an submission file by its ID, and optionaly by its submission ID
+     * Get a submission file.
+     *
+     * Optionally, pass the submission ID to only get a submission file
+     * if it exists and is assigned to that submission.
      */
     public function get(int $id, int $submissionId = null): ?SubmissionFile
     {
@@ -91,8 +94,11 @@ class DAO extends EntityDAO implements PKPPubIdPluginDAO
     }
 
     /**
-     * Check if a submission file exists with this ID, and optional submission ID
-     */
+     * Check if a submission file exists.
+     *
+     * Optionally, pass the submission ID to check if the submisison file
+     * exists and is assigned to that submission.
+    */
     public function exists(int $id, int $submissionId = null): bool
     {
         return DB::table($this->table)

--- a/classes/submissionFile/Repository.php
+++ b/classes/submissionFile/Repository.php
@@ -70,9 +70,15 @@ abstract class Repository
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?SubmissionFile
+    public function get(int $id, int $submissionId = null): ?SubmissionFile
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $submissionId);
+    }
+
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $submissionId = null): bool
+    {
+        return $this->dao->exists($id, $submissionId);
     }
 
     /** @copydoc DAO::getCollector() */

--- a/classes/user/DAO.php
+++ b/classes/user/DAO.php
@@ -84,7 +84,7 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get an user by its ID
+     * Get a user
      *
      * @param bool $allowDisabled If true, allow fetching a disabled user.
      */
@@ -101,7 +101,7 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Check if an user exists with this ID
+     * Check if a user exists
      */
     public function exists(int $id): bool
     {

--- a/classes/userGroup/DAO.php
+++ b/classes/userGroup/DAO.php
@@ -21,10 +21,13 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\traits\HasParent;
 use PKP\services\PKPSchemaService;
 
 class DAO extends EntityDAO
 {
+    use HasParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_USER_GROUP;
 
@@ -47,6 +50,14 @@ class DAO extends EntityDAO
         'permitSelfRegistration' => 'permit_self_registration',
         'permitMetadataEdit' => 'permit_metadata_edit',
     ];
+
+    /**
+     * @copydoc HasParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'context_id';
+    }
 
     /**
      * Instantiate a new DataObject

--- a/classes/userGroup/DAO.php
+++ b/classes/userGroup/DAO.php
@@ -21,12 +21,12 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
-use PKP\core\traits\HasParent;
+use PKP\core\traits\EntityWithParent;
 use PKP\services\PKPSchemaService;
 
 class DAO extends EntityDAO
 {
-    use HasParent;
+    use EntityWithParent;
 
     /** @copydoc EntityDAO::$schema */
     public $schema = PKPSchemaService::SCHEMA_USER_GROUP;
@@ -52,7 +52,7 @@ class DAO extends EntityDAO
     ];
 
     /**
-     * @copydoc HasParent::getParentColumn()
+     * @copydoc EntityWithParent::getParentColumn()
      */
     public function getParentColumn(): string
     {

--- a/classes/userGroup/Repository.php
+++ b/classes/userGroup/Repository.php
@@ -65,9 +65,15 @@ class Repository
     }
 
     /** @copydoc DAO::get() */
-    public function get(int $id): ?UserGroup
+    public function get(int $id, int $contextId = null): ?UserGroup
     {
-        return $this->dao->get($id);
+        return $this->dao->get($id, $contextId);
+    }
+
+    /** @copydoc DAO::exists() */
+    public function exists(int $id, int $contextId = null): bool
+    {
+        return $this->dao->exists($id, $contextId);
     }
 
     /** @copydoc DAO::getCollector() */

--- a/tests/classes/core/EntityDAOTest.php
+++ b/tests/classes/core/EntityDAOTest.php
@@ -33,6 +33,7 @@ class EntityDAOTest extends PKPTestCase
         // Create the database tables
         Schema::create('test_entity', function (Blueprint $table) {
             $table->bigInteger('test_id')->autoIncrement();
+            $table->bigInteger('parent_id');
             $table->bigInteger('integer_column')->nullable(false);
             $table->bigInteger('nullable_integer_column')->nullable(true);
         });
@@ -57,6 +58,9 @@ class EntityDAOTest extends PKPTestCase
                     "id": {
                         "type": "integer",
                         "readOnly": true
+                    },
+                    "parentId": {
+                        "type": "integer"
                     },
                     "integerColumn": {
                         "type": "integer"
@@ -91,6 +95,7 @@ class EntityDAOTest extends PKPTestCase
 
         // Create a data object for storage
         $testEntity = new DataObject();
+        $testEntity->setData('parentId', 2);
         $testEntity->setData('integerColumn', 3);
         $testEntity->setData('nullableIntegerColumn', 4);
         $testEntity->setData('nonlocalizedSettingString', 'test string');
@@ -116,6 +121,7 @@ class EntityDAOTest extends PKPTestCase
         $fetchedEntity = $testEntityDao->get($insertedId);
         self::assertEquals([
             'id' => $insertedId,
+            'parentId' => 2,
             'integerColumn' => 5,
             'nonlocalizedSettingString' => 'another test string',
             'nullableIntegerColumn' => null,
@@ -133,6 +139,7 @@ class EntityDAOTest extends PKPTestCase
 
         // Create a data object for storage
         $testEntity = new DataObject();
+        $testEntity->setData('parentId', 2);
         $testEntity->setData('integerColumn', 3);
         $testEntity->setData('nullableIntegerColumn', null);
 
@@ -156,6 +163,7 @@ class EntityDAOTest extends PKPTestCase
 
         // Create a data object for storage
         $testEntity = new DataObject();
+        $testEntity->setData('parentId', 2);
         $testEntity->setData('integerColumn', null); // Invalid
 
         $this->expectException(\Exception::class);

--- a/tests/classes/core/TestEntityDAO.php
+++ b/tests/classes/core/TestEntityDAO.php
@@ -19,9 +19,12 @@ namespace PKP\tests\classes\core;
 
 use PKP\core\DataObject;
 use PKP\core\EntityDAO;
+use PKP\core\traits\EntityWithParent;
 
 class TestEntityDAO extends EntityDAO
 {
+    use EntityWithParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = 'test_schema';
 
@@ -37,9 +40,18 @@ class TestEntityDAO extends EntityDAO
     /** @copydoc EntityDAO::$primaryTableColumns */
     public $primaryTableColumns = [
         'id' => 'test_id',
+        'parentId' => 'parent_id',
         'integerColumn' => 'integer_column',
         'nullableIntegerColumn' => 'nullable_integer_column',
     ];
+
+    /**
+     * @copydoc EntityWithParent::getParentColumn()
+     */
+    public function getParentColumn(): string
+    {
+        return 'parent_id';
+    }
 
     /**
      * @copydoc EntityDAO::_insert()


### PR DESCRIPTION
…tions

s. https://github.com/pkp/pkp-lib/issues/8240

The tables/objects that do not have parent ID here are announcements and users.
The objects that do have a parent ID but need a different `get()` (than the standard one in the trait HasParent) are author, submissionFile, and user.
EmailTemplate does not need `exists()`, `get()` and `getIds()` (by ID). They are not called anywhere, thus I have removed them. OK so?