### PR TITLE
pkp/pkp-lib#12398 Add descriptive error messages to ReviewerAccessInvite validation failures

### DIFF
--- a/classes/invitation/invitations/reviewerAccess/ReviewerAccessInvite.php
+++ b/classes/invitation/invitations/reviewerAccess/ReviewerAccessInvite.php
@@ -105,43 +105,45 @@ class ReviewerAccessInvite extends Invitation implements IBackofficeHandleable, 
         $context = $contextDao->getById($this->invitationModel->contextId);
 
         if ($context->getData('reviewerAccessKeysEnabled')) {
-            if (!$this->_validateAccessKey()) {
-                throw new Exception();
-            }
+            $this->_validateAccessKey();
 
             $this->invitationModel->markAs(InvitationStatus::ACCEPTED);
         }
     }
 
-    private function _validateAccessKey(): bool
+    /**
+     * Validate the access key for the reviewer invitation.
+     *
+     * @throws Exception If validation fails, with a descriptive message.
+     */
+    private function _validateAccessKey(): void
     {
         $reviewAssignment = Repo::reviewAssignment()->get($this->getPayload()->reviewAssignmentId);
 
         if (!$reviewAssignment) {
-            return false;
+            throw new Exception('The review assignment associated with this invitation could not be found.');
         }
 
-        // Check if the user is already logged in
-        if (Application::get()->getRequest()->getSessionGuard()->getUserId() && Application::get()->getRequest()->getSessionGuard()->getUserId() != $this->invitationModel->userId) {
-            return false;
+        // Check if a different user is already logged in
+        $loggedInUserId = Application::get()->getRequest()->getSessionGuard()->getUserId();
+        if ($loggedInUserId && $loggedInUserId != $this->invitationModel->userId) {
+            throw new Exception('You are logged in as a different user. Please log out and try the invitation link again.');
         }
 
         $reviewSubmission = Repo::submission()->getByBestId($reviewAssignment->getSubmissionId());
         if (!isset($reviewSubmission)) {
-            return false;
+            throw new Exception('The submission associated with this review assignment could not be found.');
         }
 
         // Get the reviewer user object
         $user = Repo::user()->get($this->invitationModel->userId);
         if (!$user) {
-            return false;
+            throw new Exception('The reviewer account associated with this invitation could not be found.');
         }
 
         // Register the user object in the session
         $reason = null;
         Validation::registerUserSession($user, $reason);
-
-        return true;
     }
 
     public function getInvitationActionRedirectController(): ?InvitationActionRedirectController

--- a/classes/invitation/invitations/reviewerAccess/handlers/ReviewerAccessInviteRedirectController.php
+++ b/classes/invitation/invitations/reviewerAccess/handlers/ReviewerAccessInviteRedirectController.php
@@ -40,7 +40,7 @@ class ReviewerAccessInviteRedirectController extends InvitationActionRedirectCon
         $reviewAssignment = Repo::reviewAssignment()->get($this->getInvitation()->getPayload()->reviewAssignmentId);
 
         if (!$reviewAssignment) {
-            throw new Exception();
+            throw new Exception('The review assignment associated with this invitation could not be found.');
         }
 
         $url = PKPApplication::get()->getDispatcher()->url(


### PR DESCRIPTION
When a reviewer clicks an invitation acceptance link and validation fails (e.g., a different user is already logged in, the review assignment doesn't exist, or the reviewer account is not found), the application currently throws empty `Exception()` instances with no message. This results in an unhelpful HTTP 500 error page for the user and unhelpful error logs for admins.

This PR adds descriptive error messages to each failure case in `_validateAccessKey()` and `ReviewerAccessInviteRedirectController::acceptHandle()`, making it easier for both users and administrators to diagnose why an invitation link failed.

**Relates to #12398**

**Follow-on work:** These exceptions still result in HTTP 500 responses. A future improvement could catch them at the controller level and redirect to a user-friendly error page with the descriptive message.

