### PR TITLE
pkp/pkp-lib#11286 make urlText field required for highlights

### DIFF
--- a/schemas/highlight.json
+++ b/schemas/highlight.json
@@ -4,7 +4,8 @@
 	"required": [
         "sequence",
 		"title",
-		"url"
+		"url",
+		"urlText"
 	],
 	"properties": {
 		"_href": {


### PR DESCRIPTION
Since we required the url field to be entered, it makes sense that the label for that button should also be required as there is no fallback value for it.