### PR TITLE
pkp/pkp-lib#9803 Ensure fetched multilingual option is an array

### DIFF
--- a/classes/components/forms/FormComponent.inc.php
+++ b/classes/components/forms/FormComponent.inc.php
@@ -292,6 +292,10 @@ class FormComponent {
 			$config['value'] = $field->isMultilingual ? array() : $field->getEmptyValue();
 		}
 		if ($field->isMultilingual) {
+			if (is_string($config['value'])) {
+				$config['value'] = json_decode($config['value'], true);
+			}
+
 			foreach ($this->locales as $locale) {
 				if (!array_key_exists($locale['key'], $config['value'])) {
 					$config['value'][$locale['key']] = $field->getEmptyValue();


### PR DESCRIPTION
This performs a quick sanity check to ensure that the pulled JSON string from the database is converted to an array before use.