### PR TITLE
fix: categoryExistsByPath now accepts contextId to scope category path uniqueness per press

### DIFF
--- a/classes/context/CategoryDAO.inc.php
+++ b/classes/context/CategoryDAO.inc.php
@@ -108,13 +108,19 @@ class CategoryDAO extends DAO {
 	 * @param $path the path for the category
 	 * @return boolean
 	 */
-	function categoryExistsByPath($path) {
-		$result = $this->retrieve(
-			'SELECT COUNT(*) AS row_count FROM categories WHERE path = ?', [$path]
-		);
-		$row = $result->current();
-		return $row ? (boolean) $row->row_count : false;
-	}
+	function categoryExistsByPath($path, $contextId = null) {
+    if ($contextId) {
+        $result = $this->retrieve(
+            'SELECT COUNT(*) AS row_count FROM categories WHERE path = ? AND context_id = ?', [$path, $contextId]
+        );
+    } else {
+        $result = $this->retrieve(
+            'SELECT COUNT(*) AS row_count FROM categories WHERE path = ?', [$path]
+        );
+    }
+    $row = $result->current();
+    return $row ? (boolean) $row->row_count : false;
+}
 
 	/**
 	 * Construct a new data object corresponding to this DAO.


### PR DESCRIPTION
https://github.com/pkp/pkp-lib/issues/12571

Problem
When trying to create a category with the same path in two different presses, OMP incorrectly returns "The category path already exists" even though the path belongs to a different press.
Root cause
CategoryForm.inc.php calls categoryExistsByPath($path, $contextId) with two parameters, but CategoryDAO::categoryExistsByPath() only accepted $path and silently discarded $contextId, so the SQL query checked across all presses instead of just the current one.
Fix
Added $contextId parameter to CategoryDAO::categoryExistsByPath() and included it in the SQL query when provided.
Related issue: [link alla tua issue]
Tested on: OMP 3.3.0-21