### PR TITLE
Adding missing label to google reCaptcha form

### DIFF
--- a/classes/user/form/RegistrationForm.inc.php
+++ b/classes/user/form/RegistrationForm.inc.php
@@ -91,7 +91,7 @@ class RegistrationForm extends Form {
 
 		if ($this->captchaEnabled) {
 			$publicKey = Config::getVar('captcha', 'recaptcha_public_key');
-			$reCaptchaHtml = '<div class="g-recaptcha" data-sitekey="' . $publicKey . '"></div>';
+			$reCaptchaHtml = '<div class="g-recaptcha" data-sitekey="' . $publicKey . '"></div><label for="g-recaptcha-response" style="display:none;">Recaptcha response</label>';
 			$templateMgr->assign(array(
 				'reCaptchaHtml' => $reCaptchaHtml,
 				'captchaEnabled' => true,


### PR DESCRIPTION
This PR adds a label to the google reCaptcha form and prevents accessibility non-compliance errors from being triggered when users are running automated accessibility audit tools like WAVE.

Issue: https://github.com/pkp/pkp-lib/issues/9386