### PR TITLE
pkp/pkp-lib#10051 Fixed HTML entity code &amp; in OJS email subject

### DIFF
--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -362,11 +362,24 @@ class Mail extends DataObject {
 	}
 
 	/**
-	 * Set the subject of the message.
-	 * @param $subject string
-	 */
+	* Set the subject of the message.
+	* @param $subject string
+	*/
 	function setSubject($subject) {
-		$this->setData('subject', $subject);
+		$sanitizedSubject = $this->sanitizeSubject($subject);
+		$decodedSubject = htmlspecialchars_decode($sanitizedSubject, ENT_QUOTES | ENT_HTML5);
+		$this->setData('subject', $decodedSubject);
+	}
+
+	/**
+	 * Sanitize subject to remove any harmful content.
+	 * @param $subject string
+	 * @return string
+	 */
+	function sanitizeSubject($subject) {
+		$sanitizedSubject = strip_tags($subject);
+		$sanitizedSubject = preg_replace('/[\x00-\x1F\x7F<>]/', '', $sanitizedSubject);
+		return $sanitizedSubject;
 	}
 
 	/**

--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -366,20 +366,7 @@ class Mail extends DataObject {
 	* @param $subject string
 	*/
 	function setSubject($subject) {
-		$sanitizedSubject = $this->sanitizeSubject($subject);
-		$decodedSubject = htmlspecialchars_decode($sanitizedSubject, ENT_QUOTES | ENT_HTML5);
-		$this->setData('subject', $decodedSubject);
-	}
-
-	/**
-	 * Sanitize subject to remove any harmful content.
-	 * @param $subject string
-	 * @return string
-	 */
-	function sanitizeSubject($subject) {
-		$sanitizedSubject = strip_tags($subject);
-		$sanitizedSubject = preg_replace('/[\x00-\x1F\x7F<>]/', '', $sanitizedSubject);
-		return $sanitizedSubject;
+		$this->setData('subject', $subject);
 	}
 
 	/**

--- a/classes/mail/Mail.inc.php
+++ b/classes/mail/Mail.inc.php
@@ -362,9 +362,9 @@ class Mail extends DataObject {
 	}
 
 	/**
-	* Set the subject of the message.
-	* @param $subject string
-	*/
+	 * Set the subject of the message.
+	 * @param $subject string
+	 */
 	function setSubject($subject) {
 		$this->setData('subject', $subject);
 	}

--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -216,7 +216,7 @@ class MailTemplate extends Mail {
 	}
 
 	/**
-	 * Replace template variables in the message body.
+	 * Replace template variables in the message body and subject.
 	 * @param $params array Parameters to assign (augments anything provided via setParams)
 	 */
 	function replaceParams() {
@@ -231,9 +231,11 @@ class MailTemplate extends Mail {
 					$body = str_replace('{$' . $key . '}', $value, $body);
 				}
 			}
-
 			$subject = str_replace('{$' . $key . '}', $value, $subject);
 		}
+
+		// Decode HTML entities for the subject after all replacements
+		$subject = htmlspecialchars_decode($subject, ENT_QUOTES | ENT_HTML5);
 		$this->setSubject($subject);
 		$this->setBody($body);
 	}


### PR DESCRIPTION
Fixes #10051 

### Changes Made
- Updated the `setSubject` function to sanitize and decode the email subject correctly.
- Added a `sanitizeSubject` function to remove HTML tags from the email subject for security.
