### PR TITLE
consider OpenAlex API key from the config

### DIFF
--- a/classes/citation/externalServices/openAlex/Inbound.php
+++ b/classes/citation/externalServices/openAlex/Inbound.php
@@ -19,6 +19,7 @@ namespace PKP\citation\externalServices\openAlex;
 use PKP\citation\Citation;
 use PKP\citation\enum\CitationType;
 use PKP\citation\externalServices\ExternalServicesHelper;
+use PKP\config\Config;
 
 class Inbound
 {
@@ -41,9 +42,15 @@ class Inbound
      */
     public function getWork(Citation $citation): ?Citation
     {
+        $apiKey = Config::getVar('features', 'openalex_api_key');
+        if ($apiKey) {
+            $options = ['query' => ['api_key' => $apiKey]];
+        } else {
+            $options = ['headers' => ['mailto' => $this->contactEmail]];
+        }
         $response = ExternalServicesHelper::apiRequest(
             $this->url . '/works/doi:' . urlencode($citation->getData('doi')),
-            ['headers' => ['mailto' => $this->contactEmail]]
+            $options
         );
 
         if (is_int($response)) {


### PR DESCRIPTION
This is temporary solution, so that we can get the structured citations for ORE immediately
The contact email, that we used in the header is not necessarily the one that gets the API key, that is why either API key or if it does not exist then the mailto header.