### PR TITLE
fix: accept POST for bulk delete of incomplete submissions

### DIFF
--- a/api/v1/_submissions/PKPBackendSubmissionsController.php
+++ b/api/v1/_submissions/PKPBackendSubmissionsController.php
@@ -86,6 +86,18 @@ abstract class PKPBackendSubmissionsController extends PKPBaseController
                 ]),
             ]);
 
+        // The frontend sends POST instead of DELETE for bulk deletion.
+        // Accept both methods until the frontend is corrected.
+        Route::post('', $this->bulkDeleteIncompleteSubmissions(...))
+            ->name('_submission.incomplete.delete.post')
+            ->middleware([
+                self::roleAuthorizer([
+                    Role::ROLE_ID_SITE_ADMIN,
+                    Role::ROLE_ID_MANAGER,
+                    Role::ROLE_ID_AUTHOR,
+                ]),
+            ]);
+
         Route::delete('{submissionId}', $this->delete(...))
             ->name('_submission.delete')
             ->middleware([


### PR DESCRIPTION
## Problem

The **Delete Incomplete Submissions** bulk action in the admin UI silently fails — clicking the button does nothing, no error is shown.

Checking the Apache access log reveals the cause:

```
POST /api/v1/_submissions?ids[]=634&... HTTP/1.1" 404
```

The frontend JavaScript sends a `POST` request to `/api/v1/_submissions`, but the backend only has `Route::delete` registered for that endpoint. The `POST` hits a 404 and is silently ignored.

## Root Cause

The frontend bulk-delete action dispatches a `POST` request (likely intending a method-override pattern), but no method-override middleware is configured in the PKP API router. The backend expects `DELETE`.

## Fix

Register `Route::post` for the same `bulkDeleteIncompleteSubmissions` handler alongside `Route::delete`, so the endpoint accepts both HTTP methods until the frontend is corrected to send `DELETE`.

## Tested

- OJS 3.5.0.4 / PHP 8.5.4 / Apache 2.4.66 / MySQL 8.4.9
- Bulk delete of incomplete submissions now works correctly through the admin UI after applying this fix.

## Note

If the frontend is later corrected to send `DELETE`, the `Route::post` alias can be safely removed — or left in place as it causes no conflict.