### PR TITLE
pkp/pkp-lib#10837 Add image code and lists to announcement desc toolbar

### DIFF
--- a/classes/components/forms/announcement/PKPAnnouncementForm.inc.php
+++ b/classes/components/forms/announcement/PKPAnnouncementForm.inc.php
@@ -32,8 +32,10 @@ class PKPAnnouncementForm extends FormComponent {
 	 * @param $action string URL to submit the form to
 	 * @param $locales array Supported locales
 	 * @param $announcementContext Context The context to get supported announcement types
+	 * @param $temporaryFileApiUrl string URL to upload files to
+	 * @param $imageUploadUrl string The API endpoint for images uploaded through the rich text field
 	 */
-	public function __construct($action, $locales, $announcementContext) {
+	public function __construct($action, $locales, $announcementContext, $temporaryFileApiUrl, $imageUploadUrl) {
 		$this->action = $action;
 		$this->locales = $locales;
 
@@ -46,14 +48,24 @@ class PKPAnnouncementForm extends FormComponent {
 				'label' => __('manager.announcements.form.descriptionShort'),
 				'description' => __('manager.announcements.form.descriptionShortInstructions'),
 				'isMultilingual' => true,
+				'toolbar' => 'bold italic superscript subscript | link | blockquote bullist numlist | image | code',
+				'plugins' => 'paste,link,image,lists,code',
+				'uploadUrl' => $imageUploadUrl,
+				'options' => [
+					'url' => $temporaryFileApiUrl,
+				],
 			]))
 			->addField(new FieldRichTextarea('description', [
 				'label' => __('manager.announcements.form.description'),
 				'description' => __('manager.announcements.form.descriptionInstructions'),
 				'isMultilingual' => true,
 				'size' => 'large',
-				'toolbar' => 'bold italic superscript subscript | link | blockquote bullist numlist',
-				'plugins' => 'paste,link,lists',
+				'toolbar' => 'bold italic superscript subscript | link | blockquote bullist numlist | image | code',
+				'plugins' => 'paste,link,image,lists,code',
+				'uploadUrl' => $imageUploadUrl,
+				'options' => [
+					'url' => $temporaryFileApiUrl,
+				],
 			]))
 			->addField(new FieldText('dateExpire', [
 				'label' => __('manager.announcements.form.dateExpire'),

--- a/pages/management/ManagementHandler.inc.php
+++ b/pages/management/ManagementHandler.inc.php
@@ -315,6 +315,10 @@ class ManagementHandler extends Handler {
 		$templateMgr = TemplateManager::getManager($request);
 		$this->setupTemplate($request);
 
+		$context = $request->getContext();
+		$dispatcher = $request->getDispatcher();
+		$temporaryFileApiUrl = $dispatcher->url($request, ROUTE_API, $context->getPath(), 'temporaryFiles');
+		$publicFileApiUrl = $dispatcher->url($request, ROUTE_API, $context->getPath(), '_uploadPublicFile');
 		$apiUrl = $request->getDispatcher()->url($request, ROUTE_API, $request->getContext()->getPath(), 'announcements');
 
 		$supportedFormLocales = $request->getContext()->getSupportedFormLocales();
@@ -323,7 +327,7 @@ class ManagementHandler extends Handler {
 			return ['key' => $localeKey, 'label' => $localeNames[$localeKey]];
 		}, $supportedFormLocales);
 
-		$announcementForm = new \PKP\components\forms\announcement\PKPAnnouncementForm($apiUrl, $locales, $request->getContext());
+		$announcementForm = new \PKP\components\forms\announcement\PKPAnnouncementForm($apiUrl, $locales, $request->getContext(), $temporaryFileApiUrl, $publicFileApiUrl);
 
 		$getParams = [
 			'contextIds' => $request->getContext()->getId(),


### PR DESCRIPTION
Hi @asmecher,
Here is the PR that adds support for images, lists, and code display in the Announcement description and short description content.

OJS version: 3.3.0