### PR TITLE
ORCID: Handle authors accessing authorize link multiple times

### DIFF
--- a/jobs/orcid/SendAuthorMail.php
+++ b/jobs/orcid/SendAuthorMail.php
@@ -58,7 +58,7 @@ class SendAuthorMail extends BaseJob implements ShouldBeUnique
         $this->author->setData('orcidEmailToken', $emailToken);
         $oauthUrl = OrcidManager::buildOAuthUrl(
             'verify',
-            ['token' => $emailToken, 'state' => $publicationId],
+            ['token' => $emailToken, 'state' => $publicationId, 'author_id' => $this->author->getId()],
             $this->context
         );
 


### PR DESCRIPTION
This PR covers a couple of issues we have faced around where authors were clicking multiple times on the "Authorize" link within emails sent for ORCIDs.

* There was a fatal error upon trying again as it would try to still complete the action with no author available
* There was a confusing error message where the author thought the action was not complete, yet it was already completed, so we have added an ability to the page to display a different error message in this situation.