### PR TITLE
Remove remember on Eloquent collection

### DIFF
--- a/pages/catalog/PKPCatalogHandler.php
+++ b/pages/catalog/PKPCatalogHandler.php
@@ -108,8 +108,7 @@ class PKPCatalogHandler extends Handler
             'publishedSubmissions' => $submissions->toArray(),
             'authorUserGroups' => UserGroup::withRoleIds([Role::ROLE_ID_AUTHOR])
                 ->withContextIds([$context->getId()])
-                ->get()
-                ->remember(),
+                ->get(),
         ]);
 
         return $templateMgr->display('frontend/pages/catalogCategory.tpl');


### PR DESCRIPTION
Removing `remember()` which does not exist in Eloquent Collection - similar to fix in https://github.com/pkp/browseBySection/pull/46/files.