### PR TITLE
Adding missing label to google reCaptcha form - OJS 3.4

### DIFF
--- a/templates/frontend/pages/userLogin.tpl
+++ b/templates/frontend/pages/userLogin.tpl
@@ -80,7 +80,7 @@
 					<div class="fields">
 						<div class="recaptcha">
 							<div class="g-recaptcha" data-sitekey="{$recaptchaPublicKey|escape}">
-							</div>
+							</div><label for="g-recaptcha-response" style="display:none;" hidden>Recaptcha response</label>
 						</div>
 					</div>
 				</fieldset>

--- a/templates/frontend/pages/userRegister.tpl
+++ b/templates/frontend/pages/userRegister.tpl
@@ -145,7 +145,7 @@
 				<div class="fields">
 					<div class="recaptcha">
 						<div class="g-recaptcha" data-sitekey="{$recaptchaPublicKey|escape}">
-						</div>
+						</div><label for="g-recaptcha-response" style="display:none;" hidden>Recaptcha response</label>
 					</div>
 				</div>
 			</fieldset>


### PR DESCRIPTION
This PR adds a label to the google reCaptcha form and prevents accessibility non-compliance errors from being triggered when users are running automated accessibility audit tools like WAVE.

Issue: https://github.com/pkp/pkp-lib/issues/9386