### PR TITLE
Add information to asterisk on required fields (OJS 3.4)

### DIFF
--- a/locale/en/common.po
+++ b/locale/en/common.po
@@ -776,7 +776,7 @@ msgid "common.replaceFile"
 msgstr "Replace file"
 
 msgid "common.requiredField"
-msgstr "* Denotes required field"
+msgstr "Required fields are marked with an asterisk: <abbr class="required" title="required">*</abbr>"
 
 msgid "common.required"
 msgstr "Required"

--- a/templates/frontend/pages/userLogin.tpl
+++ b/templates/frontend/pages/userLogin.tpl
@@ -16,6 +16,9 @@
 		{translate key="user.login"}
 	</h1>
 
+	<p>
+		{translate key="common.requiredField"}
+	</p>
 	{* A login message may be displayed if the user was redireceted to the
 	   login page from another request. Examples include if login is required
 	   before dowloading a file. *}

--- a/templates/frontend/pages/userRegister.tpl
+++ b/templates/frontend/pages/userRegister.tpl
@@ -17,6 +17,10 @@
 		{translate key="user.register"}
 	</h1>
 
+	<p>
+		{translate key="common.requiredField"}
+	</p>
+
 	<form class="cmp_form register" id="register" method="post" action="{url op="register"}" role="form">
 		{csrf}
 


### PR DESCRIPTION
This PR fixes this issue: https://github.com/pkp/pkp-lib/issues/9503

It adds a clearer meaning of the asterisk on required fields of forms including:

- A paragraph before each Register and Login forms
- Rewording the key string.