### PR TITLE
pkp/pkp-lib#9195 removed int type hint for tries public property from jobs

### DIFF
--- a/jobs/BaseJob.php
+++ b/jobs/BaseJob.php
@@ -35,8 +35,10 @@ abstract class BaseJob implements ShouldQueue
 
     /**
      * The number of times the job may be attempted.
+     * 
+     * @var int
      */
-    public int $tries = 3;
+    public $tries = 3;
 
     /**
      * The number of SECONDS to wait before retrying the job.

--- a/jobs/testJobs/TestJobFailure.php
+++ b/jobs/testJobs/TestJobFailure.php
@@ -27,8 +27,10 @@ class TestJobFailure extends BaseJob
 
     /**
      * The number of times the job may be attempted.
+     * 
+     * @var int
      */
-    public int $tries = 1;
+    public $tries = 1;
 
     /**
      * The maximum number of unhandled exceptions to allow before failing.

--- a/jobs/testJobs/TestJobSuccess.php
+++ b/jobs/testJobs/TestJobSuccess.php
@@ -26,8 +26,10 @@ class TestJobSuccess extends BaseJob
 
     /**
      * The number of times the job may be attempted.
+     * 
+     * @var int
      */
-    public int $tries = 1;
+    public $tries = 1;
 
     /**
      * Initialize the job


### PR DESCRIPTION
patch for pkp/pkp-lib#9195 as of issue reported at https://forum.pkp.sfu.ca/t/ojs-3-4-0-2-php-fatal-error-usage-statistics-stopped-procesing-records/80762