### PR TITLE
[OJS][3.4] Update stripUnsafeHtmlMethod

### DIFF
--- a/classes/core/PKPString.php
+++ b/classes/core/PKPString.php
@@ -414,6 +414,7 @@ class PKPString
             $config->set('HTML.Doctype', 'HTML 4.01 Transitional');
             $config->set('HTML.Allowed', Config::getVar('security', $configKey));
             $config->set('Cache.SerializerPath', 'cache');
+            $config->set('Attr.AllowedFrameTargets', ['_blank']);
             $purifier = new HTMLPurifier($config);
         }
         return $purifier->purify((string) $input);

--- a/classes/template/PKPTemplateManager.php
+++ b/classes/template/PKPTemplateManager.php
@@ -254,6 +254,9 @@ class PKPTemplateManager extends Smarty
                 if (Config::getVar('captcha', 'captcha_on_login')) {
                     array_push($contexts, 'frontend-login-index', 'frontend-login-signIn');
                 }
+                if (Config::getVar('captcha', 'captcha_on_lost_password')) {
+                    array_push($contexts, 'frontend-login-lostPassword', 'frontend-login-requestResetPassword');
+                }
                 if (count($contexts)) {
                     $this->addJavaScript(
                         'recaptcha',

--- a/templates/frontend/pages/userLostPassword.tpl
+++ b/templates/frontend/pages/userLostPassword.tpl
@@ -39,6 +39,19 @@
 					<input type="email" name="email" id="email" value="{$email|escape}" required aria-required="true" autocomplete="email">
 				</label>
 			</div>
+
+			{* recaptcha spam blocker *}
+			{if $recaptchaPublicKey}
+				<fieldset class="recaptcha_wrapper">
+					<div class="fields">
+						<div class="recaptcha">
+							<div class="g-recaptcha" data-sitekey="{$recaptchaPublicKey|escape}">
+							</div><label for="g-recaptcha-response" style="display:none;" hidden>Recaptcha response</label>
+						</div>
+					</div>
+				</fieldset>
+			{/if}
+
 			<div class="buttons">
 				<button class="submit" type="submit">
 					{translate key="user.login.resetPassword"}


### PR DESCRIPTION
**Description**: This PR adds a new property to HTMLPurifier that allows users to open links in new tabs. We discovered this issue when clients reported that saved settings (like Journal Summary with links configured to open in new tabs) were being stripped of their target attributes, causing all links to open in the same tab instead of respecting the original configuration.