### PR TITLE
pkp/pkp-lib#12732 Resolve {$submissionUrl} per-recipient for author-only mails (stable-3_5_0)

### DIFF
--- a/classes/mail/variables/RecipientEmailVariable.php
+++ b/classes/mail/variables/RecipientEmailVariable.php
@@ -66,6 +66,14 @@ class RecipientEmailVariable extends Variable
     }
 
     /**
+     * @return iterable<Identity>
+     */
+    public function getRecipients(): iterable
+    {
+        return $this->recipients;
+    }
+
+    /**
      * Full names of recipients in all supported locales separated by a comma
      */
     protected function getRecipientsFullName(string $locale): string

--- a/classes/mail/variables/SubmissionEmailVariable.php
+++ b/classes/mail/variables/SubmissionEmailVariable.php
@@ -18,11 +18,15 @@ namespace PKP\mail\variables;
 
 use APP\publication\Publication;
 use APP\submission\Submission;
+use Illuminate\Support\Arr;
 use PKP\author\Author;
 use PKP\context\Context;
 use PKP\core\PKPApplication;
 use PKP\core\PKPString;
+use PKP\db\DAORegistry;
 use PKP\mail\Mailable;
+use PKP\security\Role;
+use PKP\security\RoleDAO;
 
 abstract class SubmissionEmailVariable extends Variable
 {
@@ -117,9 +121,22 @@ abstract class SubmissionEmailVariable extends Variable
     }
 
     /**
-     * URL to a current workflow stage of the submission
+     * URL to the submission, chosen per recipient: the author dashboard
+     * (`dashboard/mySubmissions`) for author-only recipients, otherwise the
+     * editorial workflow dashboard (`dashboard/editorial`).
+     *
+     * Falls back to the editorial dashboard when no recipient context is
+     * available (e.g. when previewing variables in the template editor), to
+     * preserve historical behaviour.
      */
     protected function getSubmissionUrl(Context $context): string
+    {
+        return $this->shouldUseAuthorSubmissionUrl($context)
+            ? $this->getAuthorSubmissionUrl($context)
+            : $this->getEditorialDashboardUrl($context);
+    }
+
+    protected function getEditorialDashboardUrl(Context $context): string
     {
         $application = PKPApplication::get();
         $request = $application->getRequest();
@@ -133,6 +150,47 @@ abstract class SubmissionEmailVariable extends Variable
             null,
             ['workflowSubmissionId' => $this->submission->getId()]
         );
+    }
+
+    /**
+     * True iff every recipient of the mailable can only reach the submission
+     * via the author dashboard (i.e. none has an editorial role in the context
+     * and at least one has the author role).
+     */
+    protected function shouldUseAuthorSubmissionUrl(Context $context): bool
+    {
+        $recipientVariable = Arr::first($this->mailable->getVariables(), function (Variable $variable) {
+            return $variable instanceof RecipientEmailVariable;
+        });
+        if (!$recipientVariable) {
+            return false;
+        }
+        $recipients = $recipientVariable->getRecipients();
+
+        /** @var RoleDAO $roleDao */
+        $roleDao = DAORegistry::getDAO('RoleDAO');
+        $contextId = $context->getId();
+        $editorialRoles = [
+            Role::ROLE_ID_SITE_ADMIN,
+            Role::ROLE_ID_MANAGER,
+            Role::ROLE_ID_SUB_EDITOR,
+            Role::ROLE_ID_ASSISTANT,
+        ];
+
+        $authorPresent = false;
+        foreach ($recipients as $recipient) {
+            $userId = $recipient->getId();
+            if (!$userId) {
+                continue;
+            }
+            if ($roleDao->userHasRole($contextId, $userId, $editorialRoles)) {
+                return false;
+            }
+            if ($roleDao->userHasRole($contextId, $userId, Role::ROLE_ID_AUTHOR)) {
+                $authorPresent = true;
+            }
+        }
+        return $authorPresent;
     }
 
     /**


### PR DESCRIPTION
Closes #12732 on `stable-3_5_0`. Parallel to #12733 (`stable-3_4_0`).

## What does this PR do?

Makes the `{$submissionUrl}` email-template variable recipient-aware
on `stable-3_5_0`. This is the 3.5 counterpart of #12733 — same fix,
different dashboard URL.

For each rendered mailable we inspect the recipients (via the
existing `RecipientEmailVariable`):

- If **any** recipient has an editorial role in the context
  (`SITE_ADMIN`, `MANAGER`, `SUB_EDITOR`, `ASSISTANT`) →
  `{$submissionUrl}` resolves to `…/{context}/dashboard/editorial?workflowSubmissionId={id}`
  — historical behaviour.
- Else if **any** recipient has the `AUTHOR` role →
  `{$submissionUrl}` resolves to `…/{context}/dashboard/mySubmissions?workflowSubmissionId={id}`,
  which is the only dashboard op assigned to `ROLE_ID_AUTHOR` in
  `PKPDashboardHandler::authorize()`.
- If no recipient context is available (e.g. previewing the variable
  in the template editor) → fall back to the editorial dashboard URL.

`{$authorSubmissionUrl}` is untouched: it always resolves to
`dashboard/mySubmissions`, exactly as before.

## How to test

Verified locally against `stable-3_5_0` with a small CLI that
instantiates `DiscussionCopyediting` for one submission and three
recipient configurations. Output before/after this PR:

| Recipients      | `{$submissionUrl}` before                          | `{$submissionUrl}` after                              |
| --------------- | -------------------------------------------------- | ----------------------------------------------------- |
| Author only     | `…/dashboard/editorial?workflowSubmissionId={id}`  | `…/dashboard/mySubmissions?workflowSubmissionId={id}` |
| Editor only     | `…/dashboard/editorial?workflowSubmissionId={id}`  | `…/dashboard/editorial?workflowSubmissionId={id}`     |
| Author + editor | `…/dashboard/editorial?workflowSubmissionId={id}`  | `…/dashboard/editorial?workflowSubmissionId={id}`     |

`{$authorSubmissionUrl}` always returns the `dashboard/mySubmissions`
URL in all three cases, before and after.

End-to-end UI repro (no code change needed to observe the bug):

1. Open a submission as an editor on 3.5; **Add discussion** in
   Copyediting or Production with the author as the only participant.
2. Note the rendered `{$submissionUrl}` in the resulting email.
3. Without this PR: editorial-dashboard URL → author hits access-denied.
   With this PR: `mySubmissions` URL → author lands on their own
   submission view.

## Files changed

- `classes/mail/variables/SubmissionEmailVariable.php` —
  split `getSubmissionUrl()` into editorial / author branches and pick
  per-recipient via a small role check (`RoleDAO::userHasRole`);
  preserve the historical editorial-dashboard fallback when no
  recipient context is available.
- `classes/mail/variables/RecipientEmailVariable.php` —
  expose `getRecipients(): iterable` so the submission variable can
  read the recipient list.

This mirrors the 3.4 patch in #12733 exactly; the only change is the
URL the dashboard handler exposes (`dashboard/editorial` /
`dashboard/mySubmissions` on 3.5 vs `workflow/access` /
`authorDashboard/submission` on 3.4).

## Issue

Closes #12732 on `stable-3_5_0`. The 3.4 counterpart is #12733.

## Follow-up

The hard-coded "Reply to this comment at #N…" footer appended to
discussion notification emails (referenced in #12732) inherits the
new `{$submissionUrl}` behaviour automatically because it is rendered
through the same variable. If any other email template / locale
string builds the URL outside the variable system, that will need a
separate PR.