### PR TITLE
add a new property to allow links to open on new tabs

### DIFF
--- a/classes/core/PKPString.php
+++ b/classes/core/PKPString.php
@@ -171,6 +171,7 @@ class PKPString
             $config->set('HTML.Doctype', 'HTML 4.01 Transitional');
             $config->set('HTML.Allowed', Config::getVar('security', $configKey));
             $config->set('Cache.SerializerPath', 'cache');
+            $config->set('Attr.AllowedFrameTargets', ['_blank']);
             $purifier = new HTMLPurifier($config);
         }
         return $purifier->purify((string) $input);


### PR DESCRIPTION
**Description**: This PR adds a new property to HTMLPurifier that allows users to open links in new tabs. We discovered this issue when clients reported that saved settings (like Journal Summary with links configured to open in new tabs) were being stripped of their target attributes, causing all links to open in the same tab instead of respecting the original configuration.