### PR TITLE
pkp/pkp-lib#10132 move plugin validation locale key for use in omp

### DIFF
--- a/locale/ar/manager.po
+++ b/locale/ar/manager.po
@@ -3643,3 +3643,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "طاقم المجلة"
+
+msgid "plugins.importexport.common.validation"
+msgstr "تحقق من نصوص XML قبل التصدير والتسجيل."

--- a/locale/az/manager.po
+++ b/locale/az/manager.po
@@ -3904,3 +3904,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "İdarəçi siyahısı"
+
+msgid "plugins.importexport.common.validation"
+msgstr "İxrac və qeydiyyat əməliyyatından əvvəl XML-i təsdiqləyin"

--- a/locale/be@cyrillic/manager.po
+++ b/locale/be@cyrillic/manager.po
@@ -3055,3 +3055,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Выходныя даныя"
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/bg/manager.po
+++ b/locale/bg/manager.po
@@ -3884,3 +3884,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Входни данни"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Проверете XML преди експортирането и регистрацията."

--- a/locale/bs/manager.po
+++ b/locale/bs/manager.po
@@ -3163,3 +3163,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Impresum"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Prije izvoženja i registracije potvrdi XML."

--- a/locale/ca/manager.po
+++ b/locale/ca/manager.po
@@ -3651,3 +3651,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Capçalera"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validar el XML abans de l'exportació i el registre."

--- a/locale/ckb/manager.po
+++ b/locale/ckb/manager.po
@@ -3172,3 +3172,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "دەستەی بەڕێوەبردنی گۆڤار"
+
+msgid "plugins.importexport.common.validation"
+msgstr "وردبینی لە XML بکە پێش هەناردەکردن و تۆمارکردن."

--- a/locale/cs/manager.po
+++ b/locale/cs/manager.po
@@ -3773,3 +3773,6 @@ msgstr "Zahrnout i nadřazené podrobnosti"
 
 msgid "manager.setup.masthead"
 msgstr "Hlavička"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validujte XML před exportem a registrací."

--- a/locale/da/manager.po
+++ b/locale/da/manager.po
@@ -3816,3 +3816,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Kolofon"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Godkend XML før eksport og registrering."

--- a/locale/de/manager.po
+++ b/locale/de/manager.po
@@ -3779,3 +3779,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Impressum"
+
+msgid "plugins.importexport.common.validation"
+msgstr "XML vor Export und Registrierung validieren."

--- a/locale/el/manager.po
+++ b/locale/el/manager.po
@@ -3490,3 +3490,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Κύριος τίτλος"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Επικυρώστε το XML πριν από την εξαγωγή και την ευρετηρίαση."

--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -3560,3 +3560,6 @@ msgstr "Reviewers will be displayed in a standardized format to maintain uniform
 
 msgid "mailable.changeProfileEmailInvitationNotify.name"
 msgstr "Change Email Address Invitation"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validate XML before the export and registration."

--- a/locale/es/manager.po
+++ b/locale/es/manager.po
@@ -3888,3 +3888,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Cabecera"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validar el XML antes de la exportación y el registro."

--- a/locale/eu/manager.po
+++ b/locale/eu/manager.po
@@ -3195,3 +3195,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Portada"
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/fa/manager.po
+++ b/locale/fa/manager.po
@@ -3385,3 +3385,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "سربرگ"
+
+msgid "plugins.importexport.common.validation"
+msgstr "فایل XML را قبل از برون دهی اعتبار سنجی کن."

--- a/locale/fi/manager.po
+++ b/locale/fi/manager.po
@@ -3734,3 +3734,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Tunnuslaatikko"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validoi XML ennen vientiä ja rekisteröintiä."

--- a/locale/fr_CA/manager.po
+++ b/locale/fr_CA/manager.po
@@ -3822,3 +3822,6 @@ msgstr "Counter R5"
 
 msgid "manager.setup.masthead"
 msgstr "Bloc générique"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Valider le XML avant l'exportation et l'enregistrement."

--- a/locale/fr_FR/manager.po
+++ b/locale/fr_FR/manager.po
@@ -3991,3 +3991,6 @@ msgstr "Paramètres du rapport"
 
 msgid "manager.statistics.counterR5Report.settings.includeParentDetails"
 msgstr "Inclure les détails parents"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Valider le XML avec l'export."

--- a/locale/gd/manager.po
+++ b/locale/gd/manager.po
@@ -3119,3 +3119,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr ""
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/gl/manager.po
+++ b/locale/gl/manager.po
@@ -3430,3 +3430,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Cabeceira"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validar o XML antes da exportación e rexistro."

--- a/locale/he/manager.po
+++ b/locale/he/manager.po
@@ -3091,3 +3091,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr ""
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/hi/manager.po
+++ b/locale/hi/manager.po
@@ -3176,3 +3176,8 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "मास्टहेड"
+
+msgid "plugins.importexport.common.validation"
+msgstr "निर्यात और पंजीकरण से पहले XML सत्यापित करें।"
+
+# (pofilter) endpunc: Different punctuation at the end

--- a/locale/hr/manager.po
+++ b/locale/hr/manager.po
@@ -3592,3 +3592,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Impresum"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Prije izvoženja i registracije potvrdi XML."

--- a/locale/hu/manager.po
+++ b/locale/hu/manager.po
@@ -3854,3 +3854,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Impresszum"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Érvényesítse az XML-t mielőtt exportálja és regisztrálja."

--- a/locale/hy/manager.po
+++ b/locale/hy/manager.po
@@ -3802,3 +3802,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Մասթհեդ"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Վավերացրեք XML-ը մինչև արտահանումը և գրանցումը:"

--- a/locale/id/manager.po
+++ b/locale/id/manager.po
@@ -3410,3 +3410,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Tajuk"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validasi XML sebelum proses ekspor dan registrasi."

--- a/locale/is/manager.po
+++ b/locale/is/manager.po
@@ -3375,3 +3375,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Síðuhaus"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Staðfestu XML áður en það er flutt út og skráð."

--- a/locale/it/manager.po
+++ b/locale/it/manager.po
@@ -3536,3 +3536,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Titolo"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Valida l'XML prima dell'esportazione e della registrazione."

--- a/locale/ja/manager.po
+++ b/locale/ja/manager.po
@@ -3368,3 +3368,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "マストヘッド"
+
+msgid "plugins.importexport.common.validation"
+msgstr "エクスポートや登録の前にXMLを検証します。"

--- a/locale/ka/manager.po
+++ b/locale/ka/manager.po
@@ -3559,3 +3559,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "გამომავალი მონაცემები"
+
+msgid "plugins.importexport.common.validation"
+msgstr "დაადასტურეთ XML ექსპორტამდე და რეგისტრაციამდე."

--- a/locale/kk/manager.po
+++ b/locale/kk/manager.po
@@ -3541,3 +3541,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Шығыс деректер"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Проверять XML перед экспортом и регистрацией."

--- a/locale/ko/manager.po
+++ b/locale/ko/manager.po
@@ -3052,3 +3052,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr ""
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/lt/manager.po
+++ b/locale/lt/manager.po
@@ -3071,3 +3071,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr ""
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/lv/manager.po
+++ b/locale/lv/manager.po
@@ -3718,3 +3718,6 @@ msgstr "Neietvert ikmēneša sīkāku informāciju"
 
 msgid "manager.setup.masthead"
 msgstr "Galvenā lapa"
+
+msgid "plugins.importexport.common.validation"
+msgstr "XML validācija pirms eksportēšanas un reģistrācijas."

--- a/locale/mk/manager.po
+++ b/locale/mk/manager.po
@@ -3718,3 +3718,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Мајстор"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Потврдете го XML пред извозот и регистрацијата."

--- a/locale/mn/manager.po
+++ b/locale/mn/manager.po
@@ -3046,3 +3046,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr ""
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/ms/manager.po
+++ b/locale/ms/manager.po
@@ -3421,3 +3421,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Tajuk"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Sahkan XML sebelum eksport dan pendaftaran."

--- a/locale/nb/manager.po
+++ b/locale/nb/manager.po
@@ -3614,3 +3614,6 @@ msgstr ""
 #, fuzzy
 msgid "manager.statistics.counterR5Reports.usageNotPossible"
 msgstr "Det er for øyeblikket ingen COUNTER R5 bruksstatistikk tilgjengelig."
+
+msgid "plugins.importexport.common.validation"
+msgstr "Valider XML før eksport og registrering."

--- a/locale/nl/manager.po
+++ b/locale/nl/manager.po
@@ -3405,3 +3405,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Impressum"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Valideer XML alvorens te exporteren en registreren."

--- a/locale/pl/manager.po
+++ b/locale/pl/manager.po
@@ -3740,3 +3740,6 @@ msgstr "Wymagaj od autorów oświadczenia o zbieżności zainteresowań."
 
 msgid "manager.setup.masthead"
 msgstr "Stopka redakcyjna"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Sprawdź XML przed eksportem i rejestracją."

--- a/locale/pt_BR/manager.po
+++ b/locale/pt_BR/manager.po
@@ -3817,3 +3817,6 @@ msgstr "Excluir detalhes mensais"
 
 msgid "manager.setup.masthead"
 msgstr "Expediente"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Valide o XML antes da exportação e registro."

--- a/locale/pt_PT/manager.po
+++ b/locale/pt_PT/manager.po
@@ -3793,3 +3793,6 @@ msgstr "Excluir Delhalhes Mensais"
 
 msgid "manager.setup.masthead"
 msgstr "Cabeçalho"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validar o XML antes de exportar e registar."

--- a/locale/ro/manager.po
+++ b/locale/ro/manager.po
@@ -3478,3 +3478,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Masthead"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validarea XML înainte de exportare și înregistrare."

--- a/locale/ru/manager.po
+++ b/locale/ru/manager.po
@@ -3801,3 +3801,6 @@ msgstr "Включить сведения о родительском элеме
 
 msgid "manager.setup.masthead"
 msgstr "Выходные данные"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Проверять XML перед экспортом и регистрацией."

--- a/locale/sk/manager.po
+++ b/locale/sk/manager.po
@@ -3120,3 +3120,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Hlavný titulok"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validujte XML pred exportom a registráciou."

--- a/locale/sl/manager.po
+++ b/locale/sl/manager.po
@@ -3786,3 +3786,6 @@ msgstr "Ne prikaži mesečnih podrobnosti"
 
 msgid "manager.setup.masthead"
 msgstr "Kolofon"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Preveri XML datoteko pred izvozom in registracijo."

--- a/locale/sq/manager.po
+++ b/locale/sq/manager.po
@@ -15,3 +15,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr ""
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/sr@cyrillic/manager.po
+++ b/locale/sr@cyrillic/manager.po
@@ -3201,3 +3201,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Управа"
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/sr@latin/manager.po
+++ b/locale/sr@latin/manager.po
@@ -3207,3 +3207,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Uprava"
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/sv/manager.po
+++ b/locale/sv/manager.po
@@ -3570,3 +3570,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Redaktionsruta"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Validera XML före export och registrering."

--- a/locale/tr/manager.po
+++ b/locale/tr/manager.po
@@ -3567,3 +3567,6 @@ msgid "manager.announcements.notEnabled"
 msgstr ""
 "<a href=\"#announcements/announcement-settings\">Duyuruları</a> "
 "etkinleştirmelisiniz."
+
+msgid "plugins.importexport.common.validation"
+msgstr "İhraç ve kayıt işleminden önce XML'i doğrulayın."

--- a/locale/uk/manager.po
+++ b/locale/uk/manager.po
@@ -3833,3 +3833,6 @@ msgstr "Виключити деталі за місяцями"
 
 msgid "manager.setup.masthead"
 msgstr "Вихідні данні"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Перевіряти XML перед експортом та реєстрацією."

--- a/locale/uz@cyrillic/manager.po
+++ b/locale/uz@cyrillic/manager.po
@@ -3046,3 +3046,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr ""
+
+msgid "plugins.importexport.common.validation"
+msgstr ""

--- a/locale/uz@latin/manager.po
+++ b/locale/uz@latin/manager.po
@@ -3139,3 +3139,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Sarlavha (Asosiy)"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Eksport va ro'yxatdan o'tishdan oldin XML -ni tasdiqlang."

--- a/locale/vi/manager.po
+++ b/locale/vi/manager.po
@@ -3414,3 +3414,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "Tiêu đề"
+
+msgid "plugins.importexport.common.validation"
+msgstr "Xác thực XML trước khi xuất và đăng ký."

--- a/locale/zh_CN/manager.po
+++ b/locale/zh_CN/manager.po
@@ -3211,3 +3211,6 @@ msgstr "要求投稿作者提供一个利益冲突（CI）的文字声明。"
 
 msgid "manager.setup.masthead"
 msgstr "刊头"
+
+msgid "plugins.importexport.common.validation"
+msgstr "在导出和注册之前验证 XML。"

--- a/locale/zh_Hant/manager.po
+++ b/locale/zh_Hant/manager.po
@@ -3055,3 +3055,6 @@ msgstr ""
 
 msgid "manager.setup.masthead"
 msgstr "出版資訊欄"
+
+msgid "plugins.importexport.common.validation"
+msgstr "導出及註冊前確認XML。"


### PR DESCRIPTION
Moving this locale key from OJS in order to use in OMP