### PR TITLE
pkp/pkp-lib#12396 Skip version check when show_upgrade_warning is Off

### DIFF
--- a/pages/admin/AdminHandler.php
+++ b/pages/admin/AdminHandler.php
@@ -129,16 +129,16 @@ class AdminHandler extends Handler
         }
 
         // Interact with the beacon (if enabled) and determine if a new version exists
-        $latestVersion = VersionCheck::checkIfNewVersionExists();
-
-        // Display a warning message if there is a new application version available
-        if (Config::getVar('general', 'show_upgrade_warning') && $latestVersion) {
-            $currentVersion = VersionCheck::getCurrentDBVersion();
-            $templateMgr->assign([
-                'newVersionAvailable' => true,
-                'currentVersion' => $currentVersion,
-                'latestVersion' => $latestVersion,
-            ]);
+        if (Config::getVar('general', 'show_upgrade_warning')) {
+            $latestVersion = VersionCheck::checkIfNewVersionExists();
+            if ($latestVersion) {
+                $currentVersion = VersionCheck::getCurrentDBVersion();
+                $templateMgr->assign([
+                    'newVersionAvailable' => true,
+                    'currentVersion' => $currentVersion,
+                    'latestVersion' => $latestVersion,
+                ]);
+            }
         }
 
         return parent::initialize($request, $args);

--- a/pages/management/ManagementHandler.php
+++ b/pages/management/ManagementHandler.php
@@ -195,23 +195,23 @@ class ManagementHandler extends Handler
         ]);
 
         // Interact with the beacon (if enabled) and determine if a new version exists
-        $latestVersion = VersionCheck::checkIfNewVersionExists();
+        if (Config::getVar('general', 'show_upgrade_warning')) {
+            $latestVersion = VersionCheck::checkIfNewVersionExists();
+            if ($latestVersion) {
+                $currentVersion = VersionCheck::getCurrentDBVersion();
+                $templateMgr->assign([
+                    'newVersionAvailable' => true,
+                    'currentVersion' => $currentVersion->getVersionString(),
+                    'latestVersion' => $latestVersion,
+                ]);
 
-        // Display a warning message if there is a new version of OJS available
-        if (Config::getVar('general', 'show_upgrade_warning') && $latestVersion) {
-            $currentVersion = VersionCheck::getCurrentDBVersion();
-            $templateMgr->assign([
-                'newVersionAvailable' => true,
-                'currentVersion' => $currentVersion->getVersionString(),
-                'latestVersion' => $latestVersion,
-            ]);
+                $siteAdmins = Repo::user()->getCollector()
+                    ->filterByRoleIds([Role::ROLE_ID_SITE_ADMIN])
+                    ->getMany();
 
-            $siteAdmins = Repo::user()->getCollector()
-                ->filterByRoleIds([Role::ROLE_ID_SITE_ADMIN])
-                ->getMany();
-
-            $siteAdmin = $siteAdmins->first();
-            $templateMgr->assign('siteAdmin', $siteAdmin);
+                $siteAdmin = $siteAdmins->first();
+                $templateMgr->assign('siteAdmin', $siteAdmin);
+            }
         }
 
         $templateMgr->assign('pageTitle', __('manager.setup'));


### PR DESCRIPTION
## Summary

- Move `VersionCheck::checkIfNewVersionExists()` inside the `show_upgrade_warning` conditional in both `AdminHandler::initialize()` and `ManagementHandler::context()`
- When `show_upgrade_warning = Off`, the external HTTP request to `pkp.sfu.ca/ojs/xml/ojs-version.xml` is no longer made
- This prevents unnecessary page load delays (sometimes 30+ seconds) for administrators who have disabled the feature

## Test plan

- [ ] Set `show_upgrade_warning = Off` in `config.inc.php`, load admin/management pages, verify no HTTP request to `pkp.sfu.ca`
- [ ] Set `show_upgrade_warning = On`, verify the upgrade warning still displays correctly when a new version is available

Closes https://github.com/pkp/pkp-lib/issues/12396