### PR TITLE
Allow global context to be assumed instead of 404ing

### DIFF
--- a/classes/core/PKPRouter.php
+++ b/classes/core/PKPRouter.php
@@ -202,9 +202,9 @@ abstract class PKPRouter
                 // Retrieve the context from the DAO (by path)
                 $this->_context = $contextDao->getByPath($path);
 
-                // If the context couldn't be retrieved, it's a 404 error.
+                // If the context couldn't be retrieved, assume site context so that a 404 error can be provided by the site.
                 if (!$this->_context) {
-                    $this->getDispatcher()?->handle404();
+                    $this->_context = null;
                 }
             }
         }


### PR DESCRIPTION
I've been working on getting some 404 handling working via a plugin in order to provide a better experience, and to be able to drop in redirects on an article by article level as we transition towards OJS within OICC from.

However, when OJS decides on the context, it defaults to 404ing if the context couldn't be locating, meaning we can't hook in here and do anything so I've looked at tweaking it to default to global context, allowing for 404s to be handled by any handler registered.

I didn't find much luck any other way following on the forum https://forum.pkp.sfu.ca/t/better-404-handling/89573