### PR TITLE
Fix notification bug: Cast notification type to integer

### DIFF
--- a/classes/notification/Notification.php
+++ b/classes/notification/Notification.php
@@ -115,6 +115,7 @@ class Notification extends Model
             'dateRead' => 'datetime',
             'assocType' => 'int',
             'assocId' => 'int',
+            'type' => 'int',
         ];
     }
 


### PR DESCRIPTION
Part of an issue with notifications is the text could not be displayed for notifications. This seems to be another issue with casting data to/from database which this was able to correct this issue for us.