### PR TITLE
Allow for user XML files with no additional groups

### DIFF
--- a/plugins/importexport/users/pkp-users.xsd
+++ b/plugins/importexport/users/pkp-users.xsd
@@ -86,7 +86,7 @@
 	<element name="PKPUsers">
 		<complexType>
 			<sequence>
-				<element ref="pkp:user_groups" maxOccurs="1" />
+				<element ref="pkp:user_groups" minOccurs="0" maxOccurs="1" />
 				<element ref="pkp:users" maxOccurs="1" />
 			</sequence>
 		</complexType>


### PR DESCRIPTION
A minor issue I've ran into is when using XML files of users and we don't want to create any groups, so we have not specified any groups (all of the default ones when creating a journal are fine for us).

However, the XML does not validate and in fact no error is presented to the user (an issue we'd like to explore further separately) just for not specifying any groups to add. In our testing, this allows us to get our XML importing.
