### PR TITLE
pkp/pkp-lib#11194 Remove c_v_e_s_pkey unique index from cv entry settings table

### DIFF
--- a/classes/migration/install/ControlledVocabMigration.php
+++ b/classes/migration/install/ControlledVocabMigration.php
@@ -58,7 +58,6 @@ class ControlledVocabMigration extends \PKP\migration\Migration
             $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
-            $table->unique(['controlled_vocab_entry_id', 'locale', 'setting_name'], 'c_v_e_s_pkey');
         });
 
         // Reviewer Interests Associative Table

--- a/classes/migration/upgrade/v3_5_0/I10292_UpdateControlledVocabEntrySettingName.php
+++ b/classes/migration/upgrade/v3_5_0/I10292_UpdateControlledVocabEntrySettingName.php
@@ -15,6 +15,8 @@
 namespace PKP\migration\upgrade\v3_5_0;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use PKP\install\DowngradeNotSupportedException;
 use PKP\migration\Migration;
 
@@ -25,8 +27,10 @@ class I10292_UpdateControlledVocabEntrySettingName extends Migration
      */
     public function up(): void
     {
-        DB::table('controlled_vocab_entry_settings')
-            ->update(['setting_name' => 'name']);
+        DB::table('controlled_vocab_entry_settings')->update(['setting_name' => 'name']);
+        Schema::table('controlled_vocab_entry_settings', function(Blueprint $table) {
+            $table->dropUnique('c_v_e_s_pkey');
+        });
     }
 
     /**


### PR DESCRIPTION
This PR is a subset of pkp/pkp-lib#11194 which aims to resolve the following error at upgrade , see this comment https://github.com/pkp/pkp-lib/issues/11194#issuecomment-2777486855


Basically after the merge of pkp/pkp-lib#10292, in the `controlled_vocab_entry_settings` table, we have updated the `setting_name` from different symbolic to just `name` which may clash with `c_v_e_s_pkey` unique index which is a combination of `controlled_vocab_entry_id,locale,setting_name` . Also it's not required anymore . 