### PR TITLE
pkp/pkp-lib#10463 Add missing configurable email templates

### DIFF
--- a/classes/mail/Repository.php
+++ b/classes/mail/Repository.php
@@ -20,13 +20,9 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use PKP\context\Context;
 use PKP\mail\mailables\DecisionNotifyOtherAuthors;
-use PKP\mail\mailables\EditReviewNotify;
-use PKP\mail\mailables\ReviewCompleteNotifyEditors;
 use PKP\mail\mailables\StatisticsReportNotify;
 use PKP\mail\mailables\SubmissionAcknowledgement;
 use PKP\mail\mailables\SubmissionAcknowledgementNotAuthor;
-use PKP\mail\mailables\SubmissionNeedsEditor;
-use PKP\mail\mailables\SubmissionSavedForLater;
 use PKP\mail\traits\Configurable;
 use PKP\plugins\Hook;
 
@@ -188,24 +184,6 @@ class Repository
         if (!in_array(Configurable::class, class_uses_recursive($class))) {
             return false;
         }
-
-        /**
-         * Mailables may not have associated email templates due to pkp/pkp-lib#9109 and pkp/pkp-lib#9217,
-         * don't allow to configure them
-         * FIXME remove after #9202 is resolved
-         */
-        if (in_array($class, [
-            EditReviewNotify::class,
-            ReviewCompleteNotifyEditors::class,
-            SubmissionSavedForLater::class,
-            SubmissionNeedsEditor::class,
-        ])) {
-            $template = Repo::emailTemplate()->getByKey($context->getId(), $class::getEmailTemplateKey());
-            if (!$template) {
-                return false;
-            }
-        }
-
         return true;
     }
 
@@ -278,6 +256,8 @@ class Repository
             mailables\ValidateEmailContext::class,
             mailables\ValidateEmailSite::class,
             mailables\RequestReviewRoundAuthorResponse::class,
+            mailables\SubmissionSavedForLater::class,
+            mailables\SubmissionNeedsEditor::class,
         ]);
     }
 }

--- a/classes/mail/mailables/SubmissionSavedForLater.php
+++ b/classes/mail/mailables/SubmissionSavedForLater.php
@@ -19,12 +19,14 @@ use APP\decision\Decision;
 use APP\submission\Submission;
 use PKP\context\Context;
 use PKP\mail\Mailable;
+use PKP\mail\traits\Configurable;
 use PKP\mail\traits\Recipient;
 use PKP\security\Role;
 
 class SubmissionSavedForLater extends Mailable
 {
     use Recipient;
+    use Configurable;
 
     /** @var string An email variable that contains a description of the editorial decision */
     public const DECISION_DESCRIPTION = 'decisionDescription';


### PR DESCRIPTION
Some templates were missing in the configuration list.

- SubmissionNeedsEditor
- SubmissionSavedForLater

As #9202 seems to be resolved, I also removed the patch section.

SubmissionSavedForLater is now configurable as well.

All this resolves the ticket #10463.