### PR TITLE
User search API, return all current and future users, when search status=all

### DIFF
--- a/classes/user/Collector.php
+++ b/classes/user/Collector.php
@@ -47,7 +47,7 @@ class Collector implements CollectorInterface
 
     public const STATUS_ACTIVE = 'active';
     public const STATUS_DISABLED = 'disabled';
-    public const STATUS_ALL = null;
+    public const STATUS_ALL = 'all';
 
     public DAO $dao;
 
@@ -488,6 +488,10 @@ class Collector implements CollectorInterface
         }
 
         $currentDateTime = Core::getCurrentDate();
+        if ($this->status === self::STATUS_ALL) {
+            $this->userUserGroupStatus = UserUserGroupStatus::STATUS_ALL;
+        }
+
         $subQuery = DB::table('user_user_groups as uug')
             ->join('user_groups AS ug', 'uug.user_group_id', '=', 'ug.user_group_id')
             ->whereColumn('uug.user_id', '=', 'u.user_id')


### PR DESCRIPTION
Specificaton:

- search for users with  future roles, if the status is set to all and the user  role is in current context and the role start date is in future.
- 

Example

http://localhost:8000/index.php/publicknowledge/api/v1/users?searchPhrase=admin&status=all