### PR TITLE
Cast userId column to ensure auth logic works properly

### DIFF
--- a/classes/userGroup/relationships/UserUserGroup.php
+++ b/classes/userGroup/relationships/UserUserGroup.php
@@ -33,6 +33,7 @@ class UserUserGroup extends \Illuminate\Database\Eloquent\Model
     protected $casts = [
         'dateStart' => 'datetime',
         'dateEnd' => 'datetime',
+        'userId' => 'int',
     ];
 
     public function user(): Attribute


### PR DESCRIPTION
We've had an issue where "Login As" doesn't show up correctly, and when tracing this through I found it to be caused by permission checks not quite working at https://github.com/pkp/pkp-lib/blob/f9e374720827d15b8e14a0ca93cf81a161011e3e/classes/security/Validation.php#L519

Following this through, it's seemingly caused by the Laravel/Eloquent model loading in the column for `userId` as a string and not an integer, so this small PR ensures the comparison is between an integer and an integer,