### PR TITLE
Add the FieldContrastColorPicker as a form field

### DIFF
--- a/classes/components/forms/FieldContrastColorPicker.php
+++ b/classes/components/forms/FieldContrastColorPicker.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @file classes/components/form/FieldContrastColorPicker.php
+ *
+ * Copyright (c) 2014-2025 Simon Fraser University
+ * Copyright (c) 2000-2025 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class FieldContrastColorPicker
+ *
+ * @ingroup classes_controllers_form
+ *
+ * @brief A color picker field with automatic contrast color suggestions.
+ */
+
+namespace PKP\components\forms;
+
+class FieldContrastColorPicker extends Field
+{
+    /** @copydoc Field::$component */
+    public $component = 'field-contrast-color-picker';
+
+    /** @var string The selected contrast color */
+    public $contrastColor = '';
+
+    /**
+     * @copydoc Field::getConfig()
+     */
+    public function getConfig()
+    {
+        $config = parent::getConfig();
+        $config['contrastColor'] = $this->contrastColor;
+
+        return $config;
+    }
+
+    /**
+     * Set the contrast color
+     *
+     * @param string $contrastColor
+     * @return FieldContrastColorPicker
+     */
+    public function setContrastColor($contrastColor)
+    {
+        $this->contrastColor = $contrastColor;
+        return $this;
+    }
+}

--- a/js/load.js
+++ b/js/load.js
@@ -93,6 +93,7 @@ import FieldAutosuggestPreset from '@/components/Form/fields/FieldAutosuggestPre
 import FieldBase from '@/components/Form/fields/FieldBase.vue';
 import FieldBaseAutosuggest from '@/components/Form/fields/FieldBaseAutosuggest.vue';
 import FieldColor from '@/components/Form/fields/FieldColor.vue';
+import FieldContrastColorPicker from '@/components/Form/fields/FieldContrastColorPicker.vue';
 import FieldControlledVocab from '@/components/Form/fields/FieldControlledVocab.vue';
 import FieldHtml from '@/components/Form/fields/FieldHtml.vue';
 import FieldMetadataSetting from '@/components/Form/fields/FieldMetadataSetting.vue';
@@ -203,6 +204,7 @@ VueRegistry.registerComponent(
 VueRegistry.registerComponent('PkpFieldBase', FieldBase);
 VueRegistry.registerComponent('PkpFieldBaseAutosuggest', FieldBaseAutosuggest);
 VueRegistry.registerComponent('PkpFieldColor', FieldColor);
+VueRegistry.registerComponent('PkpFieldContrastColorPicker', FieldContrastColorPicker);
 VueRegistry.registerComponent('PkpFieldControlledVocab', FieldControlledVocab);
 VueRegistry.registerComponent('PkpFieldHtml', FieldHtml);
 VueRegistry.registerComponent('PkpFieldOrcid', FieldOrcid);
@@ -234,6 +236,7 @@ VueRegistry.registerComponent('PkpFieldSlider', FieldSlider);
 // Required by the URN plugin, to be migrated at some point to pkp prefix
 VueRegistry.registerComponent('field-text', FieldText);
 VueRegistry.registerComponent('field-pub-id', FieldPubId);
+VueRegistry.registerComponent('field-contrast-color-picker', FieldContrastColorPicker);
 
 // Register ListPanel
 VueRegistry.registerComponent('PkpListPanel', ListPanel);


### PR DESCRIPTION
### Description

Add the new ContrastColorPicker form component into the UI library. Related to issue [#11169](https://github.com/pkp/pkp-lib/issues/11169).