### PR TITLE
pkp/pkp-lib#12732 Resolve {$submissionUrl} per-recipient for author-only mails

### DIFF
--- a/classes/mail/variables/RecipientEmailVariable.php
+++ b/classes/mail/variables/RecipientEmailVariable.php
@@ -66,6 +66,14 @@ class RecipientEmailVariable extends Variable
     }
 
     /**
+     * @return iterable<Identity>
+     */
+    public function getRecipients(): iterable
+    {
+        return $this->recipients;
+    }
+
+    /**
      * Full names of recipients in all supported locales separated by a comma
      */
     protected function getRecipientsFullName(string $locale): string

--- a/classes/mail/variables/SubmissionEmailVariable.php
+++ b/classes/mail/variables/SubmissionEmailVariable.php
@@ -18,11 +18,15 @@ namespace PKP\mail\variables;
 
 use APP\publication\Publication;
 use APP\submission\Submission;
+use Illuminate\Support\Arr;
 use PKP\author\Author;
 use PKP\context\Context;
 use PKP\core\PKPApplication;
 use PKP\core\PKPString;
+use PKP\db\DAORegistry;
 use PKP\mail\Mailable;
+use PKP\security\Role;
+use PKP\security\RoleDAO;
 
 abstract class SubmissionEmailVariable extends Variable
 {
@@ -118,9 +122,21 @@ abstract class SubmissionEmailVariable extends Variable
     }
 
     /**
-     * URL to a current workflow stage of the submission
+     * URL to the submission, chosen per recipient: the author dashboard for
+     * author-only recipients, otherwise the editorial workflow.
+     *
+     * Falls back to the editorial workflow when no recipient context is
+     * available (e.g. when previewing variables in the template editor), to
+     * preserve historical behaviour.
      */
     protected function getSubmissionUrl(Context $context): string
+    {
+        return $this->shouldUseAuthorSubmissionUrl($context)
+            ? $this->getAuthorSubmissionUrl($context)
+            : $this->getEditorialWorkflowUrl($context);
+    }
+
+    protected function getEditorialWorkflowUrl(Context $context): string
     {
         $application = PKPApplication::get();
         $request = $application->getRequest();
@@ -133,6 +149,47 @@ abstract class SubmissionEmailVariable extends Variable
             'access',
             $this->submission->getId()
         );
+    }
+
+    /**
+     * True iff every recipient of the mailable can only reach the submission
+     * via the author dashboard (i.e. none has an editorial role in the context
+     * and at least one has the author role).
+     */
+    protected function shouldUseAuthorSubmissionUrl(Context $context): bool
+    {
+        $recipientVariable = Arr::first($this->mailable->getVariables(), function (Variable $variable) {
+            return $variable instanceof RecipientEmailVariable;
+        });
+        if (!$recipientVariable) {
+            return false;
+        }
+        $recipients = $recipientVariable->getRecipients();
+
+        /** @var RoleDAO $roleDao */
+        $roleDao = DAORegistry::getDAO('RoleDAO');
+        $contextId = $context->getId();
+        $editorialRoles = [
+            Role::ROLE_ID_SITE_ADMIN,
+            Role::ROLE_ID_MANAGER,
+            Role::ROLE_ID_SUB_EDITOR,
+            Role::ROLE_ID_ASSISTANT,
+        ];
+
+        $authorPresent = false;
+        foreach ($recipients as $recipient) {
+            $userId = $recipient->getId();
+            if (!$userId) {
+                continue;
+            }
+            if ($roleDao->userHasRole($contextId, $userId, $editorialRoles)) {
+                return false;
+            }
+            if ($roleDao->userHasRole($contextId, $userId, Role::ROLE_ID_AUTHOR)) {
+                $authorPresent = true;
+            }
+        }
+        return $authorPresent;
     }
 
     /**


### PR DESCRIPTION
Closes #12732.

## What does this PR do?

Makes the `{$submissionUrl}` email-template variable recipient-aware.

For each rendered mailable we now inspect the recipients (via the
existing `RecipientEmailVariable`):

- If **any** recipient has an editorial role in the context
  (`SITE_ADMIN`, `MANAGER`, `SUB_EDITOR`, `ASSISTANT`) →
  `{$submissionUrl}` resolves to the editorial workflow URL
  (`…/{context}/workflow/access/{id}`) — historical behaviour.
- Else if **any** recipient has the `AUTHOR` role →
  `{$submissionUrl}` resolves to the author dashboard URL
  (`…/{context}/authorDashboard/submission/{id}`).
- If no recipient context is available (e.g. previewing the variable
  in the template editor) → fall back to the editorial workflow URL.

`{$authorSubmissionUrl}` is untouched: it always resolves to the
author dashboard, exactly as before.

## How to test

Verified locally against OJS 3.4.0 with a small CLI script that
instantiates `DiscussionCopyediting` for one submission and three
recipient configurations. Output before/after this PR:

| Recipients      | `{$submissionUrl}` before     | `{$submissionUrl}` after                 |
| --------------- | ----------------------------- | ---------------------------------------- |
| Author only     | `/{ctx}/workflow/access/{id}` | `/{ctx}/authorDashboard/submission/{id}` |
| Editor only     | `/{ctx}/workflow/access/{id}` | `/{ctx}/workflow/access/{id}`            |
| Author + editor | `/{ctx}/workflow/access/{id}` | `/{ctx}/workflow/access/{id}`            |

`{$authorSubmissionUrl}` always returns the author dashboard URL in
all three cases, before and after.

End-to-end UI repro:

1. Open a submission as an editor; **Add discussion** in Copyediting,
   with the author as the only participant.
2. Note the rendered `{$submissionUrl}` in the resulting email.
3. Without this PR: workflow URL → author hits access-denied.
   With this PR: author dashboard URL → author lands on their
   dashboard.

## Files changed

- `classes/mail/variables/SubmissionEmailVariable.php` —
  split `getSubmissionUrl()` into editorial / author branches; pick
  per-recipient via a small role check; preserve historical fallback.
- `classes/mail/variables/RecipientEmailVariable.php` —
  expose `getRecipients(): iterable` so the submission variable can
  read the recipient list.

## Issue

Closes #12732.

## Follow-up

The hard-coded "Reply to this comment at #N…" footer appended to
discussion notification emails is mentioned in the issue and is **not**
addressed here. Once this PR lands, that footer inherits the new
`{$submissionUrl}` behaviour if it is rendered via the variable; if it
is built outside the variable system it will need a separate PR.