### PR TITLE
Add locale keys for body text editor

### DIFF
--- a/locale/en/common.po
+++ b/locale/en/common.po
@@ -516,6 +516,9 @@ msgstr "Fullscreen"
 msgid "common.fullscreenOff"
 msgstr "Fullscreen Off"
 
+msgid "common.exitFullscreen"
+msgstr "Exit fullscreen"
+
 msgid "common.false"
 msgstr "False"
 

--- a/locale/en/submission.po
+++ b/locale/en/submission.po
@@ -2990,6 +2990,18 @@ msgstr "JATS XML"
 msgid "publication.bodyText"
 msgstr "Body Text"
 
+msgid "publication.bodyText.documentPanel"
+msgstr "Document Edit"
+
+msgid "publication.bodyText.selectedElement"
+msgstr "Selected Element"
+
+msgid "publication.bodyText.outline"
+msgstr "Document Outline"
+
+msgid "publication.bodyText.references.dragHint"
+msgstr "Drag references into the editor to place an in-text citation."
+
 msgid "publication.jats.confirmDeleteFileTitle"
 msgstr "Confirm deleting JATS XML"
 


### PR DESCRIPTION
Five new English keys for the publication body text editor UI: common.exitFullscreen, publication.bodyText.documentPanel, .selectedElement, .outline, and .references.dragHint.