### PR TITLE
Remove separate Dublin Core Language metadata field and only use Submission Locale to define the language

### DIFF
--- a/api/v1/vocabs/PKPVocabController.php
+++ b/api/v1/vocabs/PKPVocabController.php
@@ -34,7 +34,6 @@ use PKP\security\Role;
 use PKP\submission\SubmissionAgencyDAO;
 use PKP\submission\SubmissionDisciplineDAO;
 use PKP\submission\SubmissionKeywordDAO;
-use PKP\submission\SubmissionLanguageDAO;
 use PKP\submission\SubmissionSubjectDAO;
 use Stringy\Stringy;
 
@@ -127,16 +126,6 @@ class PKPVocabController extends PKPBaseController
                 $submissionDisciplineEntryDao = DAORegistry::getDAO('SubmissionDisciplineEntryDAO'); /** @var \PKP\submission\SubmissionDisciplineEntryDAO $submissionDisciplineEntryDao */
                 $entries = $submissionDisciplineEntryDao->getByContextId($vocab, $context->getId(), $locale, $term)->toArray();
                 break;
-            case SubmissionLanguageDAO::CONTROLLED_VOCAB_SUBMISSION_LANGUAGE:
-                $words = array_filter(PKPString::regexp_split('/\s+/', $term), 'strlen');
-                $languageNames = [];
-                foreach (Locale::getLanguages() as $language) {
-                    if ($language->getAlpha2() && $language->getType() === 'L' && $language->getScope() === 'I' && Stringy::create($language->getLocalName())->containsAny($words, false)) {
-                        $languageNames[] = $language->getLocalName();
-                    }
-                }
-                asort($languageNames);
-                return response()->json($languageNames, Response::HTTP_OK);
             case SubmissionAgencyDAO::CONTROLLED_VOCAB_SUBMISSION_AGENCY:
                 $submissionAgencyEntryDao = DAORegistry::getDAO('SubmissionAgencyEntryDAO'); /** @var \PKP\submission\SubmissionAgencyEntryDAO $submissionAgencyEntryDao */
                 $entries = $submissionAgencyEntryDao->getByContextId($vocab, $context->getId(), $locale, $term)->toArray();

--- a/classes/components/forms/context/PKPMetadataSettingsForm.php
+++ b/classes/components/forms/context/PKPMetadataSettingsForm.php
@@ -82,19 +82,6 @@ class PKPMetadataSettingsForm extends FormComponent
                 ],
                 'value' => $context->getData('disciplines') ? $context->getData('disciplines') : Context::METADATA_DISABLE,
             ]))
-            ->addField(new FieldMetadataSetting('languages', [
-                'label' => __('common.languages'),
-                'description' => __('manager.setup.metadata.languages.description'),
-                'options' => [
-                    ['value' => Context::METADATA_ENABLE, 'label' => __('manager.setup.metadata.languages.enable')]
-                ],
-                'submissionOptions' => [
-                    ['value' => Context::METADATA_ENABLE, 'label' => __('manager.setup.metadata.languages.noRequest')],
-                    ['value' => Context::METADATA_REQUEST, 'label' => __('manager.setup.metadata.languages.request')],
-                    ['value' => Context::METADATA_REQUIRE, 'label' => __('manager.setup.metadata.languages.require')],
-                ],
-                'value' => $context->getData('languages') ? $context->getData('languages') : Context::METADATA_DISABLE,
-            ]))
             ->addField(new FieldMetadataSetting('agencies', [
                 'label' => __('submission.supportingAgencies'),
                 'description' => __('manager.setup.metadata.agencies.description'),

--- a/classes/components/forms/publication/PKPMetadataForm.php
+++ b/classes/components/forms/publication/PKPMetadataForm.php
@@ -24,7 +24,6 @@ use PKP\context\Context;
 use PKP\submission\SubmissionAgencyDAO;
 use PKP\submission\SubmissionDisciplineDAO;
 use PKP\submission\SubmissionKeywordDAO;
-use PKP\submission\SubmissionLanguageDAO;
 use PKP\submission\SubmissionSubjectDAO;
 
 define('FORM_METADATA', 'metadata');
@@ -82,17 +81,6 @@ class PKPMetadataForm extends FormComponent
                 'apiUrl' => str_replace('__vocab__', SubmissionDisciplineDAO::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, $suggestionUrlBase),
                 'locales' => $this->locales,
                 'value' => (array) $publication->getData('disciplines'),
-            ]));
-        }
-
-        if ($this->enabled('languages')) {
-            $this->addField(new FieldControlledVocab('languages', [
-                'label' => __('common.languages'),
-                'tooltip' => __('manager.setup.metadata.languages.description'),
-                'isMultilingual' => true,
-                'apiUrl' => str_replace('__vocab__', SubmissionLanguageDAO::CONTROLLED_VOCAB_SUBMISSION_LANGUAGE, $suggestionUrlBase),
-                'locales' => $this->locales,
-                'value' => (array) $publication->getData('languages'),
             ]));
         }
 

--- a/classes/context/Context.php
+++ b/classes/context/Context.php
@@ -561,7 +561,6 @@ abstract class Context extends \PKP\core\DataObject
             'dataAvailability',
             'disciplines',
             'keywords',
-            'languages',
             'rights',
             'source',
             'subjects',

--- a/classes/core/PKPApplication.php
+++ b/classes/core/PKPApplication.php
@@ -510,8 +510,6 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider
             'SubmissionDisciplineEntryDAO' => 'PKP\submission\SubmissionDisciplineEntryDAO',
             'SubmissionEmailLogDAO' => 'PKP\log\SubmissionEmailLogDAO',
             'QueryDAO' => 'PKP\query\QueryDAO',
-            'SubmissionLanguageDAO' => 'PKP\submission\SubmissionLanguageDAO',
-            'SubmissionLanguageEntryDAO' => 'PKP\submission\SubmissionLanguageEntryDAO',
             'SubmissionKeywordDAO' => 'PKP\submission\SubmissionKeywordDAO',
             'SubmissionKeywordEntryDAO' => 'PKP\submission\SubmissionKeywordEntryDAO',
             'SubmissionSubjectDAO' => 'PKP\submission\SubmissionSubjectDAO',
@@ -710,7 +708,6 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider
     {
         return [
             'coverage',
-            'languages',
             'rights',
             'source',
             'subjects',

--- a/classes/install/Installer.php
+++ b/classes/install/Installer.php
@@ -1109,7 +1109,6 @@ class Installer
 
         $metadataSettings = [
             'coverage',
-            'languages',
             'rights',
             'source',
             'subjects',

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -26,7 +26,6 @@ use PKP\services\PKPSchemaService;
 use PKP\submission\SubmissionAgencyDAO;
 use PKP\submission\SubmissionDisciplineDAO;
 use PKP\submission\SubmissionKeywordDAO;
-use PKP\submission\SubmissionLanguageDAO;
 use PKP\submission\SubmissionSubjectDAO;
 
 /**
@@ -59,9 +58,6 @@ class DAO extends EntityDAO
     /** @var SubmissionDisciplineDAO */
     public $submissionDisciplineDao;
 
-    /** @var SubmissionLanguageDAO */
-    public $submissionLanguageDao;
-
     /** @var SubmissionAgencyDAO */
     public $submissionAgencyDao;
 
@@ -75,7 +71,6 @@ class DAO extends EntityDAO
         SubmissionKeywordDAO $submissionKeywordDao,
         SubmissionSubjectDAO $submissionSubjectDao,
         SubmissionDisciplineDAO $submissionDisciplineDao,
-        SubmissionLanguageDAO $submissionLanguageDao,
         SubmissionAgencyDAO $submissionAgencyDao,
         CitationDAO $citationDao,
         PKPSchemaService $schemaService
@@ -85,7 +80,6 @@ class DAO extends EntityDAO
         $this->submissionKeywordDao = $submissionKeywordDao;
         $this->submissionSubjectDao = $submissionSubjectDao;
         $this->submissionDisciplineDao = $submissionDisciplineDao;
-        $this->submissionLanguageDao = $submissionLanguageDao;
         $this->submissionAgencyDao = $submissionAgencyDao;
         $this->citationDao = $citationDao;
     }
@@ -415,7 +409,6 @@ class DAO extends EntityDAO
         $publication->setData('keywords', $this->submissionKeywordDao->getKeywords($publication->getId()));
         $publication->setData('subjects', $this->submissionSubjectDao->getSubjects($publication->getId()));
         $publication->setData('disciplines', $this->submissionDisciplineDao->getDisciplines($publication->getId()));
-        $publication->setData('languages', $this->submissionLanguageDao->getLanguages($publication->getId()));
         $publication->setData('supportingAgencies', $this->submissionAgencyDao->getAgencies($publication->getId()));
     }
 
@@ -434,7 +427,6 @@ class DAO extends EntityDAO
         $controlledVocabKeyedArray = array_flip([
             'disciplines',
             'keywords',
-            'languages',
             'subjects',
             'supportingAgencies',
         ]);
@@ -464,9 +456,6 @@ class DAO extends EntityDAO
                 case 'disciplines':
                     $this->submissionDisciplineDao->insertDisciplines($value, $publicationId);
                     break;
-                case 'languages':
-                    $this->submissionLanguageDao->insertLanguages($value, $publicationId);
-                    break;
                 case 'supportingAgencies':
                     $this->submissionAgencyDao->insertAgencies($value, $publicationId);
                     break;
@@ -482,7 +471,6 @@ class DAO extends EntityDAO
         $this->submissionKeywordDao->insertKeywords([], $publicationId);
         $this->submissionSubjectDao->insertSubjects([], $publicationId);
         $this->submissionDisciplineDao->insertDisciplines([], $publicationId);
-        $this->submissionLanguageDao->insertLanguages([], $publicationId);
         $this->submissionAgencyDao->insertAgencies([], $publicationId);
     }
 

--- a/classes/submission/SubmissionLanguage.php
+++ b/classes/submission/SubmissionLanguage.php
@@ -12,6 +12,8 @@
  * @ingroup submission
  *
  * @see SubmissionLanguageEntryDAO
+ * 
+ * @deprecated 3.5
  *
  * @brief Basic class describing a submission language
  */

--- a/classes/submission/SubmissionLanguageDAO.php
+++ b/classes/submission/SubmissionLanguageDAO.php
@@ -12,6 +12,8 @@
  * @ingroup submission
  *
  * @see Submission
+ * 
+ * @deprecated 3.5
  *
  * @brief Operations for retrieving and modifying a submission's assigned languages
  */

--- a/classes/submission/SubmissionLanguageEntryDAO.php
+++ b/classes/submission/SubmissionLanguageEntryDAO.php
@@ -12,6 +12,8 @@
  * @ingroup submission
  *
  * @see Submission
+ * 
+ * @deprecated 3.5
  *
  * @brief Operations for retrieving and modifying a submission's languages
  */

--- a/controllers/modals/submission/ViewSubmissionMetadataHandler.php
+++ b/controllers/modals/submission/ViewSubmissionMetadataHandler.php
@@ -81,9 +81,6 @@ class ViewSubmissionMetadataHandler extends handler
         if ($publication->getLocalizedData('agencies')) {
             $additionalMetadata[] = [__('submission.agencies'), implode(', ', $publication->getLocalizedData('agencies'))];
         }
-        if ($publication->getLocalizedData('languages')) {
-            $additionalMetadata[] = [__('common.languages'), implode(', ', $publication->getLocalizedData('languages'))];
-        }
 
         $templateMgr->assign('additionalMetadata', $additionalMetadata);
 

--- a/locale/ar/manager.po
+++ b/locale/ar/manager.po
@@ -2026,23 +2026,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "ينبغي على المؤلف اقتراح الكلمات المفتاحية قبل حصوله على موافقة طلب التقديم."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"اللغة تعني اللغة الأساسية التي كُتب بها العمل وهي تكون بصيغة رمز اللغة (\"ar"
-"\") مع ترميز اختياري يمثل الدولة (\"ar_IQ\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "تمكين البيانات الوصفية للغة"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "لا تطالب المؤلف بلغة العمل خلال مرحلة التقديم."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "أطلب من المؤلف تحديد لغة العمل خلال مرحلة التقديم."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr "ينبغي على المؤلف تحديد لغة العمل قبل حصوله على موافقة طلب التقديم."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "أية حقوق محفوظة يتضمنها طلب التقديم، والتي قد تشمل حقوق الملكية الفكرية، "

--- a/locale/az/manager.po
+++ b/locale/az/manager.po
@@ -965,9 +965,6 @@ msgstr "Əhatə metadatalarını aktivləşdirin"
 msgid "manager.setup.metadata.keywords.enable"
 msgstr "Açar söz metadatalarını aktivləşdirin"
 
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Dil metadatalarını aktivləşdirin"
-
 msgid "manager.setup.metadata.rights.enable"
 msgstr "Hüquqlar metadatasını aktivləşdirin"
 
@@ -2796,23 +2793,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Müəllifin təqdimatını qəbul etməzdən əvvəl açar sözlər tövsiyə etməsini "
 "istəyin"
-
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Dil, çalışmanın əsas dilini, istəyə bağlı bir ölkə kodu ilə (\"en_US\") bir "
-"dil kodu (\"en\") istifadə edərək göstərin."
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Təqdimat əsnasında müəllifdən təqdimatının dilini tələb etməyin"
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Müəllifdən təqdimat əsnasında namizəd məqalənin dilini qeyd etməsini istəyin"
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Müəllifin təqdimatını qəbul etməzdən əvvəl təqdimat dillərini daxil etməsini "
-"istəyin."
 
 msgid "manager.setup.metadata.rights.description"
 msgstr ""

--- a/locale/be@cyrillic/manager.po
+++ b/locale/be@cyrillic/manager.po
@@ -1788,21 +1788,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/bg/manager.po
+++ b/locale/bg/manager.po
@@ -2132,29 +2132,6 @@ msgstr ""
 "Изискайте от автора да предложи ключови думи, преди да приемете подадените "
 "материали."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Езикът указва основния език на произведението, използвайки езиков код („en“) "
-"с незадължителен код на държавата („en_US“)."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Активиране на езикови метаданни"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Не изисквайте езиците на материала от автора по време на подаването на "
-"материали."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Изисквайте езиците на материала от автора по време на подаването на "
-"материали."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Изисквайте от автора да въведе езиците на материала, преди да приемете "
-"подаването на материали."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Всички права, притежавани върху подадените материали, което може да включва "

--- a/locale/bs/manager.po
+++ b/locale/bs/manager.po
@@ -1847,21 +1847,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/ca/manager.po
+++ b/locale/ca/manager.po
@@ -2034,28 +2034,6 @@ msgstr ""
 "Sol·licitar als autors/es que proposin paraules clau abans d'acceptar la "
 "seva tramesa."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"L'idioma indica que l'idioma principal de l'obra utilitza un codi d'idioma "
-"(\"en\") amb un codi opcional de país (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Habilitar les metadades d'idioma"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"No sol·licitar els idiomes de la tramesa a l'autor/a durant la tramesa."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Sol·licitar a l'autor/a que indiqui els idiomes de la tramesa durant la "
-"tramesa."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Sol·licitar a l'autor que introdueixi els idiomes de la tramesa abans "
-"d'acceptar la seva tramesa."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Qualsevol dret sobre la tramesa, que pot incloure drets de propietat "

--- a/locale/ckb/manager.po
+++ b/locale/ckb/manager.po
@@ -1838,21 +1838,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/cs/manager.po
+++ b/locale/cs/manager.po
@@ -2067,23 +2067,6 @@ msgstr "Požádejte autora, aby při odesílání příspěvku navrhl klíčová
 msgid "manager.setup.metadata.keywords.require"
 msgstr "Před přijetím příspěvku požádejte autora, aby navrhl klíčová slova."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Jazyk označuje primární pracovní jazyk pomocí kódu jazyka (např. „en“) s "
-"volitelným kódem země (např. „en_US“)."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Povolit jazyková metadata"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Během odesílání nevyžadujte od autora jazyky příspěvku."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Požádejte autora, aby během podání uvedl jazyky příspěvku."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr "Před přijetím požádejte autora, aby zadal jazyky příspěvku."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Jakákoli práva k příspěvku, která mohou zahrnovat práva duševního "

--- a/locale/da/manager.po
+++ b/locale/da/manager.po
@@ -2099,25 +2099,6 @@ msgstr ""
 "Kræv at forfatteren foreslår nøgleord, før vedkommende kan acceptere "
 "indsendelsen."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Sprog angiver værkets primære sprog ved hjælp af en sprogkode (\"en\") med "
-"en valgfri landekode (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Aktivér sprogmetadata"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Anmod ikke om indsendelsens sprog fra forfatteren under indsendelse."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Bed forfatteren om at angive indsendelsens sprog under indsendelse."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Kræv at forfatteren indtaster indsendelsens sprog, før vedkommende kan "
-"acceptere indsendelsen."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Eventuelle rettigheder over indsendelsen, som kan omfatte intellektuel "

--- a/locale/de/manager.po
+++ b/locale/de/manager.po
@@ -2154,24 +2154,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Vor Annahme der Einreichung Angaben zu Schlagworten von Autor/in verlangen."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Sprache weist die Hauptsprache der Arbeit aus, indem ein Sprachcode (\"de\") "
-"mit einem optionalen Ländercode (\"de_DE\") verwendet wird."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Metadaten für Sprache aktivieren"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Bei der Einreichung keine Angabe zur Sprache von Autor/in erfragen."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Autor/in bei der Einreichung um Angaben zur Sprache bitten."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Vor Annahme der Einreichung Angaben zur Sprache von Autor/in verlangen."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Alle Rechte an diesem Beitrag einschließlich Schutz- und Urheberrechten "

--- a/locale/el/manager.po
+++ b/locale/el/manager.po
@@ -2025,28 +2025,6 @@ msgstr ""
 "Απαιτείστε από τον συγγραφέα να προτείνει λέξεις-κλειδιά πριν αποδεχτείτε "
 "την υποβολή του."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Η Γλώσσα υποδεικνύει την κύρια γλώσσα του έργου χρησιμοποιώντας έναν κωδικό "
-"γλώσσας (\"en\") με έναν προαιρετικό κωδικό χώρας (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Ενεργοποίηση μεταδεδομένων γλώσσας"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Μην ζητήσετε τις γλώσσες της υποβολής από τον συντάκτη κατά την υποβολή."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Ζητήστε από τον συγγραφέα να δηλώσει τις γλώσσες της υποβολής κατά την "
-"υποβολή."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Απαιτήστε από τον συγγραφέα να εισαγάγει τις γλώσσες της υποβολής πριν "
-"αποδεχτείτε την υποβολή τους."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Οποιαδήποτε δικαιώματα διατηρούνται κατά την υποβολή, τα οποία μπορεί να "

--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -2047,27 +2047,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Require the author to suggest keywords before accepting their submission."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Language indicates the work's primary language using a language code (\"en"
-"\") with an optional country code (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Enable language metadata"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Do not request the submission's languages from the author during submission."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Ask the author to indicate the submission's languages during submission."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Require the author to enter the submission's languages before accepting "
-"their submission."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Any rights held over the submission, which may include Intellectual Property "

--- a/locale/es/manager.po
+++ b/locale/es/manager.po
@@ -2131,26 +2131,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Exigir al autor/a que proponga palabras clave antes de aceptar su envío."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"El idioma indica que el idioma principal de la obra utiliza un código de "
-"idioma (\"en\") con un código de país opcional (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Habilitar los metadatos de idioma"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "No solicitar los idiomas del envío al autor/a durante el envío."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Solicitar al autor/a que indique los idiomas de envío durante el envío."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Exigir al autor/a que introduzca los idiomas de envío antes de aceptar su "
-"envío."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Cualquier derecho sobre el envío, que puede incluir derechos de propiedad "

--- a/locale/eu/manager.po
+++ b/locale/eu/manager.po
@@ -1864,21 +1864,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/fa/manager.po
+++ b/locale/fa/manager.po
@@ -1893,21 +1893,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/fi/manager.po
+++ b/locale/fi/manager.po
@@ -2098,23 +2098,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Vaadi kirjoittajalta avainsanoja käsikirjoituksen lähetyksen yhteydessä."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Kieli ilmaisee työn pääasiallisen kielen. Käytä muotoa \"fi, en\" tai "
-"\"fi_FI, en_US\"."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Ota kieltä koskeva kuvailutieto käyttöön"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Älä kysy kirjoittajalta lähetettävän käsikirjoituksen kieltä."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Kysy kirjoittajalta lähetettävän käsikirjoituksen kieli."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr "Vaadi kirjoittajalta lähetettävän käsikirjoituksen kieli."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Kaikki käsikirjoitukseen liittyvät immateriaalioikeudet, tekijänoikeudet ja "

--- a/locale/fr_CA/manager.po
+++ b/locale/fr_CA/manager.po
@@ -2170,29 +2170,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Obliger l'auteur-e à suggérer des mots-clés avant d'accepter sa soumission."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"La langue indique la langue principale de l'œuvre à l'aide d'un code de "
-"langue (« en ») avec, facultativement, un code de pays (« en_US »)."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Activer la métadonnée « Langue »"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Ne pas demander la,les langue-s du document à l'auteur-e pendant la "
-"soumission."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Demander à l'auteur-e d'indiquer la,les langues du document soumis au moment "
-"de la soumission."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Obliger l'auteur-e à entrer la,les langue-s du document soumis avant "
-"d'accepter sa soumission."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Tous les droits détenus sur la soumission, lesquels peuvent inclure les "

--- a/locale/fr_FR/manager.po
+++ b/locale/fr_FR/manager.po
@@ -2160,29 +2160,6 @@ msgstr ""
 "Exiger de l'auteure ou de l'auteur qu'il suggère des mots-clés avant "
 "d'accepter la soumission."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"La langue indique la langue principale du travail à l'aide d'un code de "
-"langue (« fr ») avec un code de pays facultatif (« fr_FR »)."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Activer la métadonnée de langue"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Ne pas demander les langues de soumission à l'auteur ou l'auteure lors de la "
-"soumission."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Demander à l'auteure ou l'auteur qu'il indique les langues du document lors "
-"de la soumission."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Exiger de l'auteure ou de l'auteur qu'il entre les langues du document avant "
-"d'accepter la soumission."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Tous les droits détenus sur la soumission, qui peuvent inclure les droits de "

--- a/locale/gd/manager.po
+++ b/locale/gd/manager.po
@@ -1788,21 +1788,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/gl/manager.po
+++ b/locale/gl/manager.po
@@ -2012,24 +2012,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Esixir ao autor que suxira palabras clave antes de aceptar a seu envío."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"O idioma indica o idioma principal da obra empregando un código de idioma "
-"(\"en\") cun código de país opcional (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Habilitar os metadatos do idioma"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Non solicite ao autor os idiomas durante o envío."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Pedirlle ao autor que indique os idiomas durante o envío."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Esixirlle ao autor que introduza os idiomas do envío antes de aceptalo."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Calquera dereito sobre o envío, que pode incluír Dereitos de Propiedade "

--- a/locale/he/manager.po
+++ b/locale/he/manager.po
@@ -1788,21 +1788,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/hi/manager.po
+++ b/locale/hi/manager.po
@@ -1801,21 +1801,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/hr/manager.po
+++ b/locale/hr/manager.po
@@ -2067,23 +2067,6 @@ msgstr ""
 "Zatražite od autora da predloži ključne riječi prije nego što prihvati "
 "njihovo podnošenje."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Jezik označava primarni jezik djela upotrebom jezičnog koda (\"hr\") s "
-"neobaveznim kodom zemlje (\"he_HR\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Omogući jezične metapodatke"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Prilikom podnošenja ne tražite jezik autora."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Zatražite od autora informacije o jeziku prilikom podnošenja."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr "Zamolite autora da tijekom slanja navede jezike podneska."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Sva prava nad podneskom, koja mogu uključivati prava intelektualnog "

--- a/locale/hu/manager.po
+++ b/locale/hu/manager.po
@@ -1994,27 +1994,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "A beküldés elfogadásának feltétele, hogy a szerző kulcsszavakat adjon meg."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"A nyelv az anyag elsődleges nyelvét jelzik egy nyelvi kóddal (\"en\") és az "
-"opcionális országkóddal (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Nyelvi metaadatok engedélyezése"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"A benyújtás során ne kérje a szerzőtől a benyújtás nyelveinek megadását."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Kérje meg a szerzőt, hogy a benyújtás során jelölje meg a beadvány nyelveit."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"A beküldés elfogadásának feltétele, hogy a szerző megadja a beküldési "
-"nyelveket."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "A benyújtás kapcsán fennálló jogok, amelyek magukban foglalhatják a szellemi "

--- a/locale/hy/manager.po
+++ b/locale/hy/manager.po
@@ -2098,24 +2098,6 @@ msgstr ""
 "Հեղինակից պահանջեք բանալի բառեր առաջարկել նախքան դրանց ներկայացումն "
 "ընդունելը:"
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Լեզուն ցույց է տալիս ստեղծագործության հիմնական լեզուն՝ օգտագործելով լեզվի "
-"կոդը («en») և ընտրովի երկրի կոդը («en_US»):"
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Միացնել լեզվի մետատվյալները"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Ներկայացման ընթացքում հեղինակից մի պահանջեք ներկայացման լեզուները:"
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Խնդրեք հեղինակին ներկայացնել ներկայացման լեզուները:"
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Հեղինակից պահանջեք մուտքագրել ներկայացման լեզուները՝ նախքան դրանք ընդունելը:"
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Ներկայացման նկատմամբ պահպանվող ցանկացած իրավունք, որը կարող է ներառել մտավոր "

--- a/locale/id/manager.po
+++ b/locale/id/manager.po
@@ -1982,29 +1982,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Mewajibkan penulis untuk menyarankan kata kunci sebelum naskahnya diterima."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Bahasa menunjukkan bahasa utama yang digunakan dalam naskah yang berupa kode "
-"bahasa (\"en\") dengan pilihan kode negara (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Aktifkan metadata bahasa"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Jangan meminta penulis mencantumkan bahasa yang digunakan dalam naskah saat "
-"menyerahkannya."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Minta penulis untuk mencantumkan bahasa yang digunakan naskah saat "
-"mengirimnya ke jurnal."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Minta penulis untuk memasukkan bahasa yang digunakan dalam naskah sebelum "
-"menerima naskahnya."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Semua hak yang menyertai naskah, yang mungkin mencakupi Hak Kekayaan "

--- a/locale/is/manager.po
+++ b/locale/is/manager.po
@@ -1976,26 +1976,6 @@ msgstr ""
 "Krefjast þess að höfundur leggi til lykilorð áður en viðkomandi samþykkir "
 "innsendingu."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Tungumál gefur til kynna aðaltungumál verks með því að nota "
-"tungumálakóða(\"en\"), mögulega með lengri landakóða (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Virkja tungumál lýsigagna"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Ekki biðja höfund um tungumál handrits á meðan á innsendingu stendur."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Biðja höfund um að tilgreina tungumál handrits á meðan á innsendingu stendur."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Krefjast þess að höfundur gefi upp tungumál handrits áður en viðkomandi "
-"samþykkir innsendinguna."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Öll réttindi sem hvíla á handritinu, t.d. hugverkaréttur, höfundaréttur og "

--- a/locale/it/manager.po
+++ b/locale/it/manager.po
@@ -2031,29 +2031,6 @@ msgstr ""
 "Richiedere agli autori di suggerire parole chiave prima di accettare la "
 "sottomissione."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"La lingua indica la lingua principale di un articolo utilizzando un codice "
-"di lingua (\"en\") con un codice di nazionale opzionale (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Abilitare i metadata di lingua"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Non richiedere le lingue di sottomissione agli autori in fase di "
-"sottomissione."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Chiedere agli autori di indicare la lingua del manoscritto in fase di "
-"sottomissione."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Chiedere agli autori di indicare la lingua del manoscritto prima di "
-"accettare la sottomissione."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Diritti detenuti sul manoscritto: potrebbero essere diritti di proprietà "

--- a/locale/ja/manager.po
+++ b/locale/ja/manager.po
@@ -1954,23 +1954,6 @@ msgstr "投稿時に著者にキーワードを提案してもらう。"
 msgid "manager.setup.metadata.keywords.require"
 msgstr "投稿を受け付ける前に、著者にキーワードの提案を求める。"
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"言語は、作品の主要言語を言語コード（\"ja\"）と国コード（\"ja_JP\"）で表しま"
-"す。"
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "言語メタデータの有効化"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "投稿中に著者に投稿言語を要求しない。"
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "投稿時に投稿言語を記入してもらう。"
-
-msgid "manager.setup.metadata.languages.require"
-msgstr "投稿を受け付ける前に、著者に投稿言語の入力を求める。"
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "知的財産権（IPR）、著作権、様々な財産権を含む、投稿物に対して保持されているあ"

--- a/locale/ka/manager.po
+++ b/locale/ka/manager.po
@@ -2033,24 +2033,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "ავტორს მოსთხოვეთ შესთავაზოს საკვანძო სიტყვები, სანამ მიიღებს წარდგენას."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"ენა მიუთითებს ნაწარმოების ძირითად ენაზე ენის კოდის (\"en\") გამოყენებით, "
-"ქვეყნის არასავალდებულო კოდით (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "ენების მეტამონაცემების ჩართვა"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "არ მოითხოვოთ წარდგენის ენები ავტორისგან წარდგენის დროს."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "სთხოვეთ ავტორს წარდგენის დროს მიუთითოს წარდგენის ენები."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"მოითხოვეთ ავტორი შეიტანოს წარდგენის ენები, სანამ მიიღებს მათ წარდგენას."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "წარდგენისას დაცულია ნებისმიერი უფლებები, რომელიც შეიძლება მოიცავდეს "

--- a/locale/kk/manager.po
+++ b/locale/kk/manager.po
@@ -2027,25 +2027,6 @@ msgstr ""
 "Автордан өз материалын қабылдамас бұрын кілт сөздерді міндетті түрде "
 "көрсетуін талап етіңіз."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Тіл тіл кодын («ru»), одан кейін қосымша ел кодын («ru_RU») пайдалана "
-"отырып, негізгі жұмыс тілін көрсетеді."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Метадеректерге тілді қосыңыз"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Өтініш беру кезінде автордан материалдың тілдерін сұрамаңыз."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Автордан материалды жіберу кезінде олардың тілдерін көрсетуін сұраңыз."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Осы материалды қабылдамас бұрын автордан материалдың тілдерін көрсетуін "
-"талап етіңіз."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Сіз жіберген материалға қолданылатын кез келген құқықтар зияткерлік меншік "

--- a/locale/ko/manager.po
+++ b/locale/ko/manager.po
@@ -1787,21 +1787,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/lt/manager.po
+++ b/locale/lt/manager.po
@@ -1793,21 +1793,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/lv/manager.po
+++ b/locale/lv/manager.po
@@ -2011,21 +2011,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/mk/manager.po
+++ b/locale/mk/manager.po
@@ -2094,28 +2094,6 @@ msgstr ""
 "Барај авторот да предложи клучни зборови пред да биде прифатен нивниот "
 "поднесок."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Јазикот укажува на примарен јазик за работа со користење на јазичен код (\"en"
-"\") с опција за дополнителен код на земјата (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Овозможи метаподатоци за јазик"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"За време на поднесувањето, не ги барајте јазиците на поднесокот од авторот."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"За време на поднесувањето, прашајте го авторот да ги посочи јазиците на "
-"поднесокот."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Барај авторот да ги внесе јазиците на поднесокот пред да биде прифатен "
-"нивниот поднесок."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Задржани се било какви права над поднесокот, што може да вклучува права на "

--- a/locale/mn/manager.po
+++ b/locale/mn/manager.po
@@ -1781,21 +1781,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/ms/manager.po
+++ b/locale/ms/manager.po
@@ -1994,25 +1994,6 @@ msgstr ""
 "Memerlukan pengarang untuk mencadangkan kata kunci sebelum menerima "
 "penyerahannya."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Bahasa menunjukkan bahasa utama kerja menggunakan kod bahasa (\"ms\") dengan "
-"kod negara pilihan (\"ms_MS\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Dayakan metadata bahasa"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Jangan minta bahasa penyerahan daripada pengarang semasa penyerahan."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Minta pengarang menyatakan bahasa penyerahan semasa penyerahan."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Memerlukan pengarang untuk memasukkan bahasa penyerahan sebelum menerima "
-"penyerahan mereka."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Sebarang hak yang dipegang atas penyerahan, yang mungkin termasuk Hak Harta "

--- a/locale/nb/manager.po
+++ b/locale/nb/manager.po
@@ -2005,24 +2005,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Be forfatteren foreslå nøkkelord, før vedkommende godkjenner innleveringen."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Språk angir verkets primære språk ved hjelp av en spåkkode (\"en\") med en "
-"valgfri landekode (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Aktiver språkmetadata"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Ikke krev at forfatteren angir språk på innleveringen."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Be forfatteren om å angi språk på innleveringen."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Krev at forfatteren angir innleveringens språk før innleveringen godkjennes."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Eventuelle rettigheter over innleveringen som kan omfatte intellektuell "

--- a/locale/nl/manager.po
+++ b/locale/nl/manager.po
@@ -1981,29 +1981,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Verplicht auteurs om trefwoorden toe te voegen tijdens het inzendingsproces."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Taal duidt de hoofdtaal aan van een werk, met een taalcode (\"en\") en een "
-"optionele landcode (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Schakel metadata over talen in"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Vraag auteurs niet om talen van een inzending aan te duiden tijdens het "
-"inzendingsproces."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Vraag auteurs om talen van een inzending aan te duiden tijdens het "
-"inzendingsproces."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Verplicht auteurs om talen van een inzending aan te duiden tijdens het "
-"inzendingsproces."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Rechten op de inzending, zoals intellectuele eigendomsrechten (IPR), "

--- a/locale/pl/manager.po
+++ b/locale/pl/manager.po
@@ -2073,25 +2073,6 @@ msgstr ""
 "Wymagaj od autora podania danych dot. Słów kluczowych zanim zgłoszenie "
 "zostanie zaakceptowane do wydania."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Język oznacza główny język tekstu oznaczony wg kodu (\"pl\") z opcją w "
-"postaci (\"pl_PL\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Włącz metadane Język"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Nie wymagaj podania danych dot. Języka w trakcie zgłaszania tekstu."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Poproś autora o podanie danych dot. Języka w trakcie składania tekstu."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Wymagaj od autora podania danych dot. Języka zanim zgłoszenie zostanie "
-"zaakceptowane do wydania."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Dowolne prawa które są częścią tego zgłoszenia, które są częścią czyjejś "

--- a/locale/pt_BR/manager.po
+++ b/locale/pt_BR/manager.po
@@ -2110,26 +2110,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Exigir do autor que sugira palavras-chave antes de aceitar sua submissão."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Idioma indica o idioma principal do trabalho utilizando um código de idioma "
-"(\"en\") com um código de país opcional (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Habilitar metadados de idioma"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Não exigir do autor os idiomas da submissão durante a submissão."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Solicitar ao autor que indique o idioma da submissão durante a submissão."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Exigir do autor para inserir os idiomas da submissão antes de aceitar sua "
-"submissão."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Quaisquer direitos detidos sobre a submissão, que podem incluir Direitos de "

--- a/locale/pt_PT/manager.po
+++ b/locale/pt_PT/manager.po
@@ -2088,26 +2088,6 @@ msgstr ""
 "Exigir aos autores que sugiram palavras-chave antes de aceitar a sua "
 "submissão."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Idioma indica o idioma principal do trabalho através de códigos ISO (\"en\") "
-"com códigos de país opcionais (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Ativar metadado de idioma"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Não solicitar o idioma da submissão aos autores durante a submissão."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Solicitar aos autores que indiquem o idioma da submissão durante a submissão."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Exigir aos autores que insiram os idiomas da submissão antes de aceitar a "
-"submissão."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Quaisquer direitos sobre a submissão, que podem ser incluídos nos Direitos "

--- a/locale/ro/manager.po
+++ b/locale/ro/manager.po
@@ -1998,29 +1998,6 @@ msgstr ""
 "Solicitați autorului să sugereze cuvintele cheie înainte de a accepta "
 "înregistrarea acestora."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Limba selectată indică limba primară de lucru folosind un cod de limbă "
-"(„en”) cu un cod de țară opțional („en_US”)."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Activați metadatele de limbă"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Nu solicitați limbile de trimitere de la autor în timpul înregistrării de "
-"manuscris."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Solicitați autorului să indice limbile transmiterii în timpul înregistrării "
-"de manuscris."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Solicitați autorului să introducă limbile manuscrisului înainte de a accepta "
-"transmiterea."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Orice drepturi deținute asupra manuscrisului, care pot include drepturi de "

--- a/locale/ru/manager.po
+++ b/locale/ru/manager.po
@@ -2117,25 +2117,6 @@ msgstr ""
 "Требовать, чтобы автор обязательно указал ключевые слова до приёма его "
 "материала."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Язык указывает основной язык работы с помощью кода языка («ru») с "
-"дополнительным кодом страны («ru_RU»)."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Включить язык в метаданные"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Не запрашивать языки материала у автора во время отправки."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Просить автора указать языки материала во время отправки."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Требовать, чтобы автор обязательно указал языки материала до приёма этого "
-"материала."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Любые права, которые распространяются на отправляемый материал, сюда могут "

--- a/locale/sk/manager.po
+++ b/locale/sk/manager.po
@@ -1801,21 +1801,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/sl/manager.po
+++ b/locale/sl/manager.po
@@ -2061,25 +2061,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Zahtevaj od avtorjev, da navedejo ključne besede pred sprejetjem prispevka."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Jezik določi primarni jezik prispevka, za kar se uporablja koda jezika (\"sl"
-"\") z opcijsko kodo države (\"sl_SI\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Omogoči metapodatke za jezik"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-"Ne zahtevaj od avtorjev, da navedejo jezik prispevka med oddajo prispevka."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Zahtevaj od avtorja, da navede jezik prispevka med oddajo prispevka."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Zahtevaj od avtorjev, da navedejo jezik prispevka pred sprejetjem prispevka."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Vse pravice, ki se nanašajo na prispevek. Vsebujejo lahko intelektualne "

--- a/locale/sr@cyrillic/manager.po
+++ b/locale/sr@cyrillic/manager.po
@@ -1922,21 +1922,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/sr@latin/manager.po
+++ b/locale/sr@latin/manager.po
@@ -1931,21 +1931,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/sv/manager.po
+++ b/locale/sv/manager.po
@@ -2027,23 +2027,6 @@ msgstr "Be författaren att föreslå nyckelord vid inskickandet av bidrag."
 msgid "manager.setup.metadata.keywords.require"
 msgstr "Kräv att författaren föreslår nyckelord innan bidraget accepteras."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Språk anger arbetets primära språk, genom att använda språkkod (\"en\") med "
-"en frivillig landkod (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Gör det möjligt att lägga in metadata om språk"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Kräv inte att författaren ska ange språk vid inskickandet av bidrag."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Be författaren att ange bidragets språk vid inskickandet."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr "Kräv att författaren anger bidragets språk innan bidraget accepteras."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Immateriella rättigheter till bidraget som t.ex. upphovsrätt, patent, eller "

--- a/locale/tr/manager.po
+++ b/locale/tr/manager.po
@@ -2026,25 +2026,6 @@ msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 "Yazarın gönderisini kabul etmeden önce anahtar kelime önermesini isteyin."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Dil, çalışmanın birincil dilini, isteğe bağlı bir ülke koduyla (\"en_US\") "
-"bir dil kodu (\"en\") kullanarak gösterir."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Dil üst verilerini etkinleştir"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Gönderi sırasında yazardan gönderinin dilini talep etmeyin."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-"Yazardan, gönderi sırasında aday makalenin dilini belirtmesini isteyin."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Yazarın gönderisini kabul etmeden önce gönderi dillerini girmesini isteyin."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Gönderi ile ilgili olarak Fikri Mülkiyet Hakları (IPR), Telif Hakkı ve "

--- a/locale/uk/manager.po
+++ b/locale/uk/manager.po
@@ -2092,24 +2092,6 @@ msgstr ""
 "Вимагати у автора пропозиції щодо ключових слів перед прийняттям його "
 "подання."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Мова вказує на основу мову, яка використовувалася у цій роботі, позначається "
-"спеціальним кодом мови (\"en\") та (опціонально) країни (\"en_US\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Включити мову у метадані"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Не вимагати у авторів вказувати мову роботи під час подання."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Прохати авторів вказати мову роботи під час подання."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Вимагати від автора ввести дані про мову твору перед прийняттям його подання."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Будь-які права щодо подання, які можуть включати права інтелектуальної "

--- a/locale/uz@cyrillic/manager.po
+++ b/locale/uz@cyrillic/manager.po
@@ -1781,21 +1781,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/uz@latin/manager.po
+++ b/locale/uz@latin/manager.po
@@ -1814,21 +1814,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/locale/vi/manager.po
+++ b/locale/vi/manager.po
@@ -1972,24 +1972,6 @@ msgstr "Yêu cầu tác giả đề xuất từ khóa trong quá trình gửi b�
 msgid "manager.setup.metadata.keywords.require"
 msgstr "Yêu cầu tác giả đề xuất các từ khóa trước khi chấp nhận bài của họ."
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-"Ngôn ngữ chỉ ra ngôn ngữ chính của tác phẩm bằng mã ngôn ngữ, tiếng Anh/"
-"tiếng Việt (\"en\"/\"vi\") với mã quốc gia tùy chọn (\"en_US\"/\"vi_VN\")."
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr "Bật siêu dữ liệu ngôn ngữ"
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr "Không yêu cầu ngôn ngữ của bài gửi từ tác giả trong quá trình gửi bài."
-
-msgid "manager.setup.metadata.languages.request"
-msgstr "Yêu cầu tác giả cho biết ngôn ngữ của bài gửi trong quá trình gửi bài."
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-"Yêu cầu tác giả nhập ngôn ngữ của bài nộp trước khi chấp nhận bài gửi của họ."
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 "Bất kỳ quyền nào có được đối với bài gửi, có thể bao gồm Quyền sở hữu trí "

--- a/locale/zh_CN/manager.po
+++ b/locale/zh_CN/manager.po
@@ -1853,21 +1853,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr "要求作者在接受提交之前输入提交的语言。"
-
 msgid "manager.setup.metadata.rights.description"
 msgstr "提交内容所拥有的任何权利，包括知识产权（IPR），版权和各种产权。"
 

--- a/locale/zh_Hant/manager.po
+++ b/locale/zh_Hant/manager.po
@@ -1789,21 +1789,6 @@ msgstr ""
 msgid "manager.setup.metadata.keywords.require"
 msgstr ""
 
-msgid "manager.setup.metadata.languages.description"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.enable"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.noRequest"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.request"
-msgstr ""
-
-msgid "manager.setup.metadata.languages.require"
-msgstr ""
-
 msgid "manager.setup.metadata.rights.description"
 msgstr ""
 

--- a/plugins/importexport/native/filter/NativeXmlPKPPublicationFilter.php
+++ b/plugins/importexport/native/filter/NativeXmlPKPPublicationFilter.php
@@ -317,7 +317,6 @@ class NativeXmlPKPPublicationFilter extends NativeImportFilter
         return [
             'keywords' => ['SubmissionKeywordDAO', 'insertKeywords'],
             'agencies' => ['SubmissionAgencyDAO', 'insertAgencies'],
-            'languages' => ['SubmissionLanguageDAO', 'insertLanguages'],
             'disciplines' => ['SubmissionDisciplineDAO', 'insertDisciplines'],
             'subjects' => ['SubmissionSubjectDAO', 'insertSubjects'],
         ];

--- a/plugins/importexport/native/filter/PKPPublicationNativeXmlFilter.php
+++ b/plugins/importexport/native/filter/PKPPublicationNativeXmlFilter.php
@@ -306,7 +306,6 @@ class PKPPublicationNativeXmlFilter extends NativeExportFilter
         return [
             'keywords' => ['SubmissionKeywordDAO', 'getKeywords', 'keyword'],
             'agencies' => ['SubmissionAgencyDAO', 'getAgencies', 'agency'],
-            'languages' => ['SubmissionLanguageDAO', 'getLanguages', 'language'],
             'disciplines' => ['SubmissionDisciplineDAO', 'getDisciplines', 'discipline'],
             'subjects' => ['SubmissionSubjectDAO', 'getSubjects', 'subject'],
         ];

--- a/schemas/context.json
+++ b/schemas/context.json
@@ -461,14 +461,6 @@
 				"in:0,enable,request,require"
 			]
 		},
-		"languages": {
-			"type": "string",
-			"description": "Enable languages metadata. `0` is disabled. `enable` will make it available in the workflow. `request` will allow an author to enter a value during submission. `require` will require that the author enter a value during submission.",
-			"validation": [
-				"nullable",
-				"in:0,enable,request,require"
-			]
-		},
 		"librarianInformation": {
 			"type": "string",
 			"multilingual": true,

--- a/schemas/publication.json
+++ b/schemas/publication.json
@@ -182,17 +182,6 @@
 				"type": "string"
 			}
 		},
-		"languages": {
-			"type": "array",
-			"description": "Optional metadata that identifies the submission's primary language.",
-			"multilingual": true,
-			"validation": [
-				"nullable"
-			],
-			"items": {
-				"type": "string"
-			}
-		},
 		"lastModified": {
 			"type": "string",
 			"validation": [

--- a/templates/submission/review-editors.tpl
+++ b/templates/submission/review-editors.tpl
@@ -37,9 +37,6 @@
             {if in_array($currentContext->getData('disciplines'), [$currentContext::METADATA_REQUEST, $currentContext::METADATA_REQUIRE])}
                 {include file="/submission/review-publication-field.tpl" prop="disciplines" inLocale=$localeKey name="{translate key="search.discipline"}" type="array"}
             {/if}
-            {if in_array($currentContext->getData('languages'), [$currentContext::METADATA_REQUEST, $currentContext::METADATA_REQUIRE])}
-                {include file="/submission/review-publication-field.tpl" prop="languages" inLocale=$localeKey name="{translate key="common.languages"}" type="array"}
-            {/if}
             {if in_array($currentContext->getData('agencies'), [$currentContext::METADATA_REQUEST, $currentContext::METADATA_REQUIRE])}
                 {include file="/submission/review-publication-field.tpl" prop="supportingAgencies" inLocale=$localeKey name="{translate key="submission.supportingAgencies"}" type="array"}
             {/if}

--- a/tests/classes/publication/PublicationTest.php
+++ b/tests/classes/publication/PublicationTest.php
@@ -23,7 +23,6 @@ use PKP\services\PKPSchemaService;
 use PKP\submission\SubmissionAgencyDAO;
 use PKP\submission\SubmissionDisciplineDAO;
 use PKP\submission\SubmissionKeywordDAO;
-use PKP\submission\SubmissionLanguageDAO;
 use PKP\submission\SubmissionSubjectDAO;
 use PKP\tests\PKPTestCase;
 
@@ -41,7 +40,6 @@ class PublicationTest extends PKPTestCase
             new SubmissionKeywordDAO(),
             new SubmissionSubjectDAO(),
             new SubmissionDisciplineDAO(),
-            new SubmissionLanguageDAO(),
             new SubmissionAgencyDAO(),
             new CitationDAO(),
             new PKPSchemaService()


### PR DESCRIPTION
- Removed option Languages from Workflow Settings > Submission > Metadata