### PR TITLE
Adjustments so that the generated html also becomes a valid XML

### DIFF
--- a/classes/template/PKPTemplateManager.php
+++ b/classes/template/PKPTemplateManager.php
@@ -195,7 +195,7 @@ class PKPTemplateManager extends Smarty
             if (!empty($favicon)) {
                 $publicFileManager = new PublicFileManager();
                 $faviconDir = $request->getBaseUrl() . '/' . $publicFileManager->getContextFilesPath($currentContext->getId());
-                $this->addHeader('favicon', '<link rel="icon" href="' . $faviconDir . '/' . $favicon['uploadName'] . '">', ['contexts' => ['frontend', 'backend']]);
+                $this->addHeader('favicon', '<link rel="icon" href="' . $faviconDir . '/' . $favicon['uploadName'] . '" />', ['contexts' => ['frontend', 'backend']]);
             }
         }
 
@@ -256,12 +256,12 @@ class PKPTemplateManager extends Smarty
             // Register meta tags
             if (Application::isInstalled()) {
                 if (($request->getRequestedPage() == '' || $request->getRequestedPage() == 'index') && $currentContext && $currentContext->getLocalizedData('searchDescription')) {
-                    $this->addHeader('searchDescription', '<meta name="description" content="' . $currentContext->getLocalizedData('searchDescription') . '">');
+                    $this->addHeader('searchDescription', '<meta name="description" content="' . $currentContext->getLocalizedData('searchDescription') . '" />');
                 }
 
                 $this->addHeader(
                     'generator',
-                    '<meta name="generator" content="' . __($application->getNameKey()) . ' ' . $application->getCurrentVersion()->getVersionString(false) . '">',
+                    '<meta name="generator" content="' . __($application->getNameKey()) . ' ' . $application->getCurrentVersion()->getVersionString(false) . '" />',
                     [
                         'contexts' => ['frontend', 'backend'],
                     ]
@@ -290,7 +290,7 @@ class PKPTemplateManager extends Smarty
             if ($currentContext && !$currentContext->getEnabled()) {
                 $this->addHeader(
                     'noindex',
-                    '<meta name="robots" content="noindex,nofollow">',
+                    '<meta name="robots" content="noindex,nofollow" />',
                     [
                         'contexts' => ['frontend', 'backend'],
                     ]
@@ -2097,7 +2097,7 @@ class PKPTemplateManager extends Smarty
             case 'json': return json_encode($csrfToken);
             case 'html':
             default:
-                return '<input type="hidden" name="csrfToken" value="' . htmlspecialchars($csrfToken) . '">';
+                return '<input type="hidden" name="csrfToken" value="' . htmlspecialchars($csrfToken) . '" />';
         }
     }
 
@@ -2182,7 +2182,7 @@ class PKPTemplateManager extends Smarty
                     if (!empty($htmlStyle['inline'])) {
                         $links .= '<style type="text/css">' . $htmlStyle['style'] . '</style>' . "\n";
                     } else {
-                        $links .= '<link rel="stylesheet" href="' . $htmlStyle['style'] . '" type="text/css">' . "\n";
+                        $links .= '<link rel="stylesheet" href="' . $htmlStyle['style'] . '" type="text/css" />' . "\n";
                     }
                 }
             }


### PR DESCRIPTION
For digital long-term preservation with the Rosetta system, we use an XSL transformation. In order for the XSL file to be able to process the HTML pages generated here, they must also be valid XML.