### PR TITLE
pkp/pkp-lib#10415 redirect to dashboard according to user role

### DIFF
--- a/classes/core/PKPApplication.php
+++ b/classes/core/PKPApplication.php
@@ -598,7 +598,7 @@ abstract class PKPApplication implements iPKPApplicationInfoProvider
     public static function getWorkflowTypeRoles(): array
     {
         return [
-            self::WORKFLOW_TYPE_EDITORIAL => [Role::ROLE_ID_SITE_ADMIN, Role::ROLE_ID_MANAGER, Role::ROLE_ID_SUB_EDITOR, Role::ROLE_ID_ASSISTANT],
+            self::WORKFLOW_TYPE_EDITORIAL => [Role::ROLE_ID_SITE_ADMIN, Role::ROLE_ID_MANAGER, Role::ROLE_ID_SUB_EDITOR, Role::ROLE_ID_ASSISTANT, Role::ROLE_ID_AUTHOR],
             self::WORKFLOW_TYPE_AUTHOR => [Role::ROLE_ID_SITE_ADMIN, Role::ROLE_ID_MANAGER, Role::ROLE_ID_SUB_EDITOR, Role::ROLE_ID_AUTHOR],
         ];
     }


### PR DESCRIPTION
2nd solution for pkp/pkp-lib#10415 

redirect the user depending on the role he has on the submission, precisely if he is only author he is redirect to authorDashboard else he is redirected to "editor" dashboard 

(I think I prefer this solution, more universal than the first I propose)