### PR TITLE
Change submission language

### DIFF
--- a/classes/components/forms/submission/ChangeSubmissionLanguageMetadataForm.php
+++ b/classes/components/forms/submission/ChangeSubmissionLanguageMetadataForm.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @file classes/components/form/submission/ChangeSubmissionLanguageMetadataForm.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ChangeSubmissionLanguageMetadataForm
+ *
+ * @brief A form for changing submission's metadata before language change.
+ */
+
+namespace PKP\components\forms\submission;
+
+use APP\facades\Repo;
+use APP\publication\Publication;
+use APP\submission\Submission;
+use PKP\components\forms\Field;
+use PKP\components\forms\FieldHTML;
+use PKP\components\forms\FieldRadioInput;
+use PKP\components\forms\FormComponent;
+use PKP\components\forms\publication\TitleAbstractForm;
+use PKP\context\Context;
+use PKP\facades\Locale;
+
+class ChangeSubmissionLanguageMetadataForm extends FormComponent
+{
+    public const FORM_CHANGE_SUBMISSION_LANGUAGE_METADATA = 'changeSubmissionLanguageMetadata';
+    public $id = self::FORM_CHANGE_SUBMISSION_LANGUAGE_METADATA;
+    public $method = 'PUT';
+
+    public function __construct(string $action, Submission $submission, Publication $publication, Context $context)
+    {
+        $this->action = $action;
+
+        $this->addGroup([
+            'id' => 'language',
+        ]);
+
+        $submissionLocale = $submission->getData('locale');
+        $supportedLocaleNames = collect($context->getSupportedSubmissionLocaleNames());
+        $submissionLocaleNames = collect(Locale::getSubmissionLocaleDisplayNames([$submissionLocale]));
+        $showWhen = ['locale', $supportedLocaleNames->diffKeys($submissionLocaleNames)->keys()->toArray()];
+
+        $this->addGroup([
+            'id' => 'metadata',
+            'showWhen' => $showWhen,
+        ]);
+
+        // Language
+        $localeOptions = $supportedLocaleNames
+            ->union($submissionLocaleNames)
+            ->sortKeys()
+            ->map(fn ($name, $key) => ['value' => $key, 'label' => $name])
+            ->values()
+            ->toArray();
+        $this->addField(new FieldRadioInput('locale', [
+            'label' => __('submission.submit.submissionLocale'),
+            'description' => __('submission.list.changeSubmissionLanguage.languageDescription'),
+            'groupId' => 'language',
+            'type' => 'radio',
+            'options' => $localeOptions,
+            'isRequired' => true,
+            'value' => $submissionLocale,
+        ]));
+
+        // Metadata description
+        $this->addField(new FieldHTML('metadataDescription', [
+            'description' => __('submission.list.changeSubmissionLanguage.metadataDescription'),
+            'groupId' => 'metadata',
+        ]));
+
+        $submissionLocaleName = $submissionLocaleNames->get($submissionLocale);
+
+        // Title and abstract
+        $titleAbstractForm = $this->getTitleAbstractForm(FormComponent::ACTION_EMIT, [$submissionLocale], $publication, $context);
+        $this->setField($titleAbstractForm->getField('title'), $submissionLocaleName, $submissionLocale);
+        $this->setField($titleAbstractForm->getField('abstract'), $submissionLocaleName, $submissionLocale);
+
+        // Add cancel button
+        $this->addCancel();
+    }
+
+    protected function addCancel() {
+        $this->addPage([
+            'id' => 'default',
+            'submitButton' => ['label' => __('common.confirm')],
+            'cancelButton' => ['label' => __('common.cancel')],
+        ]);
+        collect($this->groups)->each(fn ($_, $i) => ($this->groups[$i]['pageId'] = 'default'));
+    }
+
+    protected function getTitleAbstractForm(string $publicationApiUrl, array $locales, Publication $publication, Context $context): TitleAbstractForm
+    {
+        $pubSecId = $publication->getData('sectionId');
+        $section = $pubSecId ? Repo::section()->get($pubSecId, $context->getId()) : null;
+        return new TitleAbstractForm(
+            $publicationApiUrl,
+            $locales,
+            $publication,
+            $section ? (int) $section->getData('wordCount') : 0,
+            $section && !$section->getData('abstractsNotRequired')
+        );
+    }
+
+    protected function setField(Field $field, string $submissionLocaleName, string $submissionLocale): void {
+        if ($field->isRequired) {
+            $field->groupId = 'metadata';
+            $field->description = __("submission.list.changeSubmissionLanguage.metadataDescription.{$field->name}", ['language' => $submissionLocaleName]);
+            if ($field->isMultilingual) {
+                $field->isMultilingual = false;
+                $field->value = $field->value[$submissionLocale];
+            }
+            $this->addField($field);
+        }
+    }
+}

--- a/locale/en/api.po
+++ b/locale/en/api.po
@@ -275,6 +275,9 @@ msgstr "The requested volume, number or year is not valid."
 msgid "api.submissions.400.invalidSubmitAs"
 msgstr "You are not allowed to submit in this user role."
 
+msgid "api.submission.403.cantChangeSubmissionLanguage"
+msgstr "You can not change language of this submission because it already has more than one publication version or a published publication."
+
 msgid "api.submissions.403.csrfTokenFailure"
 msgstr "Your request was denied. This may be because your login has expired. Try reloading the page and trying again."
 

--- a/locale/en/submission.po
+++ b/locale/en/submission.po
@@ -2043,6 +2043,28 @@ msgstr "You must assign at least one participant to this submission before initi
 msgid "submission.query.allowedEditTime"
 msgstr "You can update this discussion for {$allowedEditTimeNoticeLimit} minutes."
 
+msgid "submission.list.changeSubmissionLanguage.currentLanguage"
+msgstr "Current Submission Language:"
+
+msgid "submission.list.changeSubmissionLanguage.buttonLabel"
+msgstr "Change"
+
+msgid "submission.list.changeSubmissionLanguage.title"
+msgstr "Change Submission Language For"
+
+msgid "submission.list.changeSubmissionLanguage.languageDescription"
+msgstr "This is the primary submission language. Changing this will have effects on the submission and the metadata entered"
+
+msgid "submission.list.changeSubmissionLanguage.metadataDescription"
+msgstr "<strong>Before changing the submission language, ensure you have filled out the following metadata fields to maintain system integrity. "
+"Also, note that contributor information and file names will be copied from previously entered information.</strong>"
+
+msgid "submission.list.changeSubmissionLanguage.metadataDescription.title"
+msgstr "Enter submission title here in {$language}. You can format your title as needed"
+
+msgid "submission.list.changeSubmissionLanguage.metadataDescription.abstract"
+msgstr "Including the abstract in {$language} is recommended. This helps ensure that the content is accessible"
+
 msgid "submission.list.infoCenter"
 msgstr "Activity Log & Notes"
 
@@ -2430,3 +2452,5 @@ msgstr "Competing Interests"
 msgid "author.competingInterests.description"
 msgstr "Please disclose any competing interests this author may have with the research subject."
 
+msgid "submission.localeNotSupported"
+msgstr "The language of the submission ({$language}) is not one of the supported submission languages. You can still edit the submission details but new submissions are not currently accepted with this language."

--- a/pages/authorDashboard/PKPAuthorDashboardHandler.php
+++ b/pages/authorDashboard/PKPAuthorDashboardHandler.php
@@ -34,6 +34,7 @@ use PKP\core\JSONMessage;
 use PKP\core\PKPApplication;
 use PKP\core\PKPRequest;
 use PKP\db\DAORegistry;
+use PKP\facades\Locale;
 use PKP\log\SubmissionEmailLogEventType;
 use PKP\security\authorization\AuthorDashboardAccessPolicy;
 use PKP\security\Role;
@@ -305,6 +306,7 @@ abstract class PKPAuthorDashboardHandler extends Handler
 
         $state = [
             'canEditPublication' => $canEditPublication,
+            'currentSubmissionLanguageLabel' => Locale::getSubmissionLocaleDisplayNames([$submissionLocale])[$submissionLocale],
             'components' => [
                 $titleAbstractForm::FORM_TITLE_ABSTRACT => $this->getLocalizedForm($titleAbstractForm, $submissionLocale, $locales),
                 $citationsForm::FORM_CITATIONS => $this->getLocalizedForm($citationsForm, $submissionLocale, $locales),


### PR DESCRIPTION
- Change the submission language after submission
- Show the language of the submission in the workflow page and the author dashboard
-  In the modal window editors can change the language and add/edit required metadata
- The submission's metadata can be edited even if the submission's locale is not one of the currently supported submission locales
- The language of the submission can not be changed if the status of the publication is published or there are more than one version