### PR TITLE
Add Mailable::build hook

### DIFF
--- a/classes/mail/Mailable.php
+++ b/classes/mail/Mailable.php
@@ -54,6 +54,7 @@ use PKP\mail\variables\SenderEmailVariable;
 use PKP\mail\variables\SiteEmailVariable;
 use PKP\mail\variables\Variable;
 use PKP\payment\QueuedPayment;
+use PKP\plugins\Hook;
 use PKP\site\Site;
 use PKP\submission\PKPSubmission;
 use PKP\submission\reviewAssignment\ReviewAssignment;
@@ -321,6 +322,7 @@ class Mailable extends IlluminateMailable
      */
     public function build(): self
     {
+        Hook::run('Mailable::build', ['mailable' => $this]);
         return $this;
     }
 


### PR DESCRIPTION
Plugins can use the Mailable::build hook to modify any textual part of an email before it is sent. This includes the email subject, HTML body, plain-text body, markdown body, and all string-based template variables (viewData). Attachments, recipients, and delivery settings are unaffected unless explicitly changed.
