### PR TITLE
Bulk delete incomplete submissions incorrectly restricts managers with author role

### DIFF
--- a/api/v1/_submissions/PKPBackendSubmissionsController.php
+++ b/api/v1/_submissions/PKPBackendSubmissionsController.php
@@ -471,9 +471,8 @@ abstract class PKPBackendSubmissionsController extends PKPBaseController
         $context = $this->getRequest()->getContext();
         $user = $request->getUser();
 
-        if ($user->hasRole([Role::ROLE_ID_AUTHOR], $context->getId())) {
-            $userId = $request->getUser()->getId();
-            $collector->assignedTo([$userId]);
+        if (!$this->canAccessAllSubmissions()) {
+            $collector->assignedTo([$user->getId()]);
         }
 
         $submissions = $collector->getMany()->all();


### PR DESCRIPTION
## Summary

`bulkDeleteIncompleteSubmissions` was checking whether the current user has an author role to restrict the submission collector to assigned submissions only. This caused journal managers (and similar roles) who also hold an author role to receive a 404 ("The requested resource was not found.") when attempting to bulk delete submissions they were not assigned to, even though `canCurrentUserDelete()` correctly grants them permission.

## Root Cause

The condition:

```php
if ($user->hasRole([Role::ROLE_ID_AUTHOR], $context->getId())) {
    $collector->assignedTo([$userId]);
}
```

does not account for users holding multiple roles. A manager with an author role would have their collector filtered before `canCurrentUserDelete()` was ever reached.

## Fix

Replace the author role check with `canAccessAllSubmissions()`, consistent with how the `reviews()` endpoint handles the same scenario:

```php
if (!$this->canAccessAllSubmissions()) {
    $collector->assignedTo([$user->getId()]);
}
```