### PR TITLE
Update PKPSubmissionFileService.inc.php

### DIFF
--- a/classes/services/PKPSubmissionFileService.inc.php
+++ b/classes/services/PKPSubmissionFileService.inc.php
@@ -768,6 +768,11 @@ class PKPSubmissionFileService implements EntityPropertyInterface, EntityReadInt
 			case SUBMISSION_FILE_INTERNAL_REVIEW_REVISION:
 				$reviewRoundDao = DAORegistry::getDAO('ReviewRoundDAO'); /* @var $reviewRoundDao ReviewRoundDAO */
 				$reviewRound = $reviewRoundDao->getBySubmissionFileId($submissionFile->getId());
+				// The file should be associated with a review round. If not, fail.
+				// If $reviewRound is null here, it doesn't make sense to return $reviewRound->getStageId(); - it will cause trying to see the activity log for a submission to hang.
+				if(is_null($reviewRound)) {
+					return null;
+				}
 				return $reviewRound->getStageId();
 			case SUBMISSION_FILE_QUERY:
 				$noteDao = DAORegistry::getDAO('NoteDAO'); /* @var $noteDao NoteDAO */


### PR DESCRIPTION
See the discussion in https://github.com/pkp/pkp-lib/issues/7453

If $reviewRound is null here (which it might be), and we try to return null->getStageId(), then the activity log will hang.

Returning null if $reviewRound is null here instead of trying to return $reviewRound->getStageId() will make sure it is possible to see the activity log even if $reviewRound is null in this place.

This fix has solved our issue with activity log which hangs in ojs 3.3.0.8 and 3.3.0.13.

I reported this fix before, but I apologize for not making a pull request earlier.