### PR TITLE
pkp/pkp-lib#5836 [stable-3_5_0] Long filenames with no spaces push content off of editorial history modal

### DIFF
--- a/styles/controllers/grid/grid.less
+++ b/styles/controllers/grid/grid.less
@@ -605,6 +605,16 @@
 	word-break: break-word;
 }
 
+// Wrap long filenames in event log grids
+[id^="component-grid-eventlog-"] .gridRow .label {
+	word-break: break-word;
+}
+
+// Wrap long filenames in file grids
+.pkp_controllers_grid .pkp_linkaction_downloadFile {
+	word-break: break-word;
+}
+
 /* Fix strange grid float issue when placed inside subtabs */
 .pkpTabs--side .pkpTab .pkp_controllers_grid .header {
 	max-height: 3rem;

--- a/styles/controllers/plupload.less
+++ b/styles/controllers/plupload.less
@@ -41,8 +41,20 @@
 
 	&.complete .pkpUploaderFilename,
 	&.complete .pkp_uploader_button_change {
-		display: block;
 		opacity: 1;
+	}
+
+	&.complete .pkpUploaderFilename {
+		display: flex;
+		align-items: center;
+	}
+
+	&.complete .pkp_uploader_button_change {
+		display: block;
+	}
+
+	.pkpUploaderFilename {
+		word-break: break-word;
 	}
 
 	&.error .pkpUploaderError,
@@ -111,9 +123,22 @@
 .complete {
 
 	 .pkp_uploader_drop_zone {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
 		border-style: solid;
 		background: @bg;
 		color: @text;
+	}
+
+	.pkp_uploader_details {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.pkp_uploader_button {
+		float: none;
+		flex-shrink: 0;
 	}
 
 	.pkpUploaderFilename:before {
@@ -121,6 +146,7 @@
 		content: @fa-var-check;
 		margin-right: 1em;
 		color: @yes;
+		vertical-align: middle;
 	}
 }
 

--- a/styles/form/form.less
+++ b/styles/form/form.less
@@ -207,6 +207,11 @@
 		// appear in the wrong space
 		display: block;
 
+		// Reserve space for the globe icon so input text doesn't overlap
+		input[type="text"] {
+			padding-inline-end: 2.5rem;
+		}
+
 		// Localization globe icon within TinyMce
 		&:after {
 			.fa();

--- a/templates/submission/review-files.tpl
+++ b/templates/submission/review-files.tpl
@@ -41,7 +41,7 @@
                 :key="file.id"
                 class="submissionWizard__reviewPanel__item__value"
             >
-                <a :href="file.url" class="submissionWizard__reviewPanel__fileLink">
+                <a :href="file.url" class="submissionWizard__reviewPanel__fileLink min-w-0">
                     <file
                         :document-type="file.documentType"
                         :name="localize(file.name)"


### PR DESCRIPTION
Fix long filenames to display as truncated text or wrapped words