### PR TITLE
pkp/pkp-lib#8306 Patch for zero-length delimited identifier issue

### DIFF
--- a/classes/job/repositories/FailedJob.php
+++ b/classes/job/repositories/FailedJob.php
@@ -64,7 +64,7 @@ class FailedJob extends BaseRepository
 
         return $failedJobs->where(fn($query) => $query
             ->whereNotNull('payload')
-            ->whereRaw('payload <> ""')
+            ->whereRaw("payload <> ''")
         )->get();
     }
 


### PR DESCRIPTION
This PR aims to provide a patch for `zero-length delimited identifier` for pkp/pkp-lib#8306