### PR TITLE
pkp/lib-pkp#7495 show list of submissions as a table

### DIFF
--- a/api/v1/contexts/PKPContextHandler.php
+++ b/api/v1/contexts/PKPContextHandler.php
@@ -64,6 +64,11 @@ class PKPContextHandler extends APIHandler
                     'handler' => [$this, 'getTheme'],
                     'roles' => $roles,
                 ],
+//                [
+//                    'pattern' => $this->getEndpointPattern() . '/{contextId:\d+}/submissionsList',
+//                    'handler' => [$this, 'getSubmissionsList'],
+//                    'roles' => $roles,
+//                ],
             ],
             'POST' => [
                 [
@@ -84,6 +89,11 @@ class PKPContextHandler extends APIHandler
                     'roles' => $roles,
                 ],
                 [
+                    'pattern' => $this->getEndpointPattern() . '/{contextId:\d+}/submissionsList',
+                    'handler' => [$this, 'editSubmissionsList'],
+                    'roles' => $roles,
+                ],
+		[
                     'pattern' => $this->getEndpointPattern() . '/{contextId:\d+}/registrationAgency',
                     'handler' => [$this, 'editDoiRegistrationAgencyPlugin'],
                     'roles' => $roles,
@@ -296,6 +306,143 @@ class PKPContextHandler extends APIHandler
 
         return $response->withJson($data, 200);
     }
+
+//    /**
+//     * Get the submission list settings for a context
+//     *
+//     * @param Request $slimRequest Slim request object
+//     * @param Response $response object
+//     * @param array $args arguments
+//     *
+//     * @return Response
+//     */
+//    public function getSubmissionsList($slimRequest, $response, $args)
+//    {
+//        $request = $this->getRequest();
+//        $user = $request->getUser();
+//
+//        $contextService = Services::get('context');
+//        $context = $contextService->get((int) $args['contextId']);
+//
+//        if (!$context) {
+//            return $response->withStatus(404)->withJsonError('api.contexts.404.contextNotFound');
+//        }
+//
+//        // Don't allow to get one context from a different context's endpoint
+//        if ($request->getContext() && $request->getContext()->getId() !== $context->getId()) {
+//            return $response->withStatus(403)->withJsonError('api.contexts.403.contextsDidNotMatch');
+//        }
+//
+//        // A disabled journal can only be access by site admins and users with a
+//        // manager role in that journal
+//        if (!$context->getEnabled()) {
+//            $userRoles = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_USER_ROLES);
+//            if (!in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles)) {
+//                $roleDao = DAORegistry::getDao('RoleDAO'); /** @var RoleDAO $roleDao */
+//                if (!$roleDao->userHasRole($context->getId(), $user->getId(), Role::ROLE_ID_MANAGER)) {
+//                    return $response->withStatus(403)->withJsonError('api.contexts.403.notAllowed');
+//                }
+//            }
+//        }
+//
+//        $data = [];
+//        $data['columnsEnable'] = [
+//            [
+//                        'name' => 'id',
+//                        'label' => __('submissionId'),
+//                        'value' => 'id',             
+//                            ],
+//            [
+//                        'name' => 'title',
+//                        'label' => __('common.title'),
+//                        'value' => 'title',             
+//                    ],
+//            [
+//                        'name' => 'status',
+//                        'label' => __('common.status'),
+//                        'value' => 'status',             
+//                    ],
+//            [
+//                        'name' => 'openDiscussion',
+//                        'label' => __('common.openDiscussion'),
+//                        'value' => 'openDiscussion',             
+//                    ],
+//            [
+//                        'name' => 'files',
+//                        'label' => __('common.files'),
+//                        'value' => 'files',             
+//                    ],
+//            [
+//                        'name' => 'stage',
+//                        'label' => __('common.stage'),
+//                        'value' => 'stage',             
+//                    ],
+//            [
+//                        'name' => 'lastActivity',
+//                        'label' => __('common.lastActivity'),
+//                        'value' => 'dateLastActivity',
+//             ],
+//            
+//                    
+//            ];
+//        $data['columnsDisable'] = [
+//            [
+//                        'name' => 'dateSubmitted',
+//                        'label' => __('common.dateSubmitted'),
+//                        'value' => 'dateSubmitted',
+//                    ],
+//            ];
+//
+//        return $response->withJson($data, 200);
+//    }
+//    
+    
+     /**
+     * Save submissions list settings
+     *
+     * @param Request $slimRequest Slim request object
+     * @param Response $response object
+     * @param array $args arguments
+     *
+     * @return Response
+     */
+    public function editSubmissionsList($slimRequest, $response, $args)
+    {
+        $request = $this->getRequest();
+        $requestContext = $request->getContext();
+
+        $contextId = (int) $args['contextId'];
+
+        // Don't allow to get one context from a different context's endpoint
+        if ($request->getContext() && $request->getContext()->getId() !== $contextId) {
+            return $response->withStatus(403)->withJsonError('api.contexts.403.contextsDidNotMatch');
+        }
+
+        // Don't allow to edit the context from the site-wide API, because the
+        // context's plugins will not be enabled
+        if (!$request->getContext()) {
+            return $response->withStatus(403)->withJsonError('api.contexts.403.requiresContext');
+        }
+
+        $contextService = Services::get('context');
+        $context = $contextService->get($contextId);
+
+        if (!$context) {
+            return $response->withStatus(404)->withJsonError('api.contexts.404.contextNotFound');
+        }
+
+        $userRoles = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_USER_ROLES);
+        if (!$requestContext && !in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles)) {
+            return $response->withStatus(403)->withJsonError('api.contexts.403.notAllowedEdit');
+        }
+
+        $params = $slimRequest->getParsedBody();
+
+        $data = ['ok'];
+
+        return $response->withJson($data, 200);
+    }
+
 
     /**
      * Add a context

--- a/api/v1/submissions/PKPSubmissionHandler.php
+++ b/api/v1/submissions/PKPSubmissionHandler.php
@@ -821,7 +821,28 @@ class PKPSubmissionHandler extends APIHandler
 
         $map = Repo::user()->getSchemaMap();
         foreach ($usersIterator as $user) {
-            $data[] = $map->summarizeReviewer($user);
+            $mappedUser = $map->summarizeReviewer($user);
+            
+            // update mappedUser with the list of userGroups corresponding to stageAssignments
+            if ($stageId !== null ) {
+                $stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO'); /** @var StageAssignmentDAO $stageAssignmentDao */
+                $stageAssignments = $stageAssignmentDao->getBySubmissionAndUserIdAndStageId(
+                        $submission->getId(),
+                        $user->getId(),
+                        $stageId
+                        );
+                $mapUG = Repo::userGroup()->getSchemaMap();
+                // Make a list of the active user groups.
+                $userGroups = [];
+                while ($stageAssignment = $stageAssignments->next()) {
+                    $userGroupId = $stageAssignment->getUserGroupId();
+                    $userGroup = Repo::userGroup()->get($userGroupId);
+                    $userGroups[] = $mapUG->map($userGroup);
+                }
+                $mappedUser['assignedAs'] = $userGroups;
+            }
+
+            $data[] = $mappedUser;
         }
 
         return $response->withJson($data, 200);

--- a/classes/components/forms/context/PKPSubmissionsListSettingsForm.php
+++ b/classes/components/forms/context/PKPSubmissionsListSettingsForm.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @file classes/components/form/context/PKPSubmissionsListSettingsForm.php
+ *
+ * Copyright (c) 2014-2023 Simon Fraser University
+ * Copyright (c) 2000-2023 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class PKPSubmissionsListSettingsForm
+ * @ingroup classes_controllers_form
+ *
+ * @brief A preset form for presenting submission as a table on the backend
+ */
+
+namespace PKP\components\forms\context;
+
+use PKP\submission\maps\Schema;
+use PKP\components\forms\FormComponent;
+use PKP\components\forms\FieldOptions;
+
+define('FORM_SUBMISSIONS_LIST_SETTINGS', 'submissionsListSettings');
+
+class PKPSubmissionsListSettingsForm extends FormComponent
+{
+    /** @copydoc FormComponent::$id */
+    public $id = FORM_SUBMISSIONS_LIST_SETTINGS;
+
+    /** @copydoc FormComponent::$method */
+    public $method = 'PUT';
+
+    /**
+     * Constructor
+     *
+     * @param string $action URL to submit the form to
+     * @param array $locales Supported locales
+     * @param \Context $context Journal or Press to change settings for
+     */
+    public function __construct($action, $locales, $context)
+    {
+        $this->action = $action;
+        $this->locales = $locales;
+
+        $localizedOptions = []; // template for localized options to be used for date and time format
+        foreach ($this->locales as $key => $localeValue) {
+            $localizedOptions[$localeValue['key']] = $key;
+        }
+        
+        $availableColumns = Schema::getPropertyColumnsName();
+        
+        $enableColumns = [];
+        $disableColumns = [];
+        $currentColumns = (array) $context->getData('submissionsListSettings');
+        if (sizeof($currentColumns) > 0) {
+            // sort available columns by choosen order
+            foreach ($currentColumns as $value) {
+                $enableColumns[] = $availableColumns[$value];
+                unset($availableColumns[$value]);
+            }
+            $disableColumns = array_values($availableColumns);
+        }
+        else {
+            //never configured: enable all columns by default
+            $disableColumns = array_values($availableColumns);
+            $currentColumns = array_keys($availableColumns);
+        }
+        $columnsOptions = array_merge($enableColumns, $disableColumns);
+        
+        $this->addGroup([
+            'id' => 'descriptions',
+            'label' => __('manager.setup.submissionsListSettings.descriptionTitle'),
+            'description' => __('manager.setup.submissionsListSettings.description'),
+        ])->addField(new FieldOptions('openSubmissionsInANewTab', [
+            'label' => __('manager.setup.openSubmissionsInANewTab'),
+            'groupId' => 'descriptions',
+            'description' => __('manager.setup.openSubmissionsInANewTab.description'),
+            'options' => [
+                ['value' => true, 'label' => __('manager.setup.openSubmissionsInANewTab.enable')]
+            ],
+            'value' => (bool) $context->getData('openSubmissionsInANewTab'),
+        ]))->addField(new FieldOptions('enableCustomSubmissionsList', [
+            'label' => __('manager.setup.enableCustomSubmissionsList'),
+            'groupId' => 'descriptions',
+            'description' => __('manager.setup.enableCustomSubmissionsList.description'),
+            'options' => [
+                ['value' => true, 'label' => __('manager.setup.enableCustomSubmissionsList.enable')]
+            ],
+            'value' => (bool) $context->getData('enableCustomSubmissionsList'),
+        ]))->addField(
+                new FieldOptions('submissionsListSettings', 
+                        [
+                            'label' => __('manager.setup.submissionsListSetup'),
+                            'isMultilingual' => false,
+                            'groupId' => 'descriptions',
+                            'options' => $columnsOptions,
+                            'isOrderable' => true,
+                            'value' => $currentColumns,
+                       ])
+            );
+    }
+    
+    
+}

--- a/classes/components/listPanels/PKPSubmissionsListPanel.php
+++ b/classes/components/listPanels/PKPSubmissionsListPanel.php
@@ -50,6 +50,12 @@ abstract class PKPSubmissionsListPanel extends ListPanel
 
     /** @var array List of all available categories */
     public $categories = [];
+    
+    /** @var array List of all enable columns */
+    public $tableColumns = [];
+
+    /** @var bool Whether to open submissions in a new tab */
+    public $openSubmissionsInANewTab = false;
 
     /**
      * @copydoc ListPanel::getConfig()
@@ -66,6 +72,8 @@ abstract class PKPSubmissionsListPanel extends ListPanel
         $config['getParams'] = $this->getParams;
         $config['lazyLoad'] = $this->lazyLoad;
         $config['itemsMax'] = $this->itemsMax;
+        $config['tableColumns'] = $this->tableColumns;
+        $config['openSubmissionsInANewTab'] = $this->openSubmissionsInANewTab;
 
         // URL to add a new submission
         if ($context->getData('disableSubmissions')) {
@@ -99,6 +107,14 @@ abstract class PKPSubmissionsListPanel extends ListPanel
             'addParticipant',
             null,
             ['submissionId' => '__id__', 'stageId' => '__stageId__']
+        );
+
+        // URL to get participants on active stage
+        $config['getParticipantsApiUrl'] = $request->getDispatcher()->url(
+            $request,
+            Application::ROUTE_API,
+            $context->getPath(),
+            'submissions/__id__/participants/__stageId__',
         );
 
         $config['filters'] = [
@@ -226,6 +242,7 @@ abstract class PKPSubmissionsListPanel extends ListPanel
             'submission.list.reviewDue',
             'submission.list.reviewerWorkflowLink',
             'submission.list.reviewsCompleted',
+            'editor.submission.recommendation.display',
             'submission.list.revisionsSubmitted',
             'submission.list.viewSubmission',
         ]);

--- a/classes/submission/maps/Schema.php
+++ b/classes/submission/maps/Schema.php
@@ -285,18 +285,26 @@ class Schema extends \PKP\core\maps\Schema
             $request = Application::get()->getRequest();
             $currentUser = $request->getUser();
             $context = $request->getContext();
+            $ask = is_null($reviewAssignment->getDateAssigned()) ? null : date('Y-m-d', strtotime($reviewAssignment->getDateAssigned()));
+            $reminded = is_null($reviewAssignment->getDateReminded()) ? null : date('Y-m-d', strtotime($reviewAssignment->getDateReminded()));
             $due = is_null($reviewAssignment->getDateDue()) ? null : date('Y-m-d', strtotime($reviewAssignment->getDateDue()));
             $responseDue = is_null($reviewAssignment->getDateResponseDue()) ? null : date('Y-m-d', strtotime($reviewAssignment->getDateResponseDue()));
+            $reviewer = Repo::user()->get($reviewAssignment->getReviewerId());
+            $fullName = $reviewer->getFullName();
 
             $reviews[] = [
                 'id' => (int) $reviewAssignment->getId(),
+                'fullName' => $fullName,
                 'isCurrentUserAssigned' => $currentUser->getId() == (int) $reviewAssignment->getReviewerId(),
                 'statusId' => (int) $reviewAssignment->getStatus(),
                 'status' => __($reviewAssignment->getStatusKey()),
+                'ask' => $ask,
+                'reminded' => $reminded,
                 'due' => $due,
                 'responseDue' => $responseDue,
                 'round' => (int) $reviewAssignment->getRound(),
                 'roundId' => (int) $reviewAssignment->getReviewRoundId(),
+                'recommendation' => $reviewAssignment->getRecommendation() ? $reviewAssignment->getLocalizedRecommendation() : NULL, 
             ];
         }
 
@@ -465,6 +473,58 @@ class Schema extends \PKP\core\maps\Schema
         }
 
         return $stages;
+    }
+
+    /**
+     * Get list of columns for submission list as a table
+     * @return array
+     * ['columnId' array [{
+     *   'name' string
+     *   'label' string translated column name
+     *   'value' string corresponding submission value
+     *   'orderBy' string corresponding to columId if orderBy by default (optionnal)
+     *   'initialOrderDirection' bool (optionnal)
+     * }],
+     * ...
+     * ]
+     */
+    static public function getPropertyColumnsName(): array
+    {
+        $columnsProperties = [ 
+            'id' => [ 'name' => 'id',
+                'label' => __('article.submissionId'),
+                'value' => 'id',
+                ],
+            'title' => [ 'name' => 'title',
+                'label' => __('common.title'),
+                'value' => 'title',
+                ],
+            'openDiscussion' => [ 'name' => 'openDiscussion',
+                'label' => __('submission.list.discussions'),
+                'value' => 'openDiscussion',
+                ],
+            'stage' => [ 'name' => 'stage',
+                'label' => __('workflow.stage'),
+                'value' => 'stage',
+                ],
+            'dateLastActivity' => [ 'name' => 'lastActivity',
+                'label' => __('common.dateModified'),
+                'value' => 'dateLastActivity',
+                'orderBy' => 'lastActivity',
+                'initialOrderDirection' => true,
+                ],
+            'dateSubmitted' => [ 'name' => 'dateSubmitted',
+                'label' => __('common.dateSubmitted'),
+                'value' => 'dateSubmitted',
+                ],
+            'participants' => [ 'name' => 'participants',
+                'label' => __('submissionGroup.assignedSubEditors'),
+                'value' => 'participants',
+                ],
+            ];
+        
+
+        return $columnsProperties;
     }
 
     protected function getUserGroup(int $userGroupId): ?UserGroup

--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -1172,6 +1172,36 @@ msgstr "Date & Time (Short)"
 msgid "manager.setup.dateTime.custom"
 msgstr "Custom"
 
+msgid "manager.setup.submissionsListSettings"
+msgstr "Submissions List"
+
+msgid "manager.setup.submissionsListSettings.descriptionTitle"
+msgstr "Settings"
+
+msgid "manager.setup.submissionsListSettings.description"
+msgstr "Manage submissions list for roles <b>SITE_ADMIN and MANAGER only</b>"
+
+msgid "manager.setup.openSubmissionsInANewTab"
+msgstr "Open submissions in a new tab"
+
+msgid "manager.setup.openSubmissionsInANewTab.description"
+msgstr ""
+
+msgid "manager.setup.openSubmissionsInANewTab.enable"
+msgstr "When editing a submission, open it in a new tab"
+
+msgid "manager.setup.enableCustomSubmissionsList"
+msgstr "Submissions list as a table"
+
+msgid "manager.setup.enableCustomSubmissionsList.description"
+msgstr "Propose Submissions list in a table with customizable and sortable columns"
+
+msgid "manager.setup.enableCustomSubmissionsList.enable"
+msgstr "Submissions list as a table"
+
+msgid "manager.setup.submissionsListSetup"
+msgstr "Choose and order columns"
+
 msgid "manager.setup.privacyStatement.description"
 msgstr ""
 "This statement will appear during user registration, author submission, and "

--- a/pages/management/ManagementHandler.php
+++ b/pages/management/ManagementHandler.php
@@ -200,6 +200,7 @@ class ManagementHandler extends Handler
         $privacyForm = new \PKP\components\forms\context\PKPPrivacyForm($contextApiUrl, $locales, $context, $publicFileApiUrl);
         $themeForm = new \PKP\components\forms\context\PKPThemeForm($themeApiUrl, $locales, $context);
         $dateTimeForm = new \PKP\components\forms\context\PKPDateTimeForm($contextApiUrl, $locales, $context);
+        $submissionsListSettingsForm = new \PKP\components\forms\context\PKPSubmissionsListSettingsForm($contextApiUrl, $locales, $context);
 
         $templateMgr->setConstants([
             'FORM_ANNOUNCEMENT_SETTINGS' => FORM_ANNOUNCEMENT_SETTINGS,
@@ -213,6 +214,7 @@ class ManagementHandler extends Handler
             FORM_PRIVACY => $privacyForm->getConfig(),
             FORM_THEME => $themeForm->getConfig(),
             FORM_DATE_TIME => $dateTimeForm->getConfig(),
+            FORM_SUBMISSIONS_LIST_SETTINGS => $submissionsListSettingsForm->getConfig(),
         ];
 
         if ($informationForm) {

--- a/schemas/context.json
+++ b/schemas/context.json
@@ -758,6 +758,30 @@
 			],
 			"defaultLocaleKey": "default.contextSettings.checklist"
 		},
+		"submissionsListSettings": {
+			"type": "array",
+			"validation": [
+				"nullable"
+			],
+			"items": {
+				"type": "string",
+				"validation": [
+					"alpha_dash"
+				]
+			}
+		},
+		"openSubmissionsInANewTab": {
+			"type": "boolean",
+			"validation": [
+				"nullable"
+			]
+		},
+		"enableCustomSubmissionsList": {
+			"type": "boolean",
+			"validation": [
+				"nullable"
+			]
+		},
 		"submitWithCategories": {
 			"type": "boolean",
 			"default": false,

--- a/templates/dashboard/index.tpl
+++ b/templates/dashboard/index.tpl
@@ -17,22 +17,22 @@
 	<tabs :track-history="true">
 		<tab id="myQueue" label="{translate key="dashboard.myQueue"}" :badge="components.{$smarty.const.SUBMISSIONS_LIST_MY_QUEUE}.itemsMax">
 			{help file="submissions" class="pkp_help_tab"}
-			<submissions-list-panel
+			<{$submissionPanel}
 				v-bind="components.{$smarty.const.SUBMISSIONS_LIST_MY_QUEUE}"
-				@set="set"
-			/>
+					@set="set"
+				/>
 		</tab>
 		{if array_intersect(array(\PKP\security\Role::ROLE_ID_SITE_ADMIN, \PKP\security\Role::ROLE_ID_MANAGER), (array)$userRoles)}
 			<tab id="unassigned" label="{translate key="common.queue.long.submissionsUnassigned"}" :badge="components.{$smarty.const.SUBMISSIONS_LIST_UNASSIGNED}.itemsMax">
 				{help file="submissions" section="unassigned" class="pkp_help_tab"}
-				<submissions-list-panel
+				<{$submissionPanel}
 					v-bind="components.{$smarty.const.SUBMISSIONS_LIST_UNASSIGNED}"
 					@set="set"
 				/>
 			</tab>
 			<tab id="active" label="{translate key="common.queue.long.active"}" :badge="components.{$smarty.const.SUBMISSIONS_LIST_ACTIVE}.itemsMax">
 				{help file="submissions" section="active" class="pkp_help_tab"}
-				<submissions-list-panel
+				<{$submissionPanel}
 					v-bind="components.{$smarty.const.SUBMISSIONS_LIST_ACTIVE}"
 					@set="set"
 				/>
@@ -40,10 +40,10 @@
 		{/if}
 		<tab id="archive" label="{translate key="submissions.archived"}" :badge="components.{$smarty.const.SUBMISSIONS_LIST_ARCHIVE}.itemsMax">
 			{help file="submissions" section="archives" class="pkp_help_tab"}
-			<submissions-list-panel
+			<{$submissionPanel}
 				v-bind="components.{$smarty.const.SUBMISSIONS_LIST_ARCHIVE}"
 				@set="set"
 			/>
 		</tab>
-	</tabs>
+	</tabs>		
 {/block}

--- a/templates/management/website.tpl
+++ b/templates/management/website.tpl
@@ -90,6 +90,12 @@
 							@set="set"
 					/>
 				</tab>
+				<tab id="submissionsListSettings" label="{translate key="manager.setup.submissionsListSettings"}">
+					<pkp-form
+						v-bind="components.{$smarty.const.FORM_SUBMISSIONS_LIST_SETTINGS}"
+						@set="set"
+					/>
+				</tab>		
 				{call_hook name="Template::Settings::website::setup"}
 			</tabs>
 		</tab>


### PR DESCRIPTION
hello

this is a proposal for the presentation of the list of submissions as a table.

I started with a configuration per journal and this presentation is reserved for the roles SITE_ADMIN and MANAGER.

Indeed after discussion with our journals, this is the choice that was made and this to facilitate explanations to users, because having something customizable increases the difficulties of use and explanation: our users are not all familiar with OJS.


So for the configuration, we can enable by journal submissions list as a table.
(I took the opportunity to add an option that is much requested by our journals, namely the possibility to open the submissions in a new tab when clicking on them)

settings allow to order the columns and to display them or not.

a screenshot for the setting :

![image](https://user-images.githubusercontent.com/31130607/222698478-07820d4a-4a31-4402-afd0-30595cb74587.png)




Screenshot for the list of submissions: you can sort by last modification date
![image](https://user-images.githubusercontent.com/31130607/222699294-fc438b47-8639-4f9d-8ae9-c80e69137048.png)


the reviewAssignments are presented as a badge as seen in the issue : pkp/pkp-lib#4172
when you click on the badge, you can see details of the reviewAssignment

![image](https://user-images.githubusercontent.com/31130607/222699533-46e9f898-c004-4cae-914e-55ac43d67799.png)

I showed this new layout to our editors and they liked it.

I am open to feedback so that I can improve the code and our journams would like to see this layout integrated into OJS stable version

thank you