### PR TITLE
pkp#9045 Fix metadata display on the Workflow and Author Dashboard handlers

### DIFF
--- a/pages/authorDashboard/PKPAuthorDashboardHandler.inc.php
+++ b/pages/authorDashboard/PKPAuthorDashboardHandler.inc.php
@@ -325,19 +325,15 @@ abstract class PKPAuthorDashboardHandler extends Handler {
 		];
 
 		// Add the metadata form if one or more metadata fields are enabled
-		$metadataFields = ['coverage', 'disciplines', 'keywords', 'languages', 'rights', 'source', 'subjects', 'agencies', 'type'];
-		$metadataEnabled = false;
-		foreach ($metadataFields as $metadataField) {
-			if ($submissionContext->getData($metadataField)) {
-				$metadataEnabled = true;
-				break;
-			}
-		}
+		$vocabSuggestionUrlBase =$request->getDispatcher()->url($request, ROUTE_API, $submissionContext->getData('urlPath'), 'vocabs', null, null, ['vocab' => '__vocab__']);
+		$metadataForm = new PKP\components\forms\publication\PKPMetadataForm($latestPublicationApiUrl, $locales, $latestPublication, $submissionContext, $vocabSuggestionUrlBase);
+		$metadataFormConfig = $metadataForm->getConfig();
+
+		$metadataEnabled = !empty($metadataFormConfig['fields']);
+
 		if ($metadataEnabled) {
-			$vocabSuggestionUrlBase =$request->getDispatcher()->url($request, ROUTE_API, $submissionContext->getData('urlPath'), 'vocabs', null, null, ['vocab' => '__vocab__']);
-			$metadataForm = new PKP\components\forms\publication\PKPMetadataForm($latestPublicationApiUrl, $locales, $latestPublication, $submissionContext, $vocabSuggestionUrlBase);
 			$templateMgr->setConstants(['FORM_METADATA']);
-			$state['components'][FORM_METADATA] = $metadataForm->getConfig();
+			$state['components'][FORM_METADATA] = $metadataFormConfig;
 			$state['publicationFormIds'][] = FORM_METADATA;
 		}
 

--- a/pages/workflow/PKPWorkflowHandler.inc.php
+++ b/pages/workflow/PKPWorkflowHandler.inc.php
@@ -357,19 +357,15 @@ abstract class PKPWorkflowHandler extends Handler {
 		];
 
 		// Add the metadata form if one or more metadata fields are enabled
-		$metadataFields = ['coverage', 'disciplines', 'keywords', 'languages', 'rights', 'source', 'subjects', 'agencies', 'type'];
-		$metadataEnabled = false;
-		foreach ($metadataFields as $metadataField) {
-			if ($submissionContext->getData($metadataField)) {
-				$metadataEnabled = true;
-				break;
-			}
-		}
-		if ($metadataEnabled || in_array('publication', (array) $submissionContext->getData('enablePublisherId'))) {
-			$vocabSuggestionUrlBase =$request->getDispatcher()->url($request, ROUTE_API, $submissionContext->getData('urlPath'), 'vocabs', null, null, ['vocab' => '__vocab__']);
-			$metadataForm = new PKP\components\forms\publication\PKPMetadataForm($latestPublicationApiUrl, $locales, $latestPublication, $submissionContext, $vocabSuggestionUrlBase);
+		$vocabSuggestionUrlBase =$request->getDispatcher()->url($request, ROUTE_API, $submissionContext->getData('urlPath'), 'vocabs', null, null, ['vocab' => '__vocab__']);
+		$metadataForm = new PKP\components\forms\publication\PKPMetadataForm($latestPublicationApiUrl, $locales, $latestPublication, $submissionContext, $vocabSuggestionUrlBase);
+		$metadataFormConfig = $metadataForm->getConfig();
+
+		$metadataEnabled = !empty($metadataFormConfig['fields']);
+		
+		if ($metadataEnabled) {
 			$templateMgr->setConstants(['FORM_METADATA']);
-			$state['components'][FORM_METADATA] = $metadataForm->getConfig();
+			$state['components'][FORM_METADATA] = $metadataFormConfig;
 			$state['publicationFormIds'][] = FORM_METADATA;
 		}
 


### PR DESCRIPTION
This takes the config from the metadataForm to verify if there is any metadata enabled instead of verifying each default metadata.

Still does not fix all the problems in the [issue I opened](https://github.com/pkp/pkp-lib/issues/9045).