### PR TITLE
pkp/pkp-lib#6902 Register form fieldsets missing legend  - OJS 3.4

### DIFF
--- a/templates/frontend/pages/userRegister.tpl
+++ b/templates/frontend/pages/userRegister.tpl
@@ -70,8 +70,8 @@
 			{/foreach}
 			{if $userCanRegisterReviewer}
 				<fieldset class="reviewer">
-					{if $userCanRegisterReviewer > 1}
-						<legend>
+					{if $userCanRegisterReviewer >= 1}
+						<legend class="pkp_screen_reader">
 							{translate key="user.reviewerPrompt"}
 						</legend>
 						{capture assign="checkboxLocaleKey"}user.reviewerPrompt.userGroup{/capture}


### PR DESCRIPTION
This PR fixes the missing legend on registration form: https://github.com/pkp/pkp-lib/issues/6902