### PR TITLE
pkp/pkp-lib#3477 Show competing interests for declining reviewers

### DIFF
--- a/pages/reviewer/PKPReviewerHandler.php
+++ b/pages/reviewer/PKPReviewerHandler.php
@@ -244,6 +244,12 @@ class PKPReviewerHandler extends Handler
 
         $declineReviewMessage = $request->getUserVar('declineReviewMessage');
 
+        // Save competing interests declared on Step 1 before declining.
+        $competingInterests = $request->getUserVar('competingInterestOption') === 'hasCompetingInterests'
+            ? $request->getUserVar('reviewerCompetingInterests')
+            : null;
+        $reviewAssignment->setCompetingInterests($competingInterests);
+
         // Decline the review
         $reviewerAction = new ReviewerAction();
         $submission = $this->getAuthorizedContextObject(PKPApplication::ASSOC_TYPE_SUBMISSION);

--- a/templates/controllers/grid/users/reviewer/readReview.tpl
+++ b/templates/controllers/grid/users/reviewer/readReview.tpl
@@ -53,14 +53,14 @@
 				{translate key="editor.review.readConfirmation"}
 			{/fbvFormSection}
 
-			{if $reviewAssignment->getDateCompleted()}
-				{if $reviewAssignment->getCompetingInterests()}
-					<h3>{translate key="reviewer.submission.competingInterests"}</h3>
-					<div class="review_competing_interests">
-						{$reviewAssignment->getCompetingInterests()|nl2br|strip_unsafe_html}
-					</div>
-				{/if}
+			{if $reviewAssignment->getCompetingInterests()}
+				<h3>{translate key="reviewer.submission.competingInterests"}</h3>
+				<div class="review_competing_interests">
+					{$reviewAssignment->getCompetingInterests()|nl2br|strip_unsafe_html}
+				</div>
+			{/if}
 
+			{if $reviewAssignment->getDateCompleted()}
 				{fbvFormSection}
 					<div class="pkp_controllers_informationCenter_itemLastEvent">
 						{translate key="common.completed.date" dateCompleted=$reviewAssignment->getDateCompleted()|date_format:$datetimeFormatShort}

--- a/templates/reviewer/review/modal/regretMessage.tpl
+++ b/templates/reviewer/review/modal/regretMessage.tpl
@@ -13,11 +13,18 @@
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#declineReviewForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
+		// Copy competing interests from the still-live Step 1 form into this decline form.
+		$('#declineCompetingInterestOption').val($('input[name="competingInterestOption"]:checked').val() || 'noCompetingInterests');
+		var ciTextarea = $('textarea[name="reviewerCompetingInterests"]');
+		var ciEditor = (typeof tinymce !== 'undefined' && ciTextarea.length) ? tinymce.get(ciTextarea.attr('id')) : null;
+		$('#declineReviewerCompetingInterests').val(ciEditor ? ciEditor.getContent() : ciTextarea.val());
 	{rdelim});
 </script>
 
 <form class="pkp_form" id="declineReviewForm" method="post" action="{url op="saveDeclineReview" path=$submissionId|escape}">
 	{csrf}
+	<input type="hidden" id="declineCompetingInterestOption" name="competingInterestOption" value="">
+	<input type="hidden" id="declineReviewerCompetingInterests" name="reviewerCompetingInterests" value="">
 	<p>{translate key="reviewer.submission.declineReviewMessage"}</p>
 
 	{fbvFormArea id="declineReview"}


### PR DESCRIPTION
Placed the competing interests outside the restricted area, which was requiring a date completed value.

Resolves the ticket #3477.