### PR TITLE
Show locale in url in multilingual contexts

### DIFF
--- a/classes/core/PKPPageRouter.php
+++ b/classes/core/PKPPageRouter.php
@@ -577,10 +577,10 @@ class PKPPageRouter extends PKPRouter
 
         $indexUrl = $this->getIndexUrl($request);
         $uri = preg_replace("#^$indexUrl#", "", $setLocale ? ($_SERVER['HTTP_REFERER'] ?? "") : $request->getCompleteUrl(), 1);
-        $newUrlLocale = $multiLingual ? $sessionLocale : "";
+        $newUrlLocale = $multiLingual ? "/$sessionLocale" : "";
         $pathInfo = ($uri)
-            ? preg_replace("#^/$contextPath" . ($urlLocale ? "/$urlLocale" : "") . "(?=[/?\\#]|$)#", "/$contextPath/$newUrlLocale", $uri, 1)
-            : "/index/$newUrlLocale";
+            ? preg_replace("#^/$contextPath" . ($urlLocale ? "/$urlLocale" : "") . "(?=[/?\\#]|$)#", "/$contextPath$newUrlLocale", $uri, 1)
+            : "/index$newUrlLocale";
 
         $request->redirectUrl($indexUrl . $pathInfo);
     }


### PR DESCRIPTION
- fix bug: in some cases extra "/" added to url