### PR TITLE
pkp/pkp-lib#9400 Display competing interests once a reviewer accepts an invitation

### DIFF
--- a/controllers/grid/users/reviewer/AuthorReviewerGridCellProvider.php
+++ b/controllers/grid/users/reviewer/AuthorReviewerGridCellProvider.php
@@ -75,7 +75,13 @@ class AuthorReviewerGridCellProvider extends DataObjectGridCellProvider
                 return ['label' => __($element->getReviewMethodKey())];
 
             case 'considered':
-                return ['label' => $this->_getStatusText($this->getCellState($row, $column), $row)];
+                $statusText = $this->_getStatusText($this->getCellState($row, $column), $row);
+                $reviewAssignment = $row->getData();
+                $competingInterests = $reviewAssignment->getCompetingInterests();
+                if ($competingInterests) {
+                    $statusText .= '<span class="details">' . __('reviewer.competingInterests') . '</span>';
+                }
+                return ['label' => $statusText];
 
             case 'actions':
                 // Only attach actions to this column. See self::getCellActions()

--- a/controllers/grid/users/reviewer/ReviewerGridCellProvider.php
+++ b/controllers/grid/users/reviewer/ReviewerGridCellProvider.php
@@ -97,7 +97,13 @@ class ReviewerGridCellProvider extends DataObjectGridCellProvider
                 return ['label' => __($element->getReviewMethodKey())];
 
             case 'considered':
-                return ['label' => $this->_getStatusText($this->getCellState($row, $column), $row)];
+                $statusText = $this->_getStatusText($this->getCellState($row, $column), $row);
+                $reviewAssignment = $row->getData();
+                $competingInterests = $reviewAssignment->getCompetingInterests();
+                if ($competingInterests) {
+                    $statusText .= '<span class="details">' . __('reviewer.competingInterests') . '</span>';
+                }
+                return ['label' => $statusText];
 
             case 'actions':
                 // Only attach actions to this column. See self::getCellActions()

--- a/templates/controllers/grid/users/reviewer/readReview.tpl
+++ b/templates/controllers/grid/users/reviewer/readReview.tpl
@@ -25,6 +25,13 @@
 				{translate key="editor.review.readConfirmation"}
 			{/fbvFormSection}
 
+            {if $reviewAssignment->getCompetingInterests()}
+                <h3>{translate key="reviewer.submission.competingInterests"}</h3>
+                <div class="review_competing_interests">
+                    {$reviewAssignment->getCompetingInterests()|nl2br|strip_unsafe_html}
+                </div>
+            {/if}
+
 			{if $reviewAssignment->getDateCompleted()}
 				{fbvFormSection}
 					<div class="pkp_controllers_informationCenter_itemLastEvent">
@@ -52,12 +59,6 @@
 						<h4>{translate key="submission.comments.cannotShareWithAuthor"}</h4>
 						{include file="controllers/revealMore.tpl" content=$comment->getComments()|strip_unsafe_html}
 					{/iterate}
-				{/if}
-				{if $reviewAssignment->getCompetingInterests()}
-					<h3>{translate key="reviewer.submission.competingInterests"}</h3>
-					<div class="review_competing_interests">
-						{$reviewAssignment->getCompetingInterests()|nl2br|strip_unsafe_html}
-					</div>
 				{/if}
 
 			{else}


### PR DESCRIPTION
### How to test?

1. Activate competing interest by putting text in "Settings, Workflow, Review, Reviewer Guidance, Competing Interests".
2. Make a new submission and send it to review stage.
3. Invite a new reviewer, declare competing interest and accept the invitation.
4. As editor, open the submission, next to reviewer's name, the label Competing interest must display.
5. Open the Review details window. Text typed by reviewer is displayed at the top of the window.

Note: this should also work when a reviewer is declining the review, but for an unknown reason, the competing interests are not saved to the database using this workflow. I can't find a way to bring that information to the appropriate handler method.