### PR TITLE
Ensures text display when loading web fonts.

### DIFF
--- a/styles/font.less
+++ b/styles/font.less
@@ -21,6 +21,7 @@
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-regular.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-regular.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-regular.svg#NotoSans') format('svg'); /* Legacy iOS */
+  font-display: swap;
 }
 
 /* noto-sans-italic - vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic */
@@ -35,6 +36,7 @@
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-italic.svg#NotoSans') format('svg'); /* Legacy iOS */
+  font-display: swap;
 }
 
 /* noto-sans-700 - vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic */
@@ -49,6 +51,7 @@
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-700.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-700.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-700.svg#NotoSans') format('svg'); /* Legacy iOS */
+  font-display: swap;
 }
 
 /* noto-sans-700italic - vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic */
@@ -63,4 +66,5 @@
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-700italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-700italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/lib/pkp/styles/fonts/noto-sans-v11-vietnamese_latin-ext_latin_greek-ext_greek_devanagari_cyrillic-ext_cyrillic-700italic.svg#NotoSans') format('svg'); /* Legacy iOS */
+  font-display: swap;
 }


### PR DESCRIPTION
OJS 3.3 currently has an implementation problem, being the font files not displaying texts while they are not loaded.

One way to fix it, make sure a system default font displayed as the application's original is being loaded.

For that, it is necessary to add the resource `font-display: swap`, responsible for placing this provisional font until the original font files are loaded.