### PR TITLE
[Propsal]customized page not found error

### DIFF
--- a/classes/core/Dispatcher.php
+++ b/classes/core/Dispatcher.php
@@ -304,10 +304,10 @@ class Dispatcher
     /**
      * Handle a 404 error (page not found).
      */
-    public static function handle404()
+    public static function handle404(string $message = "404 Not Found"): void
     {
         header('HTTP/1.0 404 Not Found');
-        echo "<h1>404 Not Found</h1>\n";
+        echo "<h1>" . htmlspecialchars($message) . "</h1>\n";
         exit;
     }
 }


### PR DESCRIPTION
#### General customized page not found error, without opening the OJS interface.

### Required user-cases

- When invitation  is not deleted a customized message indicating the invitation is required.
-  