### PR TITLE
pkp/pkp-lib#12385 Only display roles from the current context in the "Limit access to specific roles" section when creating or editing email templates

### DIFF
--- a/classes/components/forms/emailTemplate/EmailTemplateForm.php
+++ b/classes/components/forms/emailTemplate/EmailTemplateForm.php
@@ -20,6 +20,7 @@ use PKP\components\forms\FieldOptions;
 use PKP\components\forms\FieldPreparedContent;
 use PKP\components\forms\FieldText;
 use PKP\components\forms\FormComponent;
+use PKP\context\Context;
 use PKP\emailTemplate\EmailTemplate;
 use PKP\security\Role;
 use PKP\userGroup\UserGroup;
@@ -29,14 +30,14 @@ class EmailTemplateForm extends FormComponent
     public const FORM_EMAIL_TEMPLATE = 'editEmailTemplate';
     public $id = self::FORM_EMAIL_TEMPLATE;
 
-    public function __construct(string $action, array $locales)
+    public function __construct(string $action, array $locales, Context $context)
     {
         $this->action = $action;
         $this->method = 'POST';
         $this->locales = $locales;
         $userGroups = collect();
 
-        UserGroup::all()
+        UserGroup::withContextIds([$context->getId()])
             ->each(function (UserGroup $group) use ($userGroups) {
                 if ($group->roleId !== Role::ROLE_ID_SITE_ADMIN) {
                     $userGroups->add([

--- a/pages/management/ManagementHandler.php
+++ b/pages/management/ManagementHandler.php
@@ -661,7 +661,7 @@ class ManagementHandler extends Handler
         $locales = $context->getSupportedFormLocaleNames();
         $locales = array_map(fn (string $locale, string $name) => ['key' => $locale, 'label' => $name], array_keys($locales), $locales);
 
-        return new EmailTemplateForm($apiUrl, $locales);
+        return new EmailTemplateForm($apiUrl, $locales, $context);
     }
 
     protected function getEmailGroupFilters(): array


### PR DESCRIPTION
For pkp/pkp-lib#12385