### PR TITLE
pkp/pkp-lib#10277 Sends email to all authors in editor decision

### DIFF
--- a/controllers/modals/editorDecision/form/EditorDecisionWithEmailForm.inc.php
+++ b/controllers/modals/editorDecision/form/EditorDecisionWithEmailForm.inc.php
@@ -213,7 +213,7 @@ class EditorDecisionWithEmailForm extends EditorDecisionForm {
 
 		// Get submission authors in the same way as for the email template form,
 		// that editor sees. This also ensures that the recipient list is not empty.
-		$authors = $submission->getAuthors(true);
+		$authors = $submission->getAuthors();
 		foreach($authors as $author) {
 			$email->addRecipient($author->getEmail(), $author->getFullName());
 		}


### PR DESCRIPTION
Removes the `onlyIncludeInBrowse` parameter to send email to all authors of the submission in editor decision.

Related issue: pkp/pkp-lib#10277