### PR TITLE
pkp/pkp-lib#10094 fix issue preventing deletion of email templates

### DIFF
--- a/api/v1/emailTemplates/PKPEmailTemplateController.php
+++ b/api/v1/emailTemplates/PKPEmailTemplateController.php
@@ -92,8 +92,7 @@ class PKPEmailTemplateController extends PKPBaseController
                 ->name('emailTemplate.restoreDefaults');
 
             Route::delete('{key}', $this->delete(...))
-                ->name('emailTemplate.delete')
-                ->whereAlphaNumeric('key');
+                ->name('emailTemplate.delete');
         });
     }
 


### PR DESCRIPTION
Enforcing alphanumeric keys is preventing the deletion of email templates (they have underscores in them).