### PR TITLE
pkp/pkp-lib#11589 add wasCurrentPublication to the hook Publication::…

### DIFF
--- a/classes/publication/Repository.php
+++ b/classes/publication/Repository.php
@@ -730,7 +730,8 @@ abstract class Repository
             [
                 &$newPublication,
                 $publication,
-                $submission
+                $submission,
+                $wasCurrentPublication
             ]
         );
 


### PR DESCRIPTION
…unpublish

Export/indexing plugins listening to this hook Publication::unpublish could not know if the current publication has just been unpublished, because the submission (and its current publication) was already updated. Thus we provide this information to the hook.

s. https://github.com/pkp/pkp-lib/issues/11589
s. https://github.com/pkp/pkp-lib/issues/11593#issuecomment-3387044177