### PR TITLE
Prevent password reuse when user is forced to change password

### DIFF
--- a/classes/user/form/LoginChangePasswordForm.php
+++ b/classes/user/form/LoginChangePasswordForm.php
@@ -42,6 +42,9 @@ class LoginChangePasswordForm extends Form
         }));
         $this->addCheck(new \PKP\form\validation\FormValidatorLength($this, 'password', 'required', 'user.register.form.passwordLengthRestriction', '>=', $site->getMinPasswordLength()));
         $this->addCheck(new \PKP\form\validation\FormValidator($this, 'password', 'required', 'user.profile.form.newPasswordRequired'));
+        $this->addCheck(new \PKP\form\validation\FormValidatorCustom($this, 'password', 'required', 'user.profile.form.passwordSameAsOld', function ($password) use ($form) {
+            return $password != $form->getData('oldPassword');
+        }));
         $this->addCheck(new \PKP\form\validation\FormValidatorCustom($this, 'password', 'required', 'user.register.form.passwordsDoNotMatch', function ($password) use ($form) {
             return $password == $form->getData('password2');
         }));


### PR DESCRIPTION
I copied the custom validator from https://github.com/pkp/pkp-lib/blob/4743d81c444af37bd37b7b338607565eb508c51a/classes/user/form/ChangePasswordForm.php#L59-L60 to apply the same rule/error-message here. 