### PR TITLE
Add definition to avoid undefined variable warning

### DIFF
--- a/controllers/grid/settings/user/UserGridHandler.php
+++ b/controllers/grid/settings/user/UserGridHandler.php
@@ -351,6 +351,7 @@ class UserGridHandler extends GridHandler
 
         // Identify the user Id.
         $userId = $request->getUserVar('userId');
+        $administrationLevel = null;
 
         if ($userId !== null && ($administrationLevel = Validation::getAdministrationLevel($userId, $user->getId(), $request->getContext()->getId())) === Validation::ADMINISTRATION_PROHIBITED) {
             // We don't have administrative rights over this user.


### PR DESCRIPTION
Hey @asmecher, could you have a quick look at this? I came across it when hunting down why my tests were failing in OMP. It was only generating an "undefined variable" warning for `$administrationLevel`, but it was popping up a lot. Thanks!