### PR TITLE
Submission and metadata languages separated from UI and form languages

### DIFF
--- a/api/v1/submissions/PKPSubmissionFileController.php
+++ b/api/v1/submissions/PKPSubmissionFileController.php
@@ -320,12 +320,12 @@ class PKPSubmissionFileController extends PKPBaseController
         $params['submissionId'] = $submission->getId();
         $params['uploaderUserId'] = (int) $request->getUser()->getId();
 
-        $primaryLocale = $request->getContext()->getPrimaryLocale();
-        $allowedLocales = $request->getContext()->getData('supportedSubmissionLocales');
+        $submissionLocale = $submission->getData('locale');
+        $allowedLocales = $request->getContext()->getSupportedSubmissionMetadataLocales();
 
         // Set the name if not passed with the request
         if (empty($params['name'])) {
-            $params['name'][$primaryLocale] = $_FILES['file']['name'];
+            $params['name'][$submissionLocale] = $_FILES['file']['name'];
         }
 
         // If no genre has been set and there is only one genre possible, set it automatically
@@ -344,7 +344,7 @@ class PKPSubmissionFileController extends PKPBaseController
                 null,
                 $params,
                 $allowedLocales,
-                $primaryLocale
+                $submissionLocale
             );
 
         if (!empty($errors)) {
@@ -430,15 +430,15 @@ class PKPSubmissionFileController extends PKPBaseController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        $primaryLocale = $request->getContext()->getPrimaryLocale();
-        $allowedLocales = $request->getContext()->getData('supportedSubmissionLocales');
+        $submissionLocale = $submission->getData('locale');
+        $allowedLocales = $request->getContext()->getSupportedSubmissionMetadataLocales();
 
         $errors = Repo::submissionFile()
             ->validate(
                 $submissionFile,
                 $params,
                 $allowedLocales,
-                $primaryLocale
+                $submissionLocale
             );
 
         if (!empty($errors)) {
@@ -466,7 +466,7 @@ class PKPSubmissionFileController extends PKPBaseController
             $params['fileId'] = $fileId;
             $params['uploaderUserId'] = $request->getUser()->getId();
             if (empty($params['name'])) {
-                $params['name'][$primaryLocale] = $_FILES['file']['name'];
+                $params['name'][$submissionLocale] = $_FILES['file']['name'];
             }
         }
 

--- a/api/v1/vocabs/PKPVocabController.php
+++ b/api/v1/vocabs/PKPVocabController.php
@@ -18,6 +18,7 @@
 namespace PKP\API\v1\vocabs;
 
 use APP\core\Application;
+use APP\facades\Repo;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -104,8 +105,9 @@ class PKPVocabController extends PKPBaseController
         $vocab = $requestParams['vocab'] ?? '';
         $locale = $requestParams['locale'] ?? Locale::getLocale();
         $term = $requestParams['term'] ?? null;
+        $locales = array_merge($context->getSupportedSubmissionMetadataLocales(), isset($requestParams['submissionId']) ? Repo::submission()->get((int) $requestParams['submissionId'])?->getPublicationLanguages() ?? [] : []);
 
-        if (!in_array($locale, $context->getData('supportedSubmissionLocales'))) {
+        if (!in_array($locale, $locales)) {
             return response()->json([
                 'error' => __('api.vocabs.400.localeNotSupported', ['locale' => $locale]),
             ], Response::HTTP_BAD_REQUEST);

--- a/classes/author/Repository.php
+++ b/classes/author/Repository.php
@@ -99,8 +99,8 @@ class Repository
     public function validate($author, $props, Submission $submission, Context $context)
     {
         $schemaService = Services::get('schema');
-        $allowedLocales = $context->getSupportedSubmissionLocales();
         $primaryLocale = $submission->getData('locale');
+        $allowedLocales = $submission->getPublicationLanguages($context->getSupportedSubmissionMetadataLocales());
 
         $validator = ValidatorFactory::make(
             $props,

--- a/classes/author/maps/Schema.php
+++ b/classes/author/maps/Schema.php
@@ -106,7 +106,9 @@ class Schema extends \PKP\core\maps\Schema
             }
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues($this->schema, $output, $this->context->getSupportedSubmissionLocales());
+        $locales = Repo::submission()->get(Repo::publication()->get($item->getData('publicationId'))->getData('submissionId'))->getPublicationLanguages($this->context->getSupportedSubmissionMetadataLocales());
+
+        $output = $this->schemaService->addMissingMultilingualValues($this->schema, $output, $locales);
 
         ksort($output);
 

--- a/classes/components/listPanels/ContributorsListPanel.php
+++ b/classes/components/listPanels/ContributorsListPanel.php
@@ -107,8 +107,6 @@ class ContributorsListPanel extends ListPanel
      */
     protected function getLocalizedForm(): array
     {
-        uksort($this->locales, fn ($a, $b) => $a === $this->submission->getData('locale') ? -1 : 1);
-
         $apiUrl = Application::get()->getRequest()->getDispatcher()->url(
             Application::get()->getRequest(),
             Application::ROUTE_API,
@@ -116,11 +114,15 @@ class ContributorsListPanel extends ListPanel
             'submissions/' . $this->submission->getId() . '/publications/__publicationId__/contributors'
         );
 
-        $form = $this->getForm($apiUrl);
+        $submissionLocale = $this->submission->getData('locale');
+        $data = $this->getForm($apiUrl)->getConfig();
 
-        $data = $form->getConfig();
-        $data['primaryLocale'] = $this->submission->getData('locale');
-        $data['visibleLocales'] = [$this->submission->getData('locale')];
+        $data['primaryLocale'] = $submissionLocale;
+        $data['visibleLocales'] = [$submissionLocale];
+        $data['supportedFormLocales'] = collect($this->locales)
+            ->sortBy([fn (array $a, array $b) => $b['key'] === $submissionLocale ? 1 : -1])
+            ->values()
+            ->toArray();
 
         return $data;
     }

--- a/classes/context/Context.php
+++ b/classes/context/Context.php
@@ -360,14 +360,10 @@ abstract class Context extends \PKP\core\DataObject
     /**
      * Return associative array of all locales supported by submissions on the
      * context.
-     *
-     * @param  int  $langLocaleStatus The const value of one of LocaleMetadata:LANGUAGE_LOCALE_*
-     *
-     * @return array
      */
-    public function getSupportedSubmissionLocaleNames(int $langLocaleStatus = LocaleMetadata::LANGUAGE_LOCALE_WITHOUT)
+    public function getSupportedSubmissionLocaleNames(): array
     {
-        return $this->getData('supportedSubmissionLocaleNames') ?? Locale::getFormattedDisplayNames($this->getSupportedSubmissionLocales(), null, $langLocaleStatus);
+        return $this->getData('supportedSubmissionLocaleNames') ?? Locale::getSubmissionLocaleDisplayNames($this->getSupportedSubmissionLocales());
     }
 
     /**
@@ -391,6 +387,55 @@ abstract class Context extends \PKP\core\DataObject
     public function getSupportedLocaleNames(int $langLocaleStatus = LocaleMetadata::LANGUAGE_LOCALE_WITHOUT)
     {
         return $this->getData('supportedLocaleNames') ?? Locale::getFormattedDisplayNames($this->getSupportedLocales(), null, $langLocaleStatus);
+    }
+
+    /**
+     * Get the supported added submission locales.
+     */
+    public function getSupportedAddedSubmissionLocales(): array
+    {
+        return $this->getData('supportedAddedSubmissionLocales');
+    }
+
+    /**
+     * Return associative array of added locales supported by submissions on the
+     * context.
+     */
+    public function getSupportedAddedSubmissionLocaleNames(): array
+    {
+        return Locale::getSubmissionLocaleDisplayNames($this->getSupportedAddedSubmissionLocales());
+    }
+
+    /**
+     * Get the supported default submission locale.
+     */
+    public function getSupportedDefaultSubmissionLocale(): string
+    {
+        return $this->getData('supportedDefaultSubmissionLocale');
+    }
+
+    /**
+     * Return string default submission locale supported by the site.
+     */
+    public function getSupportedDefaultSubmissionLocaleName(): string
+    {
+        return Locale::getSubmissionLocaleDisplayNames([$l = $this->getSupportedDefaultSubmissionLocale()])[$l];
+    }
+
+    /**
+     * Get the supported metadata locales.
+     */
+    public function getSupportedSubmissionMetadataLocales(): array
+    {
+        return $this->getData('supportedSubmissionMetadataLocales');
+    }
+
+    /**
+     * Return associative array of all locales supported by submission metadata forms on the site.
+     */
+    public function getSupportedSubmissionMetadataLocaleNames(): array
+    {
+        return Locale::getSubmissionLocaleDisplayNames($this->getSupportedSubmissionMetadataLocales());
     }
 
     /**

--- a/classes/core/DataObject.php
+++ b/classes/core/DataObject.php
@@ -47,6 +47,19 @@ class DataObject
     /** @var bool whether injection adapters have already been loaded from the database */
     public $_injectionAdaptersLoaded = false;
 
+    /** @var array conversion table for locales */
+    public $_localesTable = [
+        "be@cyrillic" => "be",
+        "bs" => "bs_Latn",
+        "fr_FR" => "fr",
+        "nb" => "nb_NO",
+        "sr@cyrillic" => "sr_Cyrl",
+        "sr@latin" => "sr_Latn",
+        "uz@cyrillic" => "uz",
+        "uz@latin" => "uz_Latn",
+        "zh_CN" => "zh_Hans",
+    ];
+
     /**
      * Constructor
      */
@@ -101,6 +114,7 @@ class DataObject
         return array_unique(
             array_filter([
                 $preferredLocale ?? Locale::getLocale(),
+                $this->_localesTable[$preferredLocale ?? Locale::getLocale()] ?? null,
                 $this->getDefaultLocale(),
                 $request->getContext()?->getPrimaryLocale(),
                 $request->getSite()->getPrimaryLocale(),

--- a/classes/dev/ComposerScript.php
+++ b/classes/dev/ComposerScript.php
@@ -32,4 +32,44 @@ class ComposerScript
             throw new Exception("The ISO639-2b file {$iso6392bFile} does not exist.");
         }
     }
+
+    /**
+     * A post-install-cmd custom composer script that
+     * creates languages.json from downloaded Weblate languages.csv.
+     */
+    public static function weblateFilesDownload(): void
+    {
+        try {
+            $dirPath = dirname(__FILE__, 3) . "/lib/weblateLanguages";
+            $langFilePath = "$dirPath/languages.json";
+            $urlCsv = 'https://raw.githubusercontent.com/WeblateOrg/language-data/main/languages.csv';
+
+            if (!is_dir($dirPath)) {
+                mkdir($dirPath);
+            }
+
+            $streamContext = stream_context_create(['http' => ['method' => 'HEAD']]);
+            $languagesCsv = !preg_match('/200 OK/', get_headers($urlCsv, false, $streamContext)[0] ?? "") ?: file($urlCsv, FILE_SKIP_EMPTY_LINES);
+            if (!is_array($languagesCsv) || !$languagesCsv) {
+                throw new Exception(__METHOD__ . " : The Weblate file 'languages.csv' cannot be downloaded !");
+            }
+
+            array_shift($languagesCsv);
+            $languages = [];
+            foreach($languagesCsv as $languageCsv) {
+                $localeAndName = str_getcsv($languageCsv, ",");
+                if (isset($localeAndName[0], $localeAndName[1]) && preg_match('/^[\w@-]{2,50}$/', $localeAndName[0])) {
+                    $displayName = locale_get_display_name($localeAndName[0], 'en');
+                    $languages[$localeAndName[0]] = (($displayName && $displayName !== $localeAndName[0]) ? $displayName : $localeAndName[1]);
+                }
+            }
+
+            $languagesJson = json_encode($languages, JSON_THROW_ON_ERROR);
+            if (!$languagesJson || !file_put_contents($langFilePath, $languagesJson)) {
+                throw new Exception(__METHOD__ . " : Json file empty, or save unsuccessful: $langFilePath !");
+            }
+        } catch (Exception $e) {
+            error_log($e->getMessage());
+        }
+    }
 }

--- a/classes/galley/maps/Schema.php
+++ b/classes/galley/maps/Schema.php
@@ -140,7 +140,9 @@ class Schema extends \PKP\core\maps\Schema
             }
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues($this->schema, $output, $this->context->getSupportedFormLocales());
+        $locales = $this->publication->getLanguages($this->context->getSupportedSubmissionMetadataLocales(), $galley->getLanguages());
+
+        $output = $this->schemaService->addMissingMultilingualValues($this->schema, $output, $locales);
 
         ksort($output);
 

--- a/classes/i18n/interfaces/LocaleInterface.php
+++ b/classes/i18n/interfaces/LocaleInterface.php
@@ -38,6 +38,7 @@ interface LocaleInterface extends \Illuminate\Contracts\Translation\Translator
 
     /** Regular expression to validate and extract pieces of a locale code */
     public const LOCALE_EXPRESSION = '/^(?P<language>[a-z]{2})(?:_(?P<country>[A-Za-z]{2,4}))?(?:@(?P<script>[A-Za-z\d]{5,8}|\d[A-Za-z\d]{3}))?$/';
+    public const LOCALE_EXPRESSION_SUBMISSION = '/^(?P<language>[A-Za-z]{2,4})(?:[_-](?P<script>[A-Za-z]{4,5}|[0-9]{4}))?(?:[_-](?P<country>[A-Za-z]{2}|[0-9]{3}))?(?:@(?P<variant>[a-z]{2,30})(?:[_-](?P<variant_script>(?&script)))?)?$/';
 
     /**
      * Attempts to retrieve the primary locale for the current context, if not available, then for the site.
@@ -71,6 +72,11 @@ interface LocaleInterface extends \Illuminate\Contracts\Translation\Translator
      * Check if the supplied locale is valid.
      */
     public function isLocaleValid(?string $locale): bool;
+
+    /**
+     * Check if the supplied submission locale is valid.
+     */
+    public function isSubmissionLocaleValid(?string $locale): bool;
 
     /**
      * Retrieves the metadata of a locale

--- a/classes/migration/install/AnnouncementsMigration.php
+++ b/classes/migration/install/AnnouncementsMigration.php
@@ -43,7 +43,7 @@ class AnnouncementsMigration extends \PKP\migration\Migration
             $table->foreign('type_id')->references('type_id')->on('announcement_types')->onDelete('cascade');
             $table->index(['type_id'], 'announcement_type_settings_type_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6);
@@ -76,7 +76,7 @@ class AnnouncementsMigration extends \PKP\migration\Migration
             $table->foreign('announcement_id')->references('announcement_id')->on('announcements')->onDelete('cascade');
             $table->index(['announcement_id'], 'announcement_settings_announcement_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/CategoriesMigration.php
+++ b/classes/migration/install/CategoriesMigration.php
@@ -55,7 +55,7 @@ class CategoriesMigration extends \PKP\migration\Migration
             $table->foreign('category_id')->references('category_id')->on('categories')->onDelete('cascade');
             $table->index(['category_id'], 'category_settings_category_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/CommonMigration.php
+++ b/classes/migration/install/CommonMigration.php
@@ -48,7 +48,7 @@ class CommonMigration extends \PKP\migration\Migration
             $table->comment('A singleton table describing basic information about the site.');
             $table->bigIncrements('site_id');
             $table->bigInteger('redirect')->default(0)->comment('If not 0, redirect to the specified journal/conference/... site.');
-            $table->string('primary_locale', 14)->comment('Primary locale for the site.');
+            $table->string('primary_locale', 28)->comment('Primary locale for the site.');
             $table->smallInteger('min_password_length')->default(6);
             $table->string('installed_locales', 1024)->default('en')->comment('Locales for which support has been installed.');
             $table->string('supported_locales', 1024)->comment('Locales supported by the site (for hosted journals/conferences/...).')->nullable();
@@ -60,7 +60,7 @@ class CommonMigration extends \PKP\migration\Migration
             $table->comment('More data about the site, including localized properties such as its name.');
             $table->bigIncrements('site_setting_id');
             $table->string('setting_name', 255);
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->mediumText('setting_value')->nullable();
             $table->unique(['setting_name', 'locale'], 'site_settings_unique');
         });
@@ -111,7 +111,7 @@ class CommonMigration extends \PKP\migration\Migration
             $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
             $table->index(['user_id'], 'user_settings_user_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 
@@ -171,7 +171,7 @@ class CommonMigration extends \PKP\migration\Migration
             $table->foreign('notification_id')->references('notification_id')->on('notifications')->onDelete('cascade');
             $table->index(['notification_id'], 'notification_settings_notification_id');
 
-            $table->string('locale', 14)->nullable();
+            $table->string('locale', 28)->nullable();
             $table->string('setting_name', 64);
             $table->mediumText('setting_value');
             $table->string('setting_type', 6)->comment('(bool|int|float|string|object)');
@@ -200,7 +200,7 @@ class CommonMigration extends \PKP\migration\Migration
             $table->comment('Default email templates created for every installed locale.');
             $table->bigIncrements('email_templates_default_data_id');
             $table->string('email_key', 255)->comment('Unique identifier for this email.');
-            $table->string('locale', 14)->default('en');
+            $table->string('locale', 28)->default('en');
             $table->string('name', 255);
             $table->string('subject', 255);
             $table->text('body')->nullable();
@@ -230,7 +230,7 @@ class CommonMigration extends \PKP\migration\Migration
             $table->foreign('email_id', 'email_templates_settings_email_id')->references('email_id')->on('email_templates')->onDelete('cascade');
             $table->index(['email_id'], 'email_templates_settings_email_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/ControlledVocabMigration.php
+++ b/classes/migration/install/ControlledVocabMigration.php
@@ -55,7 +55,7 @@ class ControlledVocabMigration extends \PKP\migration\Migration
             $table->foreign('controlled_vocab_entry_id', 'c_v_e_s_entry_id')->references('controlled_vocab_entry_id')->on('controlled_vocab_entries')->onDelete('cascade');
             $table->index(['controlled_vocab_entry_id'], 'c_v_e_s_entry_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6);

--- a/classes/migration/install/DoiMigration.php
+++ b/classes/migration/install/DoiMigration.php
@@ -46,7 +46,7 @@ class DoiMigration extends Migration
             $table->comment('More data about DOIs, including the registration agency.');
             $table->bigIncrements('doi_setting_id');
             $table->bigInteger('doi_id');
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/GenresMigration.php
+++ b/classes/migration/install/GenresMigration.php
@@ -54,7 +54,7 @@ class GenresMigration extends \PKP\migration\Migration
             $table->foreign('genre_id')->references('genre_id')->on('genres')->onDelete('cascade');
             $table->index(['genre_id'], 'genre_settings_genre_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6)->comment('(bool|int|float|string|object)');

--- a/classes/migration/install/HighlightsMigration.php
+++ b/classes/migration/install/HighlightsMigration.php
@@ -43,7 +43,7 @@ class HighlightsMigration extends \PKP\migration\Migration
             $table->foreign('highlight_id')->references('highlight_id')->on('highlights')->onDelete('cascade');
             $table->index(['highlight_id'], 'highlight_settings_highlight_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/InstitutionsMigration.php
+++ b/classes/migration/install/InstitutionsMigration.php
@@ -45,7 +45,7 @@ class InstitutionsMigration extends \PKP\migration\Migration
             $table->foreign('institution_id')->references('institution_id')->on('institutions')->onDelete('cascade');
             $table->index(['institution_id'], 'institution_settings_institution_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/LibraryFilesMigration.php
+++ b/classes/migration/install/LibraryFilesMigration.php
@@ -57,7 +57,7 @@ class LibraryFilesMigration extends \PKP\migration\Migration
             $table->foreign('file_id')->references('file_id')->on('library_files')->onDelete('cascade');
             $table->index(['file_id'], 'library_file_settings_file_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6)->comment('(bool|int|float|string|object|date)');

--- a/classes/migration/install/LogMigration.php
+++ b/classes/migration/install/LogMigration.php
@@ -49,7 +49,7 @@ class LogMigration extends \PKP\migration\Migration
             $table->foreign('log_id', 'event_log_settings_log_id')->references('log_id')->on('event_log')->onDelete('cascade');
             $table->index(['log_id'], 'event_log_settings_log_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->unique(['log_id', 'setting_name', 'locale'], 'event_log_settings_unique');

--- a/classes/migration/install/MetadataMigration.php
+++ b/classes/migration/install/MetadataMigration.php
@@ -47,7 +47,7 @@ class MetadataMigration extends \PKP\migration\Migration
             $table->foreign('citation_id', 'citation_settings_citation_id')->references('citation_id')->on('citations')->onDelete('cascade');
             $table->index(['citation_id'], 'citation_settings_citation_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6);
@@ -92,7 +92,7 @@ class MetadataMigration extends \PKP\migration\Migration
             $table->foreign('filter_id')->references('filter_id')->on('filters')->onDelete('cascade');
             $table->index(['filter_id'], 'filter_settings_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6);

--- a/classes/migration/install/NavigationMenusMigration.php
+++ b/classes/migration/install/NavigationMenusMigration.php
@@ -50,7 +50,7 @@ class NavigationMenusMigration extends \PKP\migration\Migration
             $table->foreign('navigation_menu_item_id', 'navigation_menu_item_settings_navigation_menu_id')->references('navigation_menu_item_id')->on('navigation_menu_items')->onDelete('cascade');
             $table->index(['navigation_menu_item_id'], 'navigation_menu_item_settings_navigation_menu_item_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->longText('setting_value')->nullable();
             $table->string('setting_type', 6);
@@ -83,7 +83,7 @@ class NavigationMenusMigration extends \PKP\migration\Migration
             $table->foreign('navigation_menu_item_assignment_id', 'assignment_settings_navigation_menu_item_assignment_id')->references('navigation_menu_item_assignment_id')->on('navigation_menu_item_assignments')->onDelete('cascade');
             $table->index(['navigation_menu_item_assignment_id'], 'navigation_menu_item_assignment_settings_n_m_i_a_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6);

--- a/classes/migration/install/ReviewFormsMigration.php
+++ b/classes/migration/install/ReviewFormsMigration.php
@@ -45,7 +45,7 @@ class ReviewFormsMigration extends \PKP\migration\Migration
                 $table->foreign('review_form_id', 'review_form_settings_review_form_id')->references('review_form_id')->on('review_forms')->onDelete('cascade');
                 $table->index(['review_form_id'], 'review_form_settings_review_form_id');
 
-                $table->string('locale', 14)->default('');
+                $table->string('locale', 28)->default('');
                 $table->string('setting_name', 255);
                 $table->mediumText('setting_value')->nullable();
                 $table->string('setting_type', 6);
@@ -80,7 +80,7 @@ class ReviewFormsMigration extends \PKP\migration\Migration
                 $table->foreign('review_form_element_id', 'review_form_element_settings_review_form_element_id')->references('review_form_element_id')->on('review_form_elements')->onDelete('cascade');
                 $table->index(['review_form_element_id'], 'review_form_element_settings_review_form_element_id');
 
-                $table->string('locale', 14)->default('');
+                $table->string('locale', 28)->default('');
                 $table->string('setting_name', 255);
                 $table->mediumText('setting_value')->nullable();
                 $table->string('setting_type', 6);

--- a/classes/migration/install/RolesAndUserGroupsMigration.php
+++ b/classes/migration/install/RolesAndUserGroupsMigration.php
@@ -44,7 +44,7 @@ class RolesAndUserGroupsMigration extends \PKP\migration\Migration
             $table->comment('More data about user groups, including localized properties such as the name.');
             $table->bigIncrements('user_group_setting_id');
             $table->bigInteger('user_group_id');
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/SubmissionFilesMigration.php
+++ b/classes/migration/install/SubmissionFilesMigration.php
@@ -72,7 +72,7 @@ class SubmissionFilesMigration extends \PKP\migration\Migration
             $table->foreign('submission_file_id')->references('submission_file_id')->on('submission_files')->onDelete('cascade');
             $table->index(['submission_file_id'], 'submission_file_settings_submission_file_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/SubmissionsMigration.php
+++ b/classes/migration/install/SubmissionsMigration.php
@@ -45,7 +45,7 @@ class SubmissionsMigration extends \PKP\migration\Migration
             $table->datetime('date_submitted')->nullable();
             $table->datetime('last_modified')->nullable();
             $table->bigInteger('stage_id')->default($this->defaultStageId);
-            $table->string('locale', 14)->nullable();
+            $table->string('locale', 28)->nullable();
 
             $table->smallInteger('status')->default(PKPSubmission::STATUS_QUEUED);
 
@@ -66,7 +66,7 @@ class SubmissionsMigration extends \PKP\migration\Migration
             $table->foreign('submission_id')->references('submission_id')->on('submissions')->onDelete('cascade');
             $table->index(['submission_id'], 'submission_settings_submission_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 
@@ -81,7 +81,7 @@ class SubmissionsMigration extends \PKP\migration\Migration
             // The foreign key relationship on this table is defined with the publications table.
             $table->bigInteger('publication_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 
@@ -120,7 +120,7 @@ class SubmissionsMigration extends \PKP\migration\Migration
             $table->foreign('author_id', 'author_settings_author_id')->references('author_id')->on('authors')->onDelete('cascade');
             $table->index(['author_id'], 'author_settings_author_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/TombstoneMigration.php
+++ b/classes/migration/install/TombstoneMigration.php
@@ -44,7 +44,7 @@ class TombstoneMigration extends \PKP\migration\Migration
             $table->foreign('tombstone_id', 'data_object_tombstone_settings_tombstone_id')->references('tombstone_id')->on('data_object_tombstones')->onDelete('cascade');
             $table->index(['tombstone_id'], 'data_object_tombstone_settings_tombstone_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6)->comment('(bool|int|float|string|object)');

--- a/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+++ b/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I9425_SeparateUIAndSubmissionLocales
+ *
+ * @brief pkp/pkp-lib#9425 Make submission language selection and metadata forms independent from website language settings
+ */
+
+namespace PKP\migration\upgrade\v3_5_0;
+
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use APP\core\Application;
+use PKP\install\DowngradeNotSupportedException;
+use PKP\migration\Migration;
+
+abstract class I9425_SeparateUIAndSubmissionLocales extends Migration
+{
+    abstract protected function getContextTable(): string;
+    abstract protected function getContextSettingsTable(): string;
+    abstract protected function getContextIdColumn(): string;
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        /**
+         * Update/add locale arrays
+         */
+
+        $insert = function (object $localeId, string $settingName, string $settingValue): void {
+            DB::table($this->getContextSettingsTable())->insert(
+                [
+                    $this->getContextIdColumn() => $localeId->{$this->getContextIdColumn()},
+                    'locale' => '',
+                    'setting_name' => $settingName,
+                    'setting_value' => $settingValue,
+                ]
+            );
+        };
+        $update = function (object $localeId, string $settingName, string $settingValue): void {
+            DB::table($this->getContextSettingsTable())
+            ->where($this->getContextIdColumn(), '=', $localeId->{$this->getContextIdColumn()})
+            ->where('setting_name', '=', $settingName)
+            ->update(['setting_value' => $settingValue]);
+        };
+        $pluck = fn (object $localeId, string $settingName): array => json_decode(
+            DB::table($this->getContextSettingsTable())
+                ->where($this->getContextIdColumn(), '=', $localeId->{$this->getContextIdColumn()})
+                ->where('setting_name', '=', $settingName)
+                ->pluck('setting_value')[0]
+        );
+        $union = fn (array $a, array $b): string => collect($a)->concat($b)->unique()->sort()->values()->toJson();
+
+        foreach (DB::table($this->getContextTable())->select('primary_locale', $this->getContextIdColumn())->get() as $localeId) {
+            // Add primary locale to form locales
+            $formLocales = $union([$localeId->primary_locale], $pluck($localeId, 'supportedFormLocales'));
+            $update($localeId, 'supportedFormLocales', $formLocales);
+            // Add primary locale to submission locales
+            $submissionLocales = $union([$localeId->primary_locale], $pluck($localeId, 'supportedSubmissionLocales'));
+            $update($localeId, 'supportedSubmissionLocales', $submissionLocales);
+            // supportedDefaultSubmissionLocale from primary locale
+            $insert($localeId, 'supportedDefaultSubmissionLocale', $localeId->primary_locale);
+            // supportedAddedSubmissionLocales from supportedSubmissionLocales and supportedFormLocales
+            $submFormLocales = $union(json_decode($submissionLocales), json_decode($formLocales));
+            $insert($localeId, 'supportedAddedSubmissionLocales', $submFormLocales);
+            // supportedSubmissionMetadataLocales from supportedSubmissionLocales and supportedFormLocales
+            $insert($localeId, 'supportedSubmissionMetadataLocales', $submFormLocales);
+        }
+
+        /**
+         * Update locale character lengths
+         */
+
+        $schemaLocName = (DB::connection() instanceof PostgresConnection) ? 'TABLE_CATALOG' : 'TABLE_SCHEMA';
+        $updateLength = fn (string $l) => collect(DB::select("SELECT DISTINCT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_NAME = ? AND $schemaLocName = ?", [$l, DB::connection()->getDatabaseName()]))
+            ->each(fn (\stdClass $sc) => Schema::table($sc->TABLE_NAME ?? $sc->table_name, fn (Blueprint $table) => $table->string($l, 28)->change()));
+
+        $updateLength('primary_locale');
+        $updateLength('locale');
+
+        /**
+         * Convert locales 
+         */
+
+        $localesTable = [
+            "be@cyrillic" => "be",
+            "bs" => "bs_Latn",
+            "fr_FR" => "fr",
+            "nb" => "nb_NO",
+            "sr@cyrillic" => "sr_Cyrl",
+            "sr@latin" => "sr_Latn",
+            "uz@cyrillic" => "uz",
+            "uz@latin" => "uz_Latn",
+            "zh_CN" => "zh_Hans",
+        ];
+        $tableNames = array_merge([
+            'author_settings',
+            'controlled_vocab_entry_settings',
+            'publication_settings',
+            'submission_file_settings',
+            'submission_settings',
+            'submissions',
+        ], Application::get()->getName() === 'omp'
+            ? ['publication_format_settings', 'submission_chapter_settings',]
+            : ['publication_galley_settings', 'publication_galleys',]
+        );
+        collect($tableNames)->each(fn (string $tn) => collect(DB::table($tn)->select('locale')->distinct()->get())->each(function (\stdClass $sc) use ($tn, $localesTable) {
+            if (isset($localesTable[$sc->locale])) {
+                DB::table($tn)->where('locale', '=', $sc->locale)->update(['locale' => $localesTable[$sc->locale]]);
+            }
+        }));
+    }
+
+    /**
+     * Reverse the downgrades
+     */
+    public function down(): void
+    {
+        throw new DowngradeNotSupportedException();
+    }
+}

--- a/classes/publication/Repository.php
+++ b/classes/publication/Repository.php
@@ -133,8 +133,8 @@ abstract class Repository
      */
     public function validate(?Publication $publication, array $props, Submission $submission, Context $context): array
     {
-        $allowedLocales = $context->getSupportedSubmissionLocales();
         $primaryLocale = $submission->getData('locale');
+        $allowedLocales = $submission->getpublicationLanguages($context->getSupportedSubmissionMetadataLocales());
 
         $errors = [];
 
@@ -245,7 +245,7 @@ abstract class Repository
      * wants to enforce particular publishing requirements, such as
      * requiring certain metadata or other information.
      *
-     * @param array $allowedLocales The context's supported submission locales
+     * @param array $allowedLocales The context's supported submission metadata locales
      * @param string $primaryLocale The submission's primary locale
      *
      * @hook Publication::validatePublish [[&$errors, $publication, $submission, $allowedLocales, $primaryLocale]]
@@ -286,7 +286,7 @@ abstract class Repository
                 $submissionContext = Services::get('context')->get($submission->getData('contextId'));
             }
 
-            $supportedLocales = $submissionContext->getSupportedSubmissionLocales();
+            $supportedLocales = $submission->getPublicationLanguages($submissionContext->getSupportedSubmissionMetadataLocales());
             foreach ($supportedLocales as $localeKey) {
                 if (!array_key_exists($localeKey, $publication->getData('coverImage'))) {
                     continue;
@@ -394,7 +394,7 @@ abstract class Repository
                 $submissionContext = Services::get('context')->get($submission->getData('contextId'));
             }
 
-            $supportedLocales = $submissionContext->getSupportedSubmissionLocales();
+            $supportedLocales = $submission->getPublicationLanguages($submissionContext->getSupportedSubmissionMetadataLocales());
             foreach ($supportedLocales as $localeKey) {
                 if (!array_key_exists($localeKey, $params['coverImage'])) {
                     continue;

--- a/classes/services/PKPContextService.php
+++ b/classes/services/PKPContextService.php
@@ -276,9 +276,11 @@ abstract class PKPContextService implements EntityPropertyInterface, EntityReadI
             [
                 'urlPath.regex' => __('admin.contexts.form.pathAlphaNumeric'),
                 'primaryLocale.regex' => __('validator.localeKey'),
+                'supportedDefaultSubmissionLocale.regex' => __('validator.localeKey'),
                 'supportedFormLocales.regex' => __('validator.localeKey'),
                 'supportedLocales.regex' => __('validator.localeKey'),
                 'supportedSubmissionLocales.*.regex' => __('validator.localeKey'),
+                'supportedSubmissionMetadataLocales.*.regex' => __('validator.localeKey'),
             ]
         );
 
@@ -501,8 +503,17 @@ abstract class PKPContextService implements EntityPropertyInterface, EntityReadI
         if (!$context->getData('supportedFormLocales')) {
             $context->setData('supportedFormLocales', [$context->getData('primaryLocale')]);
         }
+        if (!$context->getData('supportedDefaultSubmissionLocale')) {
+            $context->setData('supportedDefaultSubmissionLocale', $context->getData('primaryLocale'));
+        }
+        if (!$context->getData('supportedAddedSubmissionLocales')) {
+            $context->setData('supportedAddedSubmissionLocales', [$context->getData('supportedDefaultSubmissionLocale')]);
+        }
         if (!$context->getData('supportedSubmissionLocales')) {
-            $context->setData('supportedSubmissionLocales', [$context->getData('primaryLocale')]);
+            $context->setData('supportedSubmissionLocales', [$context->getData('supportedDefaultSubmissionLocale')]);
+        }
+        if (!$context->getData('supportedSubmissionMetadataLocales')) {
+            $context->setData('supportedSubmissionMetadataLocales', [$context->getData('supportedDefaultSubmissionLocale')]);
         }
 
         $contextDao->insertObject($context);

--- a/classes/submission/PKPSubmission.php
+++ b/classes/submission/PKPSubmission.php
@@ -32,6 +32,7 @@ use APP\submission\DAO;
 use Illuminate\Support\LazyCollection;
 use PKP\core\Core;
 use PKP\facades\Locale;
+use PKP\i18n\LocaleMetadata;
 
 /**
  * @extends \PKP\core\DataObject<DAO>
@@ -199,6 +200,32 @@ abstract class PKPSubmission extends \PKP\core\DataObject
     public function getDAO(): DAO
     {
         return Repo::submission()->dao;
+    }
+
+    /**
+     * Get metadata language names from publications
+     */
+    public function getPublicationLanguageNames(): array
+    {
+        return (($l = $this->getData('locale')) ? [$l => Locale::getSubmissionLocaleDisplayNames([$l])[$l]] : [])
+            + collect($this->getData('publications'))
+                ->flatMap(fn (Publication $p): array => $p->getLanguageNames())
+                ->toArray();
+    }
+
+    /**
+     * Get metadata languages from publications
+     */
+    public function getPublicationLanguages(?array ...$additionalLanguages): array
+    {
+        return collect([$this->getData('locale')])
+            ->concat($this->getData('publications')->map(fn (Publication $p): array => $p->getLanguages()))
+            ->concat($additionalLanguages)
+            ->flatten()
+            ->filter()
+            ->unique()
+            ->values()
+            ->toArray();
     }
 
     //

--- a/classes/submission/Repository.php
+++ b/classes/submission/Repository.php
@@ -262,8 +262,12 @@ abstract class Repository
      */
     public function validate(?Submission $submission, array $props, Context $context): array
     {
-        $primaryLocale = $props['locale'] ?? $submission?->getData('locale') ?? $context->getPrimaryLocale();
+        $primaryLocale = $props['locale'] ?? $submission?->getData('locale') ?? $context->getSupportedDefaultSubmissionLocale();
         $allowedLocales = $context->getSupportedSubmissionLocales();
+        
+        if (!in_array($primaryLocale, $allowedLocales) ) {
+            $allowedLocales[] = $primaryLocale;
+        }
 
         $errors = [];
 
@@ -382,7 +386,7 @@ abstract class Repository
                 if (!isset($errors['contributors'])) {
                     $errors['contributors'] = [];
                 }
-                $errors['contributors'][] = __('submission.wizard.missingContributorLanguage', ['language' => Locale::getMetadata($locale)->getDisplayName()]);
+                $errors['contributors'][] = __('submission.wizard.missingContributorLanguage', ['language' => Locale::getSubmissionLocaleDisplayNames([$locale])[$locale]]);
                 break;
             }
         }
@@ -555,7 +559,7 @@ abstract class Repository
             $submission->setData('status', Submission::STATUS_QUEUED);
         }
         if (!$submission->getData('locale')) {
-            $submission->setData('locale', $context->getPrimaryLocale());
+            $submission->setData('locale', $context->getSupportedDefaultSubmissionLocale());
         }
         $submissionId = $this->dao->insert($submission);
         $submission = Repo::submission()->get($submissionId);

--- a/classes/submissionFile/Repository.php
+++ b/classes/submissionFile/Repository.php
@@ -109,8 +109,8 @@ abstract class Repository
      * Perform validation checks on data used to add or edit a submission file.
      *
      * @param array $props A key/value array with the new data to validate
-     * @param array $allowedLocales The context's supported locales
-     * @param string $primaryLocale The context's primary locale
+     * @param array $allowedLocales The supported submission metadata locales
+     * @param string $submissionLocale The submission's locale
      *
      * @return array A key/value array with validation errors. Empty if no errors
      *
@@ -120,7 +120,7 @@ abstract class Repository
         ?SubmissionFile $object,
         array $props,
         array $allowedLocales,
-        string $primaryLocale
+        string $submissionLocale
     ): array {
         $validator = ValidatorFactory::make(
             $props,
@@ -135,7 +135,7 @@ abstract class Repository
             $this->schemaService->getRequiredProps($this->dao->schema),
             $this->schemaService->getMultilingualProps($this->dao->schema),
             $allowedLocales,
-            $primaryLocale
+            $submissionLocale
         );
 
         // Check for input from disallowed locales
@@ -248,7 +248,7 @@ abstract class Repository
                 $object,
                 $props,
                 $allowedLocales,
-                $primaryLocale
+                $submissionLocale
             ]
         );
 

--- a/classes/submissionFile/SubmissionFile.php
+++ b/classes/submissionFile/SubmissionFile.php
@@ -16,7 +16,11 @@
 
 namespace PKP\submissionFile;
 
+use APP\core\Services;
 use APP\facades\Repo;
+use PKP\facades\Locale;
+use PKP\i18n\LocaleMetadata;
+use PKP\services\PKPSchemaService;
 
 /**
  * @extends \PKP\core\DataObject<DAO>
@@ -381,6 +385,30 @@ class SubmissionFile extends \PKP\core\DataObject
     public function getDAO(): DAO
     {
         return Repo::submissionFile()->dao;
+    }
+
+    /**
+     * Get metadata language names
+     */
+    public function getLanguageNames(): array
+    {
+        return Locale::getSubmissionLocaleDisplayNames($this->getLanguages());
+    }
+
+    /**
+     * Get metadata languages
+     */
+    public function getLanguages(): array
+    {
+        $props = Services::get('schema')->getMultilingualProps(PKPSchemaService::SCHEMA_SUBMISSION_FILE);
+        $locales = array_map(fn (string $prop): array => array_keys($this->getData($prop) ?? []), $props);
+        return collect([$this->getData('locale')])
+            ->concat($locales)
+            ->flatten()
+            ->filter()
+            ->unique()
+            ->values()
+            ->toArray();
     }
 }
 

--- a/classes/submissionFile/maps/Schema.php
+++ b/classes/submissionFile/maps/Schema.php
@@ -226,10 +226,12 @@ class Schema extends BaseSchema
             $output[$prop] = $submissionFile->getData($prop);
         }
 
+        $locales = Repo::submission()->get($submissionFile->getData('submissionId'))->getPublicationLanguages($this->context->getSupportedSubmissionMetadataLocales(), $submissionFile->getLanguages());
+
         $output = $this->schemaService->addMissingMultilingualValues(
             $this->schema,
             $output,
-            $this->context->getSupportedFormLocales()
+            $locales
         );
 
         ksort($output);

--- a/classes/template/PKPTemplateManager.php
+++ b/classes/template/PKPTemplateManager.php
@@ -752,7 +752,8 @@ class PKPTemplateManager extends Smarty
                 $allLocales = array_merge(
                     $context->getSupportedLocales() ?? [],
                     $context->getSupportedFormLocales() ?? [],
-                    $context->getSupportedSubmissionLocales() ?? []
+                    $context->getSupportedSubmissionLocales() ?? [],
+                    $context->getSupportedSubmissionMetadataLocales() ?? [],
                 );
             } else {
                 $allLocales = $this->_request->getSite()->getSupportedLocales();

--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,14 @@
 	"scripts": {
 		"fix": "PHP_CS_FIXER_IGNORE_ENV=1 ./lib/vendor/bin/php-cs-fixer fix --allow-risky=yes",
 		"post-install-cmd": [
-			"@isoFileCheck"
+			"@isoFileCheck",
+			"@weblateFilesDownload"
 		],
 		"isoFileCheck": [
-			"PKP\\dev\\ComposerScript::isoFileCheck"		]
+			"PKP\\dev\\ComposerScript::isoFileCheck"		],
+		"weblateFilesDownload": [
+			"PKP\\dev\\ComposerScript::weblateFilesDownload"
+		]
 	},
 	"autoload": {
 		"psr-4": {

--- a/controllers/grid/admin/languages/AdminLanguageGridHandler.php
+++ b/controllers/grid/admin/languages/AdminLanguageGridHandler.php
@@ -166,7 +166,7 @@ class AdminLanguageGridHandler extends LanguageGridHandler
         }
 
         if ($this->_canManage($request)) {
-            $data = $this->addManagementData($request, $data);
+            $data = $this->addLocaleSettingData($request, $data);
         }
 
         return $data;
@@ -430,7 +430,8 @@ class AdminLanguageGridHandler extends LanguageGridHandler
         while ($context = $contexts->next()) {
             $params = [];
             $primaryLocale = $context->getPrimaryLocale();
-            foreach (['supportedLocales', 'supportedFormLocales', 'supportedSubmissionLocales'] as $settingName) {
+            $params['supportedDefaultSubmissionLocale'] = $context->getData('supportedDefaultSubmissionLocale');
+            foreach (['supportedLocales', 'supportedFormLocales', 'supportedSubmissionLocales', 'supportedSubmissionMetadataLocales'] as $settingName) {
                 $localeList = $context->getData($settingName);
 
                 if (is_array($localeList)) {

--- a/controllers/grid/languages/LanguageGridCellProvider.php
+++ b/controllers/grid/languages/LanguageGridCellProvider.php
@@ -59,8 +59,14 @@ class LanguageGridCellProvider extends GridCellProvider
             case 'formLocale':
                 return ['selected' => $element['supportedFormLocales'],
                     'disabled' => !$element['supported']];
+            case 'defaultSubmissionLocale':
+                return ['selected' => $element['supportedDefaultSubmissionLocale'],
+                    'disabled' => !$element['supported']];
             case 'submissionLocale':
                 return ['selected' => $element['supportedSubmissionLocales'],
+                    'disabled' => !$element['supported']];
+            case 'submissionMetadataLocale':
+                return ['selected' => $element['supportedSubmissionMetadataLocales'],
                     'disabled' => !$element['supported']];
             default:
                 assert(false);
@@ -128,10 +134,25 @@ class LanguageGridCellProvider extends GridCellProvider
                 $actionArgs['value'] = !$element['supportedFormLocales'];
                 $actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
                 break;
+            case 'defaultSubmissionLocale':
+                $default = $element['supportedDefaultSubmissionLocale'];
+                if (!$default) {
+                    $action = 'setDefaultSubmissionLocale-' . $row->getId();
+                    $actionArgs['setting'] = 'supportedDefaultSubmissionLocale';
+                    $actionArgs['value'] = !$element['supportedDefaultSubmissionLocale'];
+                    $actionRequest = new AjaxAction($router->url($request, null, null, 'setDefaultSubmissionLocale', null, $actionArgs));
+                }
+                break;
             case 'submissionLocale':
                 $action = 'setSubmissionLocale-' . $row->getId();
                 $actionArgs['setting'] = 'supportedSubmissionLocales';
                 $actionArgs['value'] = !$element['supportedSubmissionLocales'];
+                $actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
+                break;
+            case 'submissionMetadataLocale':
+                $action = 'setSubmissionMetadataLocale-' . $row->getId();
+                $actionArgs['setting'] = 'supportedSubmissionMetadataLocales';
+                $actionArgs['value'] = !$element['supportedSubmissionMetadataLocales'];
                 $actionRequest = new AjaxAction($router->url($request, null, null, 'saveLanguageSetting', null, $actionArgs));
                 break;
         }

--- a/controllers/grid/languages/form/AddLanguageForm.php
+++ b/controllers/grid/languages/form/AddLanguageForm.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @file controllers/grid/languages/form/AddLanguageForm.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class AddLanguageForm
+ *
+ * @ingroup controllers_grid_languages_form
+ *
+ * @brief Form for adding languages.
+ */
+
+namespace PKP\controllers\grid\languages\form;
+
+use APP\core\Application;
+use APP\core\Services;
+use APP\template\TemplateManager;
+use PKP\facades\Locale;
+use PKP\form\Form;
+
+class AddLanguageForm extends Form
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct('controllers/grid/languages/addLanguageForm.tpl');
+    }
+
+    //
+    // Overridden methods from Form.
+    //
+    /**
+     * @copydoc Form::initData()
+     */
+    public function initData()
+    {
+        parent::initData();
+        $this->setData('addedLocales', ((Application::get()->getRequest())->getContext())->getSupportedAddedSubmissionLocales());
+    }
+
+    /**
+     * @copydoc Form::fetch()
+     *
+     * @param null|mixed $template
+     */
+    public function fetch($request, $template = null, $display = false)
+    {
+        $templateMgr = TemplateManager::getManager($request);
+        $templateMgr->assign([
+            'availableLocales' => collect(Locale::getSubmissionLocaleDisplayNames())
+                ->map(fn ($name, $localeCode) => "[ $localeCode ] $name"),
+            'addedLocales' => $request->getContext()->getSupportedAddedSubmissionLocales(),
+        ]);
+
+        return parent::fetch($request, $template, $display);
+    }
+
+    /**
+     * @copydoc Form::readInputData()
+     */
+    public function readInputData()
+    {
+        parent::readInputData();
+
+        $request = Application::get()->getRequest();
+        $localesToAdd = $request->getUserVar('localesToAdd');
+        $this->setData('localesToAdd', $localesToAdd);
+    }
+
+    /**
+     * @copydoc Form::execute()
+     */
+    public function execute(...$functionArgs)
+    {
+        $request = Application::get()->getRequest();
+        $context = $request->getContext();
+        $localesToAdd = $this->getData('localesToAdd');
+
+        parent::execute(...$functionArgs);
+
+        if (isset($localesToAdd) && is_array($localesToAdd)) {
+            $locales = array_values(array_filter($localesToAdd, fn (string $locale) => Locale::isSubmissionLocaleValid($locale)));
+
+            if ($locales) {
+                sort($locales);
+
+                $removedLocales = array_values(array_diff($context->getSupportedAddedSubmissionLocales(), $locales));
+                $defaultLocaleRemoved = in_array($context->getSupportedDefaultSubmissionLocale(), $removedLocales);
+
+                $edit = fn (array $ll): array => collect($ll)
+                    ->diff($removedLocales)
+                    ->concat($defaultLocaleRemoved ? [$locales[0]] : [])
+                    ->unique()
+                    ->sort()
+                    ->values()
+                    ->toArray();
+
+                Services::get('context')->edit(
+                    $context,
+                    [
+                        'supportedAddedSubmissionLocales' => $locales,
+                        'supportedSubmissionLocales' => $edit($context->getSupportedSubmissionLocales()),
+                        'supportedSubmissionMetadataLocales' => $edit($context->getSupportedSubmissionMetadataLocales()),
+                        ...($defaultLocaleRemoved ? ['supportedDefaultSubmissionLocale' => $locales[0]] : []),
+                    ],
+                    $request
+                );
+            }
+        }
+    }
+
+    /**
+     * Perform additional validation checks
+     *
+     * @copydoc Form::validate
+     */
+    public function validate($callHooks = true)
+    {
+        $localesToAdd = $this->getData('localesToAdd');
+        if (!isset($localesToAdd) || !is_array($localesToAdd) || !array_filter($localesToAdd, fn (string $locale) => Locale::isSubmissionLocaleValid($locale))) {
+            $this->addError('localesToAdd', __('manager.language.submission.from.error'));
+        }
+        return parent::validate($callHooks);
+    }
+}

--- a/controllers/grid/settings/languages/ManageLanguageGridHandler.php
+++ b/controllers/grid/settings/languages/ManageLanguageGridHandler.php
@@ -75,7 +75,7 @@ class ManageLanguageGridHandler extends LanguageGridHandler
             $data[$locale]['primary'] = ($locale == $contextPrimaryLocale);
         }
 
-        $data = $this->addManagementData($request, $data);
+        $data = $this->addLocaleSettingData($request, $data);
         return $data;
     }
 
@@ -90,6 +90,9 @@ class ManageLanguageGridHandler extends LanguageGridHandler
     public function initialize($request, $args = null)
     {
         parent::initialize($request, $args);
+
+        $this->setTitle('manager.language.websiteLanguages');
+
         $this->addNameColumn();
         $this->addLocaleCodeColumn();
         $this->addPrimaryColumn('contextPrimary');

--- a/controllers/grid/settings/languages/SubmissionLanguageGridHandler.php
+++ b/controllers/grid/settings/languages/SubmissionLanguageGridHandler.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * @file controllers/grid/settings/languages/SubmissionLanguageGridHandler.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class SubmissionLanguageGridHandler
+ *
+ * @ingroup controllers_grid_settings_languages
+ *
+ * @brief Handle language submission grid requests only.
+ */
+
+namespace PKP\controllers\grid\settings\languages;
+
+use APP\core\Request;
+use APP\notification\NotificationManager;
+use PKP\controllers\grid\languages\LanguageGridHandler;
+use PKP\controllers\grid\languages\form\AddLanguageForm;
+use PKP\core\JSONMessage;
+use PKP\core\PKPRequest;
+use PKP\facades\Locale;
+use PKP\linkAction\LinkAction;
+use PKP\linkAction\request\AjaxModal;
+use PKP\notification\PKPNotification;
+use PKP\security\authorization\ContextAccessPolicy;
+use PKP\security\Role;
+
+class SubmissionLanguageGridHandler extends LanguageGridHandler
+{
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->addRoleAssignment(
+            [Role::ROLE_ID_MANAGER, Role::ROLE_ID_SITE_ADMIN],
+            ['addLanguages', 'addLanguageModal', 'fetchGrid', 'fetchRow']
+        );
+    }
+
+
+    //
+    // Implement methods from GridHandler.
+    //
+    /**
+     * @copydoc GridHandler::authorize()
+     */
+    public function authorize($request, &$args, $roleAssignments)
+    {
+        $this->addPolicy(new ContextAccessPolicy($request, $roleAssignments));
+        return parent::authorize($request, $args, $roleAssignments);
+    }
+
+    /**
+     * @copydoc GridHandler::loadData()
+     */
+    protected function loadData($request, $filter)
+    {
+        $context = $request->getContext();
+        $addedLocales = $context->getSupportedAddedSubmissionLocales();
+        $defaultSubmissionLocale = $context->getSupportedDefaultSubmissionLocale();
+        $localeNames = Locale::getSubmissionLocaleDisplayNames($addedLocales);
+
+        $data = [];
+
+        foreach ($addedLocales as $locale) {
+            $data[$locale] = [];
+            $data[$locale]['code'] = $locale;
+            $data[$locale]['name'] = "$localeNames[$locale]/" . Locale::getSubmissionLocaleDisplayNames([$locale], $locale)[$locale];
+            $data[$locale]['supported'] = true;
+            $data[$locale]['supportedDefaultSubmissionLocale'] = ($locale === $defaultSubmissionLocale);
+        }
+
+        $data = $this->addLocaleSettingData($request, $data, ['supportedSubmissionLocales', 'supportedSubmissionMetadataLocales']);
+        return $data;
+    }
+
+    //
+    // Extended methods from LanguageGridHandler.
+    //
+    /**
+     * @copydoc LanguageGridHandler::initialize()
+     *
+     * @param null|mixed $args
+     */
+    public function initialize($request, $args = null): void
+    {
+        parent::initialize($request, $args);
+
+        $this->setTitle('manager.language.submissionLanguages');
+
+        $this->addNameColumn();
+        $this->addLocaleCodeColumn();
+        $this->addPrimaryColumn('defaultSubmissionLocale', 'common.default');
+        $this->addSubmissionColumns();
+
+        // Add grid action.
+        $this->addAction(
+            new LinkAction(
+                'addLanguageModal',
+                new AjaxModal(
+                   ($request->getRouter())->url($request, null, null, 'addLanguageModal', null, null),
+                    __('manager.language.gridAction.addLangauage'),
+                    null,
+                    true,
+                    'addLanguageForm'
+                ),
+                __('manager.language.gridAction.addLangauage')
+            )
+        );
+    }
+
+    /**
+     * Show the add language form.
+     */
+    public function addLanguageModal(array $args, PKPRequest $request): JSONMessage
+    {
+        $addLanguageForm = new AddLanguageForm();
+        $addLanguageForm->initData();
+        return new JSONMessage(true, $addLanguageForm->fetch($request));
+    }
+
+    /**
+     * Add/Remove languages
+     */
+    public function addLanguages(array $args, PKPRequest $request): JSONMessage
+    {
+        $addLanguageForm = new AddLanguageForm();
+        $addLanguageForm->readInputData();
+
+        if ($addLanguageForm->validate()) {
+            $addLanguageForm->execute();
+
+            $notificationManager = new NotificationManager();
+            $user = $request->getUser();
+            $notificationManager->createTrivialNotification(
+                $user->getId(),
+                PKPNotification::NOTIFICATION_TYPE_SUCCESS,
+                ['contents' => __('notification.submissionLocales')]
+            );
+
+            return \PKP\db\DAO::getDataChangedEvent();
+        } else {
+            return new JSONMessage(true, $addLanguageForm->fetch($request));
+        }
+    }
+}

--- a/controllers/wizard/fileUpload/FileUploadWizardHandler.php
+++ b/controllers/wizard/fileUpload/FileUploadWizardHandler.php
@@ -454,13 +454,14 @@ class FileUploadWizardHandler extends Handler
             'primaryLocale' => $this->getSubmission()->getData('locale'),
         ]);
 
+        $context = $request->getContext();
         $submissionFile = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_SUBMISSION_FILE);
         $form = new SubmissionFilesMetadataForm($submissionFile, $this->getStageId(), $this->getReviewRound());
         $form->initData();
 
         /** @var GenreDAO $genreDao */
         $genreDao = DAORegistry::getDAO('GenreDAO');
-        $fileGenres = $genreDao->getByContextId($request->getContext()->getId())->toArray();
+        $fileGenres = $genreDao->getByContextId($context->getId())->toArray();
 
         $fileData = Repo::submissionFile()
             ->getSchemaMap()

--- a/controllers/wizard/fileUpload/form/SubmissionFilesMetadataForm.php
+++ b/controllers/wizard/fileUpload/form/SubmissionFilesMetadataForm.php
@@ -16,6 +16,7 @@
 
 namespace PKP\controllers\wizard\fileUpload\form;
 
+use APP\core\Application;
 use APP\facades\Repo;
 use APP\template\TemplateManager;
 use PKP\db\DAORegistry;
@@ -48,7 +49,14 @@ class SubmissionFilesMetadataForm extends Form
         if ($template === null) {
             $template = 'controllers/wizard/fileUpload/form/submissionFileMetadataForm.tpl';
         }
-        parent::__construct($template);
+
+        $submissionLocale = $submissionFile->getData('locale');
+        $publicationLanguageNames = Repo::submission()->get($submissionFile->getData('submissionId'))->getPublicationLanguageNames();
+
+        $localeNames = Application::get()->getRequest()->getContext()->getSupportedSubmissionMetadataLocaleNames() + $publicationLanguageNames + $submissionFile->getLanguageNames();
+        ksort($localeNames);
+
+        parent::__construct($template, true, $submissionLocale, $localeNames);
 
         // Initialize the object.
         $this->_submissionFile = $submissionFile;
@@ -57,7 +65,6 @@ class SubmissionFilesMetadataForm extends Form
             $this->_reviewRound = $reviewRound;
         }
 
-        $submissionLocale = $submissionFile->getData('locale');
         $this->setDefaultFormLocale($submissionLocale);
 
         // Add validation checks.

--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -586,14 +586,32 @@ msgstr "Image"
 msgid "manager.importExport"
 msgstr "Import/Export Data"
 
+msgid "manager.language.websiteLanguages"
+msgstr "Website Languages"
+
+msgid "manager.language.submissionLanguages"
+msgstr "Submission Languages"
+
 msgid "manager.language.ui"
 msgstr "UI"
 
 msgid "manager.language.submissions"
 msgstr "Submissions"
 
+msgid "manager.language.gridAction.addLangauage"
+msgstr "Add/Remove Languages"
+
 msgid "manager.language.forms"
 msgstr "Forms"
+
+msgid "manager.language.submissionMetadata"
+msgstr "Metadata"
+
+msgid "manager.language.submission.form.description"
+msgstr "Select submission and metadata languages."
+
+msgid "manager.language.submission.from.error"
+msgstr "At least one locale needs to be selected."
 
 msgid "manager.language.reloadLocalizedDefaultSettings"
 msgstr "Reload defaults"
@@ -1636,6 +1654,12 @@ msgid "notification.localeSettingsCannotBeSaved"
 msgstr ""
 "The language setting could not be saved. At least one language must be "
 "enabled for each option"
+
+msgid "notification.defaultLocaleSettingsCannotBeSaved"
+msgstr "The language setting could not be saved. All options need to be enabled."
+
+msgid "notification.submissionLocales"
+msgstr "Submission locales updated."
 
 msgid "notification.editedUser"
 msgstr "User edited."

--- a/schemas/context.json
+++ b/schemas/context.json
@@ -778,6 +778,21 @@
 			"default": false,
 			"description": "Whether or not submitting authors should be asked to select categories when they make a new submission."
 		},
+		"supportedAddedSubmissionLocales": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"validation": [
+					"regex:/^([A-Za-z]{2,4})(?<sc>[_-]([A-Za-z]{4,5}|[0-9]{4}))?([_-]([A-Za-z]{2}|[0-9]{3}))?(@[a-z]{2,30}(?&sc)?)?$/"
+				]
+			}
+		},
+		"supportedDefaultSubmissionLocale": {
+			"type": "string",
+			"validation": [
+				"regex:/^([A-Za-z]{2,4})(?<sc>[_-]([A-Za-z]{4,5}|[0-9]{4}))?([_-]([A-Za-z]{2}|[0-9]{3}))?(@[a-z]{2,30}(?&sc)?)?$/"
+			]
+		},
 		"supportedFormLocales": {
 			"type": "array",
 			"items": {
@@ -801,7 +816,16 @@
 			"items": {
 				"type": "string",
 				"validation": [
-					"regex:/^([a-z]{2})((_[A-Z]{2})?)(@[a-z]{0,})?$/"
+					"regex:/^([A-Za-z]{2,4})(?<sc>[_-]([A-Za-z]{4,5}|[0-9]{4}))?([_-]([A-Za-z]{2}|[0-9]{3}))?(@[a-z]{2,30}(?&sc)?)?$/"
+				]
+			}
+		},
+		"supportedSubmissionMetadataLocales": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"validation": [
+					"regex:/^([A-Za-z]{2,4})(?<sc>[_-]([A-Za-z]{4,5}|[0-9]{4}))?([_-]([A-Za-z]{2}|[0-9]{3}))?(@[a-z]{2,30}(?&sc)?)?$/"
 				]
 			}
 		},

--- a/schemas/submission.json
+++ b/schemas/submission.json
@@ -68,7 +68,7 @@
 			"description": "The primary language of this submission.",
 			"apiSummary": true,
 			"validation": [
-				"regex:/^([a-z]{2})((_[A-Z]{2})?)(@[a-z]{0,})?$/"
+				"regex:/^([A-Za-z]{2,4})(?<sc>[_-]([A-Za-z]{4,5}|[0-9]{4}))?([_-]([A-Za-z]{2}|[0-9]{3}))?(@[a-z]{2,30}(?&sc)?)?$/"
 			]
 		},
 		"publications": {

--- a/templates/admin/contextSettings.tpl
+++ b/templates/admin/contextSettings.tpl
@@ -38,6 +38,8 @@
 				<tab id="languages" label="{translate key="common.languages"}">
 					{capture assign=languagesUrl}{url router=\PKP\core\PKPApplication::ROUTE_COMPONENT context=$editContext->getPath() component="grid.settings.languages.ManageLanguageGridHandler" op="fetchGrid" escape=false}{/capture}
 					{load_url_in_div id="languageGridContainer" url=$languagesUrl}
+					{capture assign=submissionLanguagesUrl}{url router=\PKP\core\PKPApplication::ROUTE_COMPONENT context=$editContext->getPath() component="grid.settings.languages.SubmissionLanguageGridHandler" op="fetchGrid" escape=false}{/capture}
+					{load_url_in_div id="submissionLanguageGridContainer" url=$submissionLanguagesUrl}
 				</tab>
 				<tab id="indexing" label="{translate key="manager.setup.searchEngineIndexing"}">
 					<pkp-form

--- a/templates/controllers/grid/languages/addLanguageForm.tpl
+++ b/templates/controllers/grid/languages/addLanguageForm.tpl
@@ -1,0 +1,35 @@
+{**
+ * templates/controllers/grid/languages/addLanguageForm.tpl
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * Form to add languages.
+ *}
+
+<script>
+	$(function() {ldelim}
+		// Attach the form handler.
+		$('#addLanguageForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
+	{rdelim});
+</script>
+
+<form class="pkp_form" id="addLanguageForm" method="post" action="{url router=\PKP\core\PKPApplication::ROUTE_COMPONENT component="grid.settings.languages.SubmissionLanguageGridHandler" op="addLanguages"}">
+	{csrf}
+	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="installLanguageFormNotification"}
+
+	{fbvFormArea id="availableLocalesFormArea" title="admin.languages.availableLocales"}
+		{fbvFormSection list="true" description="manager.language.submission.form.description"}
+			{foreach $availableLocales as $locale => $name}
+				{fbvElement type="checkbox" id="locale-$locale" name="localesToAdd[$locale]" value=$locale label=$name|unescape:"html" translate=false checked=in_array($locale, $addedLocales)}
+			{foreachelse}
+				<p>{translate key="admin.languages.noLocalesAvailable"}</p>
+			{/foreach}
+		{/fbvFormSection}
+	{/fbvFormArea}
+
+	{if not empty($availableLocales)}
+		{fbvFormButtons id="installLanguageFormSubmit" submitText="common.save"}
+	{/if}
+</form>

--- a/templates/management/website.tpl
+++ b/templates/management/website.tpl
@@ -70,6 +70,8 @@
 				<tab id="languages" label="{translate key="common.languages"}">
 					{capture assign=languagesUrl}{url router=\PKP\core\PKPApplication::ROUTE_COMPONENT component="grid.settings.languages.ManageLanguageGridHandler" op="fetchGrid" escape=false}{/capture}
 					{load_url_in_div id="languageGridContainer" url=$languagesUrl}
+					{capture assign=submissionLanguagesUrl}{url router=\PKP\core\PKPApplication::ROUTE_COMPONENT component="grid.settings.languages.SubmissionLanguageGridHandler" op="fetchGrid" escape=false}{/capture}
+					{load_url_in_div id="submissionLanguageGridContainer" url=$submissionLanguagesUrl}
 				</tab>
 				<tab id="navigationMenus" label="{translate key="manager.navigationMenus"}">
 					{capture assign=navigationMenusGridUrl}{url router=\PKP\core\PKPApplication::ROUTE_COMPONENT component="grid.navigationMenus.NavigationMenusGridHandler" op="fetchGrid" escape=false}{/capture}


### PR DESCRIPTION
- In Website Settings > Setup > Languages and in Administration > Hosted Journals > Settings Wizard > Journal Settings > Languages, separate Website Languages and Submission Languages settings. In the website languages are UI and Forms, and in the submission languages  are submission and metadata.
- Submission metadata can be edited even if metadata isn't checked in that language  in the settings.