### PR TITLE
Submission Emails: Use author email link when emailing authors

### DIFF
--- a/classes/mail/variables/SubmissionEmailVariable.php
+++ b/classes/mail/variables/SubmissionEmailVariable.php
@@ -121,6 +121,16 @@ abstract class SubmissionEmailVariable extends Variable
      */
     protected function getSubmissionUrl(Context $context): string
     {
+        $to = $this->mailable->to[0]['address'];
+        $authors = $this->currentPublication->getData('authors');
+        foreach($authors as $author)
+        {
+            if($to == $author->getEmail())
+            {
+                return $this->getAuthorSubmissionUrl($context);
+            }
+        }
+        
         $application = PKPApplication::get();
         $request = $application->getRequest();
         $dispatcher = $application->getDispatcher();


### PR DESCRIPTION
We have come across an issue when using discussions on a submission:

The email link sends the author to a dead end as it assumes they are an editor. This PR checks if they are the author and swaps for the "my submissions" url instead allowing them to view the conversation and correct context,