### PR TITLE
pkp/pkp-lib#6296 Article breadcrumbs - OMP 3.4

### DIFF
--- a/templates/frontend/components/breadcrumbs.tpl
+++ b/templates/frontend/components/breadcrumbs.tpl
@@ -14,22 +14,22 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
 
-<nav class="cmp_breadcrumbs" role="navigation">
+<nav class="cmp_breadcrumbs">
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">
 				{translate key="common.homepageNavigationLabel"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
-			<span aria-current="page">
+			<a href="{url}" aria-current="page">
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			</span>
+			</a>
 		</li>
 	</ol>
 </nav>

--- a/templates/frontend/components/breadcrumbs_announcement.tpl
+++ b/templates/frontend/components/breadcrumbs_announcement.tpl
@@ -11,22 +11,22 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
 
-<nav class="cmp_breadcrumbs cmp_breadcrumbs_announcement" role="navigation">
+<nav class="cmp_breadcrumbs cmp_breadcrumbs_announcement">
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">
 				{translate key="common.homepageNavigationLabel"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li>
 			<a href="{url page="announcement" router=\PKP\core\PKPApplication::ROUTE_PAGE}">
 				{translate key="announcement.announcements"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
-			<span aria-current="page">{$currentTitle|escape}</span>
+			<a href="{url}" aria-current="page">{$currentTitle|escape}</a>
 		</li>
 	</ol>
 </nav>

--- a/templates/frontend/components/breadcrumbs_catalog.tpl
+++ b/templates/frontend/components/breadcrumbs_catalog.tpl
@@ -15,30 +15,34 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
 
-<nav class="cmp_breadcrumbs cmp_breadcrumbs_catalog" role="navigation">
+<nav class="cmp_breadcrumbs cmp_breadcrumbs_catalog" >
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">
 				{translate key="common.homepageNavigationLabel"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		{if $parent}
 			<li>
 				<a href="{url op=$type path=$parent->getPath()}">
 					{$parent->getLocalizedTitle()|escape}
 				</a>
-				<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+				<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 			</li>
 		{/if}
-		<li class="current" aria-current="page">
-			<span aria-current="page">
-				{if $currentTitleKey}
-					{translate key=$currentTitleKey}
-				{else}
-					{$currentTitle|escape}
-				{/if}
-			</span>
+		<li class="current">
+			{if $category}	
+				<a href="{url op=$type path=$category->getPath()}"  aria-current="page">
+			{else }
+				<a href="{url op=$type path=$series->getPath()}"  aria-current="page">
+			{/if}
+					{if $currentTitleKey}
+						{translate key=$currentTitleKey}
+					{else}
+						{$currentTitle|escape}
+					{/if}
+				</a>
 		</li>
 	</ol>
 </nav>


### PR DESCRIPTION
This PR fixes on OMP 3.4 the issue https://github.com/pkp/pkp-lib/issues/6296 and also implements:

- [x] `aria-current="page"` attribute was not being use on a link to the current page
- [x] Removed `aria-current="page"` attribute from li element, it should to be used on link elements only
- [x] Include a link, using the page title as the label, to the last item on the breadcrumb (article and archive pages)
- [x] Added `aria-hidden="true"` to the breadcrumb separators (they were announced as "slash" by screen readers which is annoying for screen reader users and don't add any information to the context)

Even though it is an update to the pkp-lib repo, it affects only OMP platform since OJS and OPS have the template files under their own repo.