### PR TITLE
Fix null locale when inserting into "email_templates_settings"

### DIFF
--- a/classes/migration/upgrade/v3_4_0/I5716_EmailTemplateAssignments.php
+++ b/classes/migration/upgrade/v3_4_0/I5716_EmailTemplateAssignments.php
@@ -457,7 +457,7 @@ abstract class I5716_EmailTemplateAssignments extends Migration
 
         $contextIds->each(function (int $contextId) use ($primaryLocales) {
             $primaryLocale = $primaryLocales
-                ->first(fn ($row) => $row->context_id === $contextId)
+                ->first(fn ($row) => $row->context_id == $contextId)
                 ->primary_locale;
 
             $nameRows = DB::table('email_templates')


### PR DESCRIPTION
Hello!

I had a problem when upgrading from 3.3.0-14 into 3.4.0-3:

```
PHP Warning:  Attempt to read property "primary_locale" on null in /lib/pkp/classes/migration/upgrade/v3_4_0/I5716_EmailTemplateAssignments.php on line 461
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'locale' cannot be null (SQL: insert into `email_templates_settings` (`email_id`, `locale`, `setting_name`, `setting_value`) values (...)
```

As we only have one journal, `context_id` was equal to `1` in our installation. Removing the strict comparison fixed the migration flow.

Feel free to suggest any changes to this PR.

Regards!