### PR TITLE
pkp/pkp-lib#5199 Set the current page on the top menu  - OJS 3.4

### DIFF
--- a/templates/frontend/components/navigationMenu.tpl
+++ b/templates/frontend/components/navigationMenu.tpl
@@ -19,16 +19,27 @@
 			{if !$navigationMenuItemAssignment->navigationMenuItem->getIsDisplayed()}
 				{continue}
 			{/if}
-			<li class="{$liClass|escape}">
-				<a href="{$navigationMenuItemAssignment->navigationMenuItem->getUrl()}">
+
+			{* Check if menu item has submenu *}
+			{if $navigationMenuItemAssignment->navigationMenuItem->getIsChildVisible()}
+				{assign var=hasSubmenu value=true}
+			{else}
+				{assign var=hasSubmenu value=false}
+			{/if}
+			{* Check if is current page for aria-current parameter*}
+			{assign var="isActive" value={default_item_active item=$navigationMenuItemAssignment->navigationMenuItem}}
+
+		<li class="{$liClass|escape} main-menu__nav-item{if $hasSubmenu} dropdown{/if} {default_item_active item=$navigationMenuItemAssignment->navigationMenuItem}" >
+				<a {if $isActive} aria-current="page" {/if}{if $hasSubmenu} aria-current="true"{/if} href="{$navigationMenuItemAssignment->navigationMenuItem->getUrl()}">
 					{$navigationMenuItemAssignment->navigationMenuItem->getLocalizedTitle()}
 				</a>
 				{if $navigationMenuItemAssignment->navigationMenuItem->getIsChildVisible()}
 					<ul>
 						{foreach key=childField item=childNavigationMenuItemAssignment from=$navigationMenuItemAssignment->children}
+							{assign var="isActive2" value={default_item_active item=$childNavigationMenuItemAssignment->navigationMenuItem}}
 							{if $childNavigationMenuItemAssignment->navigationMenuItem->getIsDisplayed()}
-								<li class="{$liClass|escape}">
-									<a href="{$childNavigationMenuItemAssignment->navigationMenuItem->getUrl()}">
+								<li class="{$liClass|escape} {default_item_active item=$childNavigationMenuItemAssignment->navigationMenuItem}">
+									<a href="{$childNavigationMenuItemAssignment->navigationMenuItem->getUrl()}" {if $isActive2} aria-current="page" {/if} >
 										{$childNavigationMenuItemAssignment->navigationMenuItem->getLocalizedTitle()}
 									</a>
 								</li>


### PR DESCRIPTION
This PR fixes this issue https://github.com/pkp/pkp-lib/issues/5199:

- [x]  Add class `"active"` to visually highlight the current menu item
- [x] Add `aria-current="page"` to screen readers announce the current page from the na menu
- [X] Increase menu items padding-top and padding-bottom when using mobile screen (24px height minimum recommended buy WCAG 2.2)

I've ported the check page function from Pragma theme adjusting the function to add the class and the aria attribute while checking for submenus.