### PR TITLE
pkp/pkp-lib#9295 continuous publication implementation update

### DIFF
--- a/classes/search/engines/DatabaseEngine.php
+++ b/classes/search/engines/DatabaseEngine.php
@@ -76,7 +76,7 @@ class DatabaseEngine extends ScoutEngine
                 fn ($q) => $q->selectRaw(1)
                     ->from('publications AS p')
                     ->whereColumn('p.submission_id', 's.submission_id')
-                    ->where('p.published', 1)
+                    ->where('p.status', PKPSubmission::STATUS_PUBLISHED)
                     ->when($publishedFrom, fn ($q) => $q->whereDate('p.date_published', '>=', $publishedFrom))
                     ->when($publishedTo, fn ($q) => $q->whereDate('p.date_published', '<', $publishedTo))
                     ->when(is_array($sectionIds), fn ($q) => $q->whereIn('p.section_id', $sectionIds))

--- a/classes/submission/Collector.php
+++ b/classes/submission/Collector.php
@@ -422,7 +422,7 @@ abstract class Collector implements CollectorInterface, ViewsCount
         // search phrases starting with number followed by a '.'  will be interpreted as a DOI identifier. E.g: 10.1
         $isSearchPhraseDoi = Doi::beginsWithDoiPrefixPattern($this->searchPhrase ?: '');
         // Prepare keywords (allows short and numeric words)
-        $keywords = collect(!$isSearchPhraseDoi ? explode(' ', $this->searchPhrase) : [])
+        $keywords = collect(!$isSearchPhraseDoi ? explode(' ', $this->searchPhrase ?? '') : [])
             ->unique()
             ->take($this->maxSearchKeywords ?? PHP_INT_MAX);
 

--- a/classes/submission/PKPSubmission.php
+++ b/classes/submission/PKPSubmission.php
@@ -43,6 +43,7 @@ abstract class PKPSubmission extends \PKP\core\DataObject
     public const STATUS_PUBLISHED = 3;
     public const STATUS_DECLINED = 4;
     public const STATUS_SCHEDULED = 5;
+    public const STATUS_READY_TO_PUBLISH = 6;
 
     // License settings (internal use only)
     public const PERMISSIONS_FIELD_LICENSE_URL = 1;

--- a/classes/template/PKPTemplateManager.php
+++ b/classes/template/PKPTemplateManager.php
@@ -868,6 +868,7 @@ class PKPTemplateManager extends Smarty
             'STATUS_PUBLISHED' => Submission::STATUS_PUBLISHED,
             'STATUS_DECLINED' => Submission::STATUS_DECLINED,
             'STATUS_SCHEDULED' => Submission::STATUS_SCHEDULED,
+            'STATUS_READY_TO_PUBLISH' => Submission::STATUS_READY_TO_PUBLISH,
         ]);
 
 


### PR DESCRIPTION
for pkp/pkp-lib#9295 , second batch of PRs to update the implementation to 
1. remove the previously introduced `published` column in `publications` table
2. introduce on the `status` column of `publications` table by introducing a new status `PKPSubmission::STATUS_READY_TO_PUBLISH`
3. update the publishing/scheduling workflow by combining multiple modal into one . 