### PR TITLE
pkp/pkp-lib#9914 sort services by start date and display user name an…

### DIFF
--- a/classes/userGroup/relationships/UserUserGroup.php
+++ b/classes/userGroup/relationships/UserUserGroup.php
@@ -125,4 +125,9 @@ class UserUserGroup extends \Illuminate\Database\Eloquent\Model
     {
         return $query->where('user_user_groups.masthead', 1);
     }
+
+    public function scopeSortBy(Builder $query, string $column, ?string $direction = 'asc')
+    {
+        return $query->orderBy('user_user_groups.' . $column, $direction);
+    }
 }

--- a/locale/en/common.po
+++ b/locale/en/common.po
@@ -45,6 +45,9 @@ msgstr "Principal Contact"
 msgid "about.contact.supportContact"
 msgstr "Support Contact"
 
+msgid "about.editorialMasthead.linkToEditorialHistory"
+msgstr "View <a href=\"{$url}\">Editorial History</a>"
+
 msgid "about.other"
 msgstr "Other"
 
@@ -159,6 +162,12 @@ msgstr "The editors express their appreciation of the reviewers for {$year} list
 
 msgid "common.editorialHistory"
 msgstr "Editorial History"
+
+msgid "common.editorialHistory.page"
+msgstr "Editorial History Page"
+
+msgid "common.editorialHistory.page.description"
+msgstr "This section lists past contributors."
 
 msgid "common.name"
 msgstr "Name"

--- a/pages/about/AboutContextHandler.php
+++ b/pages/about/AboutContextHandler.php
@@ -167,6 +167,7 @@ class AboutContextHandler extends Handler
                     ->withUserGroupId($mastheadUserGroup->getId())
                     ->withEnded()
                     ->withMasthead()
+                    ->sortBy('date_start', 'desc')
                     ->get();
                 $services = [];
                 foreach ($userUserGroups as $userUserGroup) {

--- a/templates/frontend/pages/editorialHistory.tpl
+++ b/templates/frontend/pages/editorialHistory.tpl
@@ -13,34 +13,39 @@
 <div class="page page_masthead">
 	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey="common.editorialHistory"}
 
-	<h1>{translate key="common.editorialHistory"}</h1>
+	<h1>{translate key="common.editorialHistory.page"}</h1>
+	<p>{translate key="common.editorialHistory.page.description"}</p>
 	{foreach from=$mastheadRoles item="mastheadRole"}
 		{if array_key_exists($mastheadRole->getId(), $mastheadUsers)}
 			<h2>{$mastheadRole->getLocalizedName()|escape}</h2>
 			<ul>
-			{foreach from=$mastheadUsers[$mastheadRole->getId()] item="mastheadUser"}
-				{foreach from=$mastheadUser['services'] item="service"}
+				{foreach from=$mastheadUsers[$mastheadRole->getId()] item="mastheadUser"}
 					<li>
 						<ul id="commaList">
 							<li>{$mastheadUser['user']->getFullName()|escape}</li>
 							{if !empty($mastheadUser['user']->getLocalizedData('affiliation'))}
 								<li>{$mastheadUser['user']->getLocalizedData('affiliation')|escape}</li>
 							{/if}
-							<li>{translate key="common.fromUntil" from=$service['dateStart'] until=$service['dateEnd']}</li>
+							{if $mastheadUser['user']->getData('orcid')}
+								<span class="orcid">
+									{if $mastheadUser['user']->getData('orcidAccessToken')}
+										{$orcidIcon}
+									{/if}
+									<a href="{$mastheadUser['user']->getData('orcid')|escape}" target="_blank">
+										{$mastheadUser['user']->getData('orcid')|escape}
+									</a>
+								</span>
+							{/if}
+							<li>
+								{foreach from=$mastheadUser['services'] item="service"}
+									<ul>
+										<li>{translate key="common.fromUntil" from=$service['dateStart'] until=$service['dateEnd']}</li>
+									</ul>
+								{/foreach}
+							</li>
 						</ul>
-						{if $mastheadUser['user']->getData('orcid')}
-							<span class="orcid">
-								{if $mastheadUser['user']->getData('orcidAccessToken')}
-									{$orcidIcon}
-								{/if}
-								<a href="{$mastheadUser['user']->getData('orcid')|escape}" target="_blank">
-								{$mastheadUser['user']->getData('orcid')|escape}
-							</a>
-							</span>
-						{/if}
 					</li>
 				{/foreach}
-			{/foreach}
 			</ul>
 		{/if}
 	{/foreach}

--- a/templates/frontend/pages/editorialMasthead.tpl
+++ b/templates/frontend/pages/editorialMasthead.tpl
@@ -44,9 +44,8 @@
 	{/foreach}
 
 	<p>
-		<a href="{url page="about" op="editorialHistory" router=\PKP\core\PKPApplication::ROUTE_PAGE}">
-			{translate key="common.editorialHistory"}
-		</a>
+		{capture assign=editorialHistoryUrl}{url page="about" op="editorialHistory" router=\PKP\core\PKPApplication::ROUTE_PAGE}{/capture}
+		{translate key="about.editorialMasthead.linkToEditorialHistory" url=$editorialHistoryUrl}
 	</p>
 
 	{if !empty($reviewers)}


### PR DESCRIPTION
…d affiliation only once on editorial history page, use different text to link to the editorial history form the editorial masthead page

This PR contains some design changes:

- The text that links to the Editorial History from the Editorial Masthead page should be: `View Editorial History for this journal`
- The title heading on the Editorial History page should be `Editorial History Page`, followed by this explanation text: `Here, you will find a comprehensive record of all past contributors associated with this journal. This page highlights our commitment to transparency and showcases our editorial evolution.`
- Editorial History page can contain/list several services for one and the same user and role -- for example if an user was an editor from 2019-2020, and then again from 2022-2023. Thus the services should be listed by start date desc, and user name and affiliation should be listed only once (and not for each service). I.e. like this:

```
Editors

<Name>
Affiliation
Start Date - Last Date
Start Date - Last Date

<Name>
Affiliation
Start Date - Last Date

Section Editor

<Name>
Affiliation
Start Date - Last Date

<Name>
Affiliation
Start Date - Last Date


```