### PR TITLE
Update Repository.php fill missing user_id for cli mode (user_id cons…

### DIFF
--- a/classes/submissionFile/Repository.php
+++ b/classes/submissionFile/Repository.php
@@ -270,6 +270,7 @@ abstract class Repository
             [
                 'assocType' => PKPApplication::ASSOC_TYPE_SUBMISSION_FILE,
                 'assocId' => $submissionFile->getId(),
+                'userId' => $submissionFile->getUploaderUserId(),
                 'eventType' => SubmissionFileEventLogEntry::SUBMISSION_LOG_FILE_UPLOAD,
                 'dateLogged' => Core::getCurrentDate(),
                 'message' => 'submission.event.fileUploaded',
@@ -285,6 +286,7 @@ abstract class Repository
             [
                 'assocType' => PKPApplication::ASSOC_TYPE_SUBMISSION,
                 'assocId' => $submission->getId(),
+                'userId' => $submissionFile->getUploaderUserId(),
                 'eventType' => SubmissionFileEventLogEntry::SUBMISSION_LOG_FILE_REVISION_UPLOAD,
                 'dateLogged' => Core::getCurrentDate(),
                 'message' => 'submission.event.fileRevised',
@@ -364,6 +366,7 @@ abstract class Repository
             [
                 'assocType' => PKPApplication::ASSOC_TYPE_SUBMISSION_FILE,
                 'assocId' => $submissionFile->getId(),
+                'userId' => $submissionFile->getUploaderUserId(),
                 'eventType' => $newFileUploaded ? SubmissionFileEventLogEntry::SUBMISSION_LOG_FILE_REVISION_UPLOAD : SubmissionFileEventLogEntry::SUBMISSION_LOG_FILE_EDIT,
                 'message' => $newFileUploaded ? 'submission.event.revisionUploaded' : 'submission.event.fileEdited',
                 'isTranslated' => false,


### PR DESCRIPTION
…taint index)

When I did 
php tools/importExport.php NativeImportExportPlugin import bio_6v3+.xml bio oleg 

received
SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`ojsbio`.`event_log`, CONSTRAINT `event_log_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE) (SQL: insert into `event_log` (`assoc_type`, `assoc_id`, `user_id`, `date_logged`, `event_type`, `message`, `is_translated`) values (515, 1538, 0, 2023-12-02 11:59:21, 1342177296, submission.event.fileEdited, 0))

so let them fill