### PR TITLE
Don't error out if a ReviewerSuggestion does not have a submission

### DIFF
--- a/classes/submission/reviewer/suggestion/ReviewerSuggestion.php
+++ b/classes/submission/reviewer/suggestion/ReviewerSuggestion.php
@@ -181,7 +181,7 @@ class ReviewerSuggestion extends Model
     protected function existingReviewerRole(): Attribute
     {
         return Attribute::make(
-            get: fn () => (bool)$this->existingUser?->hasRole(
+            get: fn () => ($this->submission !== null) && (bool)$this->existingUser?->hasRole(
                 [Role::ROLE_ID_REVIEWER],
                 $this->submission->getData('contextId')
             )


### PR DESCRIPTION
We've come across an issue with some submissions where they cannot be viewed with the API call erroring as such:

```
{ "error": "Call to member function getData() on null" }
```

with the following error log:

```
Error: Call to a member function getData() on null in /home/oiccpres/public_html/lib/pkp/classes/submission/reviewer/suggestion/ReviewerSuggestion.php:186
Stack trace:
#0 [internal function]: PKP\submission\reviewer\suggestion\ReviewerSuggestion->PKP\submission\reviewer\suggestion\{closure}()
#1 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(718): call_user_func()
#2 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(2226): Illuminate\Database\Eloquent\Model->mutateAttributeMarkedAttribute()
#3 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(520): Illuminate\Database\Eloquent\Model->transformModelValue()
#4 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(474): Illuminate\Database\Eloquent\Model->getAttributeValue()
#5 /home/oiccpres/public_html/lib/pkp/classes/core/traits/ModelWithSettings.php(221): Illuminate\Database\Eloquent\Model->getAttribute()
#6 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2260): PKP\submission\reviewer\suggestion\ReviewerSuggestion->getAttribute()
#7 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Http/Resources/DelegatesToResource.php(139): Illuminate\Database\Eloquent\Model->__get()
#8 /home/oiccpres/public_html/lib/pkp/api/v1/reviewers/suggestions/resources/ReviewerSuggestionResource.php(43): Illuminate\Http\Resources\Json\JsonResource->__get()
#9 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/HigherOrderCollectionProxy.php(65): PKP\API\v1\reviewers\suggestions\resources\ReviewerSuggestionResource->toArray()
#10 [internal function]: Illuminate\Support\HigherOrderCollectionProxy->Illuminate\Support\{closure}()
#11 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/Arr.php(609): array_map()
#12 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(799): Illuminate\Support\Arr::map()
#13 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/HigherOrderCollectionProxy.php(64): Illuminate\Support\Collection->map()
#14 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Http/Resources/Json/ResourceCollection.php(102): Illuminate\Support\HigherOrderCollectionProxy->__call()
#15 /home/oiccpres/public_html/lib/pkp/classes/submission/maps/Schema.php(613): Illuminate\Http\Resources\Json\ResourceCollection->toArray()
#16 /home/oiccpres/public_html/lib/pkp/classes/submission/maps/Schema.php(548): PKP\submission\maps\Schema->getPropertyReviewerSuggestions()
#17 /home/oiccpres/public_html/classes/submission/maps/Schema.php(55): PKP\submission\maps\Schema->mapByProperties()
#18 /home/oiccpres/public_html/lib/pkp/classes/submission/maps/Schema.php(156): APP\submission\maps\Schema->mapByProperties()
#19 /home/oiccpres/public_html/lib/pkp/api/v1/submissions/PKPSubmissionController.php(550): PKP\submission\maps\Schema->map()
#20 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/CallableDispatcher.php(40): PKP\API\v1\submissions\PKPSubmissionController->get()
#21 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Route.php(244): Illuminate\Routing\CallableDispatcher->dispatch()
#22 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Route.php(215): Illuminate\Routing\Route->runCallable()
#23 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(808): Illuminate\Routing\Route->run()
#24 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(170): Illuminate\Routing\Router->Illuminate\Routing\{closure}()
#25 /home/oiccpres/public_html/lib/pkp/classes/middleware/HasRoles.php(75): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#26 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\HasRoles->handle()
#27 /home/oiccpres/public_html/lib/pkp/classes/middleware/HasContext.php(35): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#28 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\HasContext->handle()
#29 /home/oiccpres/public_html/lib/pkp/classes/middleware/HasUser.php(35): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#30 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\HasUser->handle()
#31 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(127): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#32 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(807): Illuminate\Pipeline\Pipeline->then()
#33 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(786): Illuminate\Routing\Router->runRouteWithinStack()
#34 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(750): Illuminate\Routing\Router->runRoute()
#35 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(739): Illuminate\Routing\Router->dispatchToRoute()
#36 /home/oiccpres/public_html/lib/pkp/classes/handler/APIHandler.php(103): Illuminate\Routing\Router->dispatch()
#37 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(170): PKP\handler\APIHandler->PKP\handler\{closure}()
#38 /home/oiccpres/public_html/lib/pkp/classes/middleware/PolicyAuthorizer.php(71): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#39 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\PolicyAuthorizer->handle()
#40 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#41 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php(31): Illuminate\Foundation\Http\Middleware\TransformsRequest->handle()
#42 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull->handle()
#43 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#44 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php(51): Illuminate\Foundation\Http\Middleware\TransformsRequest->handle()
#45 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): Illuminate\Foundation\Http\Middleware\TrimStrings->handle()
#46 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Http/Middleware/ValidatePostSize.php(27): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#47 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): Illuminate\Http\Middleware\ValidatePostSize->handle()
#48 /home/oiccpres/public_html/lib/pkp/classes/middleware/ValidateCsrfToken.php(55): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#49 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\ValidateCsrfToken->handle()
#50 /home/oiccpres/public_html/lib/pkp/classes/middleware/DecodeApiTokenWithValidation.php(76): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#51 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\DecodeApiTokenWithValidation->handle()
#52 /home/oiccpres/public_html/lib/pkp/classes/middleware/SetupContextBasedOnRequestUrl.php(63): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#53 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\SetupContextBasedOnRequestUrl->handle()
#54 /home/oiccpres/public_html/lib/pkp/classes/middleware/AllowCrossOrigin.php(34): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#55 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): PKP\middleware\AllowCrossOrigin->handle()
#56 /home/oiccpres/public_html/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(127): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#57 /home/oiccpres/public_html/lib/pkp/classes/handler/APIHandler.php(102): Illuminate\Pipeline\Pipeline->then()
#58 /home/oiccpres/public_html/lib/pkp/classes/core/APIRouter.php(116): PKP\handler\APIHandler->runRoutes()
#59 /home/oiccpres/public_html/lib/pkp/classes/core/Dispatcher.php(157): PKP\core\APIRouter->route()
#60 /home/oiccpres/public_html/lib/pkp/classes/core/PKPApplication.php(426): PKP\core\Dispatcher->dispatch()
#61 /home/oiccpres/public_html/index.php(21): PKP\core\PKPApplication->execute()
#62 {main}
```

I'm not sure how this got into this position, but I just added a quick check to preventing the error, and returning false in the case the submission is not available
