### PR TITLE
Add BeforeSend hook to Mailer

### DIFF
--- a/classes/mail/Mailer.php
+++ b/classes/mail/Mailer.php
@@ -159,7 +159,7 @@ class Mailer extends IlluminateMailer
     {
         $sentMessage = null;
         try {
-            Hook::call('Email::BeforeSend', [$message]);
+            Hook::call('Email::send::before', [$message]);
             $sentMessage = $this->transport->send($message, Envelope::create($message));
         } catch (TransportException $e) {
             error_log($e->getMessage());

--- a/classes/mail/Mailer.php
+++ b/classes/mail/Mailer.php
@@ -159,7 +159,7 @@ class Mailer extends IlluminateMailer
     {
         $sentMessage = null;
         try {
-            Hook::call('Email::send::before', [$message]);
+            Hook::call('Email::send::before', ['message' => $message, 'mailer' => $this]);
             $sentMessage = $this->transport->send($message, Envelope::create($message));
         } catch (TransportException $e) {
             error_log($e->getMessage());

--- a/classes/mail/Mailer.php
+++ b/classes/mail/Mailer.php
@@ -27,6 +27,7 @@ use PKP\config\Config;
 use PKP\observers\events\MessageSendingFromContext;
 use PKP\observers\events\MessageSendingFromSite;
 use PKP\site\Site;
+use PKP\plugins\Hook;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -158,6 +159,7 @@ class Mailer extends IlluminateMailer
     {
         $sentMessage = null;
         try {
+            Hook::call('Email::BeforeSend', [$message]);
             $sentMessage = $this->transport->send($message, Envelope::create($message));
         } catch (TransportException $e) {
             error_log($e->getMessage());


### PR DESCRIPTION
Adds a hook to allow email changes before sending an email - i.e changing emails to follow policies

For example to force a from address no matter what (i.e we don't want the return path or any address pointing to the contact email address), or to add content to every email being sent out