### PR TITLE
fix: PKPReviewerReviewStep3Form::initData() now calls parent::

### DIFF
--- a/classes/submission/reviewer/form/PKPReviewerReviewStep3Form.inc.php
+++ b/classes/submission/reviewer/form/PKPReviewerReviewStep3Form.inc.php
@@ -55,6 +55,8 @@ class PKPReviewerReviewStep3Form extends ReviewerReviewForm {
 		$submissionCommentsPrivate = $submissionCommentDao->getReviewerCommentsByReviewerId($reviewAssignment->getSubmissionId(), $reviewAssignment->getReviewerId(), $reviewAssignment->getId(), false);
 		$submissionCommentPrivate = $submissionCommentsPrivate->next();
 		$this->setData('commentsPrivate', $submissionCommentPrivate?$submissionCommentPrivate->getComments():'');
+
+		parent::initData();
 	}
 
 	//


### PR DESCRIPTION
My plugin development (based on OJS 3.3) came to a halt when I needed a callback at `reviewerreviewstep3form::initData`.  
The callback never got called, because `ReviewerReviewStep3Form::initData()` does not call `parent::initData();`  
This patch adds this call (and nothing else).

I have checked the other methods that override something from `Form`.
Their required `parent::` calls _are_ present.

I have also provided the equivalent patch in a version 3.4 form in [#8264](https://github.com/pkp/pkp-lib/pull/8264).
