### PR TITLE
pkp/pkp-lib#9468 add api.dois.403.editItemDoiCantBeAssigned key, adapt cypress tests to check after disabled doi assignments

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -745,6 +745,10 @@ Cypress.Commands.add('checkDoiAssignment', (selectorId) => {
 	});
 });
 
+Cypress.Commands.add('checkDisabledDoiAssignment', (selectorId) => {
+	cy.get(`input#${selectorId}`).should('have.value', '');
+});
+
 Cypress.Commands.add('checkDoiFilterResults', (filterName, textToCheck, expectedCount, itemType = 'submission') => {
 	if (filterName === 'Unpublished') {
 		// 'Unpublished' is ambiguious so we must specify which 'Unpublished' button we mean

--- a/locale/en/api.po
+++ b/locale/en/api.po
@@ -71,6 +71,9 @@ msgstr "The following locales are not supported: {$locales}."
 msgid "api.dois.403.editItemOutOfContext"
 msgstr "You cannot edit an item's DOI that is not in this context."
 
+msgid "api.dois.403.editItemDoiCantBeAssigned"
+msgstr "A DOI cannot be assigned to this item."
+
 msgid "api.dois.403.pubTypeNotRecognized"
 msgstr "The publication type was not recognized."
 


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/9468