### PR TITLE
Add default country for contributors

### DIFF
--- a/classes/components/forms/publication/ContributorForm.php
+++ b/classes/components/forms/publication/ContributorForm.php
@@ -90,6 +90,7 @@ class ContributorForm extends FormComponent
                 'label' => __('common.country'),
                 'options' => $countries,
                 'isRequired' => true,
+                'value' => $context->getData('country'),
             ]))
             ->addField(new FieldText('url', [
                 'label' => __('user.url'),

--- a/controllers/grid/users/author/form/PKPAuthorForm.php
+++ b/controllers/grid/users/author/form/PKPAuthorForm.php
@@ -143,8 +143,15 @@ class PKPAuthorForm extends Form
                 'includeInBrowse' => $author->getIncludeInBrowse(),
             ];
         } else {
+            // Get context to set default country for new contributors
+            $publication = $this->getPublication();
+            $submission = Repo::submission()->get($publication->getData('submissionId'));
+            $context = Services::get('context')->get($submission->getData('contextId'));
             // assume authors should be listed unless otherwise specified.
-            $this->_data = ['includeInBrowse' => true];
+            $this->_data = [
+                'includeInBrowse' => true,
+                'country' => $context->getData('country'),
+            ];
         }
         // in order to be able to use the hook
         return parent::initData();


### PR DESCRIPTION
After setting up, when adding a new contributor:
The Country field will automatically default to the country set in the Journal settings
Users can still change the country if needed
Benefits:
- Save time when adding contributors
- Ensure data consistency
- Reduce errors when users forget to select a country
- Compatible with both new and old forms of the system

Feature requests: https://forum.pkp.sfu.ca/t/setting-a-default-contributor-country-in-ojs-3-4-submission-wizard/95984/3