### PR TITLE
fix ReviewFormResponseDAO::insertObject using a nonvar &type

### DIFF
--- a/classes/reviewForm/ReviewFormResponseDAO.inc.php
+++ b/classes/reviewForm/ReviewFormResponseDAO.inc.php
@@ -66,6 +66,7 @@ class ReviewFormResponseDAO extends DAO {
 	 * @param $reviewFormResponse ReviewFormResponse
 	 */
 	function insertObject($reviewFormResponse) {
+		$type = $reviewFormResponse->getResponseType();
 		$this->update(
 			'INSERT INTO review_form_responses
 				(review_form_element_id, review_id, response_type, response_value)
@@ -74,8 +75,8 @@ class ReviewFormResponseDAO extends DAO {
 			[
 				$reviewFormResponse->getReviewFormElementId(),
 				$reviewFormResponse->getReviewId(),
-				$reviewFormResponse->getResponseType(),
-				$this->convertToDB($reviewFormResponse->getValue(), $reviewFormResponse->getResponseType())
+				$type,
+				$this->convertToDB($reviewFormResponse->getValue(), $type)
 			]
 		);
 	}


### PR DESCRIPTION
This patch makes `insertObject()` work like `updateObject()` already does.
(There are sister PRs for stable-3_3_0 and main.)