### PR TITLE
pkp/pkp-lib#9278 Use ISO639-2b instead of ISO639-3 for locale conversion

### DIFF
--- a/classes/dev/ComposerScript.php
+++ b/classes/dev/ComposerScript.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @file classes/dev/ComposerScript.php
+ *
+ * Copyright (c) 2023 Simon Fraser University
+ * Copyright (c) 2023 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ComposerScript
+ *
+ * @brief Custom composer script that checks if the file iso_639-2.json exists in sokil library
+ */
+
+namespace PKP\dev;
+
+use Exception;
+
+class ComposerScript
+{
+    /**
+     * A post-install-cmd custom composer script that checks if
+     * the file iso_639-2.json exists in the installed sokil library
+     *
+     * @throw Exception
+     */
+    public static function isoFileCheck(): void
+    {
+        // We use dirname(__FILE__, 3) and not Core::getBaseDir() because
+        // this funciton is called by Composer, where INDEX_FILE_LOCATION is not defined.
+        $iso6392bFile = dirname(__FILE__, 3) . '/lib/vendor/sokil/php-isocodes-db-i18n/databases/iso_639-2.json';
+        if (!file_exists($iso6392bFile)) {
+            throw new Exception("The ISO639-2b file {$iso6392bFile} does not exist.");
+        }
+    }
+}

--- a/classes/i18n/LocaleMetadata.php
+++ b/classes/i18n/LocaleMetadata.php
@@ -229,7 +229,7 @@ class LocaleMetadata
     }
 
     /**
-     * Retrieves the ISO639-2b representation
+     * Retrieves the ISO639-1 representation
      */
     public function getIsoAlpha2(): string
     {

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,12 @@
 		"sort-packages": true
 	},
 	"scripts": {
-		"fix": "PHP_CS_FIXER_IGNORE_ENV=1 ./lib/vendor/bin/php-cs-fixer fix --allow-risky=yes"
+		"fix": "PHP_CS_FIXER_IGNORE_ENV=1 ./lib/vendor/bin/php-cs-fixer fix --allow-risky=yes",
+		"post-install-cmd": [
+			"@isoFileCheck"
+		],
+		"isoFileCheck": [
+			"PKP\\dev\\ComposerScript::isoFileCheck"		]
 	},
 	"extra": {
 		"patches": {

--- a/tests/classes/i18n/LocaleTest.php
+++ b/tests/classes/i18n/LocaleTest.php
@@ -101,6 +101,7 @@ class LocaleTest extends PKPTestCase
      */
     public function testGetLocales()
     {
+        $this->_primaryLocale = 'en_US';
         $expectedLocales = [
             'en' => 'English',
             'pt_BR' => 'Portuguese',
@@ -133,6 +134,7 @@ class LocaleTest extends PKPTestCase
     {
         self::assertEquals('eng', LocaleConversion::get3LetterFrom2LetterIsoLanguage('en'));
         self::assertEquals('por', LocaleConversion::get3LetterFrom2LetterIsoLanguage('pt'));
+        self::assertEquals('fre', LocaleConversion::get3LetterFrom2LetterIsoLanguage('fr'));
         self::assertNull(LocaleConversion::get3LetterFrom2LetterIsoLanguage('xx'));
     }
 
@@ -143,6 +145,7 @@ class LocaleTest extends PKPTestCase
     {
         self::assertEquals('en', LocaleConversion::get2LetterFrom3LetterIsoLanguage('eng'));
         self::assertEquals('pt', LocaleConversion::get2LetterFrom3LetterIsoLanguage('por'));
+        self::assertEquals('fr', LocaleConversion::get2LetterFrom3LetterIsoLanguage('fre'));
         self::assertNull(LocaleConversion::get2LetterFrom3LetterIsoLanguage('xxx'));
     }
 


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/9278