### PR TITLE
Update JQuery UI library version

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -823,7 +823,7 @@ class PKPTemplateManager extends Smarty {
 		);
 		$this->addJavaScript(
 			'jqueryUI',
-			$request->getBaseUrl() . '/lib/pkp/lib/vendor/components/jqueryui/jquery-ui' . $min . '.js',
+			$request->getBaseUrl() . '/lib/pkp/lib/vendor/components/jqueryui/dist/jquery-ui' . $min . '.js',
 			[
 				'priority' => STYLE_SEQUENCE_CORE,
 				'contexts' => 'backend',

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
 	"require": {
 		"ralouphie/getallheaders": "*",
-		"components/jqueryui": "1.*",
-		"components/jquery": "^3.5",
+		"components/jqueryui": "^1.13.2",
+		"components/jquery": "^3.6",
 		"wikimedia/less.php": "3.*",
 		"phpmailer/phpmailer": "6.*",
 		"smarty/smarty": "4.*",
@@ -21,7 +21,7 @@
 		"doctrine/dbal": "^2.10",
 		"guzzlehttp/guzzle": "^6.5",
 		"league/flysystem": "^1.0",
-	        "league/flysystem-sftp": "^1.0",
+		"league/flysystem-sftp": "^1.0",
 		"staudenmeir/laravel-upsert": "^1.3",
 		"cweagans/composer-patches": "^1.7",
 		"composer/semver": "*",
@@ -45,7 +45,19 @@
 		{
 			"type": "vcs",
 			"url": "https://github.com/asmecher/ADOdb"
-		}
+		},
+		{
+      "type": "package",
+      "url": "https://github.com/jquery/jquery-ui",
+      "package": {
+        "name": "components/jqueryui",
+        "version": "1.13.2",
+        "dist": {
+          "url": "https://github.com/jquery/jquery-ui/archive/refs/tags/1.13.2.zip",
+          "type": "zip"
+        }
+      }
+    }
 	],
 	"extra": {
 		"patches": {

--- a/composer.lock
+++ b/composer.lock
@@ -117,7 +117,7 @@
         },
         {
             "name": "components/jquery",
-            "version": "3.5.1",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/components/jquery.git",
@@ -156,91 +156,6 @@
             "description": "jQuery JavaScript Library",
             "homepage": "http://jquery.com",
             "time": "2020-05-05T13:21:02+00:00"
-        },
-        {
-            "name": "components/jqueryui",
-            "version": "1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/components/jqueryui.git",
-                "reference": "44ecf3794cc56b65954cc19737234a3119d036cc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/components/jqueryui/zipball/44ecf3794cc56b65954cc19737234a3119d036cc",
-                "reference": "44ecf3794cc56b65954cc19737234a3119d036cc",
-                "shasum": ""
-            },
-            "require": {
-                "components/jquery": ">=1.6"
-            },
-            "type": "component",
-            "extra": {
-                "component": {
-                    "name": "jquery-ui",
-                    "scripts": [
-                        "jquery-ui.js"
-                    ],
-                    "files": [
-                        "ui/**",
-                        "themes/**",
-                        "jquery-ui.min.js"
-                    ],
-                    "shim": {
-                        "deps": [
-                            "jquery"
-                        ],
-                        "exports": "jQuery"
-                    }
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "jQuery UI Team",
-                    "homepage": "http://jqueryui.com/about"
-                },
-                {
-                    "name": "Joern Zaefferer",
-                    "email": "joern.zaefferer@gmail.com",
-                    "homepage": "http://bassistance.de"
-                },
-                {
-                    "name": "Scott Gonzalez",
-                    "email": "scott.gonzalez@gmail.com",
-                    "homepage": "http://scottgonzalez.com"
-                },
-                {
-                    "name": "Kris Borchers",
-                    "email": "kris.borchers@gmail.com",
-                    "homepage": "http://krisborchers.com"
-                },
-                {
-                    "name": "Mike Sherov",
-                    "email": "mike.sherov@gmail.com",
-                    "homepage": "http://mike.sherov.com"
-                },
-                {
-                    "name": "TJ VanToll",
-                    "email": "tj.vantoll@gmail.com",
-                    "homepage": "http://tjvantoll.com"
-                },
-                {
-                    "name": "Corey Frang",
-                    "email": "gnarf37@gmail.com",
-                    "homepage": "http://gnarf.net"
-                },
-                {
-                    "name": "Felix Nagel",
-                    "email": "info@felixnagel.com",
-                    "homepage": "http://www.felixnagel.com"
-                }
-            ],
-            "description": "jQuery UI is a curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library. Whether you're building highly interactive web applications or you just need to add a date picker to a form control, jQuery UI is the perfect choice.",
-            "time": "2016-09-16T05:47:55+00:00"
         },
         {
             "name": "composer/semver",
@@ -1422,6 +1337,15 @@
                 "url"
             ],
             "time": "2020-09-30T07:37:11+00:00"
+        },
+        {
+            "name": "components/jqueryui",
+            "version": "1.13.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/jquery/jquery-ui/archive/refs/tags/1.13.2.zip"
+            },
+            "type": "library"
         },
         {
             "name": "laravel/framework",
@@ -7713,4 +7637,5 @@
         "php": "7.3.0"
     },
     "plugin-api-version": "2.3.0"
-}
+  }
+  


### PR DESCRIPTION
This pull request updating the _JQuery UI_ Library version. 

## Implementation summary

For the update _JQuery-UI_ library, it was necessary:

- Update _JQuery_ to version 3.6, since the one [dependence that the new version of the UI only runs with this version minimum](https://jqueryui.com/)

- Remove the import and dependency on the old version of the library, and import the new version of the library and create the dependency of code to use the new version of the UI library.

- For this process, it was necessary: 
	- Change two files related to _composer_ ([_composer.json_](https://github.com/pkp/pkp-lib/blob/stable-3_3_0/composer.json) e [_composer.lock_](https://github.com/pkp/pkp-lib/blob/stable-3_3_0/composer.lock))

	- Change [file  `PKPTemplateManager.inc.php`](https://github.com/pkp/pkp-lib/blob/stable-3_3_0/classes/template/PKPTemplateManager.inc.php) — responsible for [importing functions from _JQuery-UI_](https://github.com/pkp/pkp-lib/blob/stable-3_3_0/classes/template/PKPTemplateManager.inc.php#L826).

- This change was made before the [installation of _OJS_ libraries of composer](https://github.com/pkp/ojs#documentation) process.

## [What change between library versions](https://blog.jqueryui.com/2022/07/jquery-ui-1-13-2-released/)

- Compatibility with version 3.6 of the _JQuery_ library
- Remove [deprecated use of _JQuery_ API's](https://jqueryui.com/)
- Added a security fix for the _Checkboxradio_ widget.
- Localization updates for _Datepicker_.
- Fixes for issues submitted by the community.
- Built jQuery _UI_ files are now included in the _npm_ package.