### PR TITLE
pkp/pkp-lib#9627 Add indexes to usage stats temporary tables, conside…

### DIFF
--- a/classes/migration/upgrade/v3_4_0/I9627_AddUsageStatsTemporaryTablesIndexes.php
+++ b/classes/migration/upgrade/v3_4_0/I9627_AddUsageStatsTemporaryTablesIndexes.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_4_0/I9627_AddUsageStatsTemporaryTablesIndexes.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I9627_AddUsageStatsTemporaryTablesIndexes
+ *
+ * @brief Add an index to temporary usage stats tables to fix/improve the removeDoubleClicks and compileUniqueClicks query.
+ */
+
+namespace PKP\migration\upgrade\v3_4_0;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use PKP\install\DowngradeNotSupportedException;
+use PKP\migration\Migration;
+
+class I9627_AddUsageStatsTemporaryTablesIndexes extends Migration
+{
+    public $ipTables = [
+        'usage_stats_total_temporary_records',
+        'usage_stats_unique_item_investigations_temporary_records',
+        'usage_stats_unique_item_requests_temporary_records',
+    ];
+
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        // Decrease the size of the column ip to 64 characters
+        foreach ($this->ipTables as $ipTable) {
+            Schema::table($ipTable, function (Blueprint $table) {
+                $table->string('ip', 64)->change();
+            });
+        }
+
+        $sm = Schema::getConnection()->getDoctrineSchemaManager();
+        Schema::table('usage_stats_total_temporary_records', function (Blueprint $table) use ($sm) {
+            $indexesFound = $sm->listTableIndexes('usage_stats_total_temporary_records');
+            if (!array_key_exists('ust_load_id_context_id_ip', $indexesFound)) {
+                $table->index(['load_id', 'context_id', 'ip'], 'ust_load_id_context_id_ip');
+            }
+        });
+        Schema::table('usage_stats_unique_item_investigations_temporary_records', function (Blueprint $table) use ($sm) {
+            $indexesFound = $sm->listTableIndexes('usage_stats_unique_item_investigations_temporary_records');
+            if (!array_key_exists('usii_load_id_context_id_ip', $indexesFound)) {
+                $table->index(['load_id', 'context_id', 'ip'], 'usii_load_id_context_id_ip');
+            }
+        });
+        Schema::table('usage_stats_unique_item_requests_temporary_records', function (Blueprint $table) use ($sm) {
+            $indexesFound = $sm->listTableIndexes('usage_stats_unique_item_requests_temporary_records');
+            if (!array_key_exists('usir_load_id_context_id_ip', $indexesFound)) {
+                $table->index(['load_id', 'context_id', 'ip'], 'usir_load_id_context_id_ip');
+            }
+        });
+    }
+
+    /**
+     * Reverse the downgrades
+     *
+     * @throws DowngradeNotSupportedException
+     */
+    public function down(): void
+    {
+        throw new DowngradeNotSupportedException();
+    }
+}

--- a/classes/observers/listeners/LogUsageEvent.php
+++ b/classes/observers/listeners/LogUsageEvent.php
@@ -132,9 +132,6 @@ class LogUsageEvent
         // Hash the IP
         $ip = $request->getRemoteAddr();
         $hashedIp = StatisticsHelper::hashIp($ip, $salt);
-        if ($hashedIp === null) {
-            error_log('UsageEventLog: the IP cound not be hashed.');
-        }
 
         $site = $request->getSite();
         $context = $usageEvent->context;

--- a/classes/statistics/PKPStatisticsHelper.php
+++ b/classes/statistics/PKPStatisticsHelper.php
@@ -137,18 +137,9 @@ abstract class PKPStatisticsHelper
     * We just do not implement the PHP4 part as OJS dropped PHP4 support.
     *
     */
-    public static function hashIp(string $ip, string $salt): ?string
+    public static function hashIp(string $ip, string $salt): string
     {
-        $hashedIp = null;
-        if (function_exists('mhash')) {
-            $hashedIp = bin2hex(mhash(MHASH_SHA256, $ip . $salt));
-        } else {
-            assert(function_exists('hash'));
-            if (function_exists('hash')) {
-                $hashedIp = hash('sha256', $ip . $salt);
-            }
-        }
-        return $hashedIp;
+        return hash('sha256', $ip . $salt);
     }
 
     /**


### PR DESCRIPTION
…r inheritance in usage stats temp classes (fix for OMP), decrease the column ip to 64 characters, remove deprecated mhash and use hash

s. https://github.com/pkp/pkp-lib/issues/9627