### PR TITLE
Normalize jpeg extension in announcement image validation - fixes #12744

### DIFF
--- a/classes/announcement/Announcement.php
+++ b/classes/announcement/Announcement.php
@@ -389,7 +389,7 @@ class Announcement extends Model
         $extension = pathinfo($temporaryFile->getOriginalFileName(), PATHINFO_EXTENSION);
         if ($extension === 'jpeg') {
   		$extension = 'jpg';
-	}
+	} 
 	$fileManager = new FileManager();
         $extensionFromMimeType = $fileManager->getImageExtension(
             PKPString::mime_content_type($temporaryFile->getFilePath())

--- a/classes/announcement/Announcement.php
+++ b/classes/announcement/Announcement.php
@@ -387,7 +387,10 @@ class Announcement extends Model
             return false;
         }
         $extension = pathinfo($temporaryFile->getOriginalFileName(), PATHINFO_EXTENSION);
-        $fileManager = new FileManager();
+        if ($extension === 'jpeg') {
+  		$extension = 'jpg';
+	}
+	$fileManager = new FileManager();
         $extensionFromMimeType = $fileManager->getImageExtension(
             PKPString::mime_content_type($temporaryFile->getFilePath())
         );


### PR DESCRIPTION
## Summary

This pull request fixes #12744.

Announcement image upload currently rejects valid `.jpeg` files because `image/jpeg` is mapped to `.jpg` by `FileManager::getImageExtension()`, while the uploaded file extension may be `.jpeg`.

This change normalizes the uploaded file extension by treating `jpeg` as equivalent to `jpg` before comparing it with the MIME-derived extension.

## Testing

Tested locally with OJS 3.5.0.4:

- `.jpeg` announcement image upload failed before the change.
- `.jpeg` announcement image upload succeeded after the change.
- `.jpg` files continued to work as expected.