### PR TITLE
pkp/pkp-lib#9202 Include 3.4 missing email templates in 3.5 upgrade

### DIFF
--- a/classes/migration/upgrade/v3_5_0/InstallEmailTemplates.php
+++ b/classes/migration/upgrade/v3_5_0/InstallEmailTemplates.php
@@ -28,11 +28,23 @@ class InstallEmailTemplates extends Migration
     {
         return [
             'CHANGE_EMAIL',
+            'SUBMISSION_SAVED_FOR_LATER',
+            'SUBMISSION_NEEDS_EDITOR',
+            'REVIEW_COMPLETE',
+            'REVIEW_EDIT',
         ];
     }
 
     public function up(): void
     {
+        // remove the carried-over notifications template rows
+        DB::table('email_templates_default_data')
+            ->where('email_key', 'NOTIFICATION')
+            ->delete();
+        DB::table('email_templates')
+            ->where('email_key', 'NOTIFICATION')
+            ->delete();
+
         $xmlDao = new XMLDAO();
 
         $data = $xmlDao->parseStruct('registry/emailTemplates.xml', ['email']);


### PR DESCRIPTION
For [issue#9202](https://github.com/pkp/pkp-lib/issues/9202)