### PR TITLE
Add default envelope sender configuration handling

### DIFF
--- a/classes/mail/Mailable.php
+++ b/classes/mail/Mailable.php
@@ -302,6 +302,16 @@ class Mailable extends IlluminateMailable
             );
         }
 
+        $configDefaultEnvelopeSender = Config::getVar('email', 'default_envelope_sender');
+        $configNameSender = Config::getVar('email', 'smtp_name');
+        if (Config::getVar('email', 'force_default_envelope_sender') && $configDefaultEnvelopeSender) {
+            if($configNameSender) {
+                return parent::from($configDefaultEnvelopeSender, $configNameSender);
+            }else{
+                return parent::from($configDefaultEnvelopeSender, $name);
+            }
+        }
+        
         return parent::from($address, $name);
     }
 


### PR DESCRIPTION
Add logic to assign the default sender and its name from the configuration file config.inc.php

smtp_name = "My Publisher"
default_envelope_sender = my@mail.org
force_default_envelope_sender = On