### PR TITLE
Fixes #11799

### DIFF
--- a/controllers/grid/users/reviewer/form/AdvancedSearchReviewerForm.php
+++ b/controllers/grid/users/reviewer/form/AdvancedSearchReviewerForm.php
@@ -209,9 +209,10 @@ class AdvancedSearchReviewerForm extends ReviewerForm
                     }
                 }
 
+                $warnOnAssignment = array_values(array_diff($warnOnAssignment, $lastRoundReviewerIds));
+                $selectReviewerListPanel->set(['warnOnAssignment' => $warnOnAssignment]);
                 $lastRoundReviewers = Repo::user()->getCollector()
                     ->filterByContextIds([$submissionContext->getId()])
-                    ->filterByRoleIds([Role::ROLE_ID_REVIEWER])
                     ->filterByUserIds($lastRoundReviewerIds)
                     ->includeReviewerData()
                     ->getMany();


### PR DESCRIPTION
When a reviewer also holds a Manager/Editor role, they are added to warnOnAssignment which causes the frontend to hide the Reassign button in round 2. Unlike round 1 (which shows an "Unblock" confirmation), round 2 silently blocks the assignment with no way to proceed.

Changes
AdvancedSearchReviewerForm.php

1. Removed filterByRoleIds([Role::ROLE_ID_REVIEWER]) from the lastRoundReviewers collector query. Users who also hold a Manager role were being excluded from this list entirely.

2. After computing array_diff() to remove last-round reviewers from warnOnAssignment, the updated array is now re-set on the $selectReviewerListPanel object via ->set(). Previously only the local variable was updated; the already-constructed object retained the original value, so the frontend still treated these users as warned.

Testing
1. Assign a reviewer who also has a Manager role in round 1
2. Create round 2
3. Confirm the Reassign button is now visible for that reviewe