### PR TITLE
Fix PHP 8.3 deprecation in Validation::suggestUsername

### DIFF
--- a/classes/security/Validation.php
+++ b/classes/security/Validation.php
@@ -351,8 +351,12 @@ class Validation
         }
 
         $suggestion = Str::of($name)->ascii()->lower()->replaceMatches('/[^a-zA-Z0-9_-]/', '');
-        for ($i = ''; Repo::user()->getByUsername($suggestion . $i, true); $i++);
-        return $suggestion . $i;
+        $suffix = '';
+        $i = 0;
+        while (Repo::user()->getByUsername($suggestion . $suffix, true)) {
+            $suffix = (string) ++$i;
+        }
+        return $suggestion . $suffix;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replace empty-string increment (`$i = ''; $i++`) with integer arithmetic to eliminate the PHP 8.3 deprecation notice "Increment on non-alphanumeric string is deprecated" (will become a `TypeError` in PHP 9.0)
- Output is identical: `jsmith`, `jsmith1`, `jsmith2`, ...

## Changes

`lib/pkp/classes/security/Validation.php` — `suggestUsername()`:

```php
// Before (deprecated in PHP 8.3)
for ($i = ''; Repo::user()->getByUsername($suggestion . $i, true); $i++);
return $suggestion . $i;

// After
$suffix = '';
$i = 0;
while (Repo::user()->getByUsername($suggestion . $suffix, true)) {
    $suffix = (string) ++$i;
}
return $suggestion . $suffix;
```

Fixes #12377