### PR TITLE
pkp/pkp-lib#10573 Fix reminder emails being sent to non-editors OJS 3_5_0

### DIFF
--- a/jobs/email/EditorialReminder.php
+++ b/jobs/email/EditorialReminder.php
@@ -77,7 +77,7 @@ class EditorialReminder extends BaseJob
 
         $submissionIds = Repo::submission()
             ->getCollector()
-            ->assignedTo([$this->editorId])
+            ->assignedTo([$this->editorId], [Role::ROLE_ID_SUB_EDITOR])
             ->filterByContextIds([$this->contextId])
             ->filterByStatus([Submission::STATUS_QUEUED])
             ->filterByIncomplete(false)


### PR DESCRIPTION
Hi @asmecher,
This is a solution for: https://github.com/pkp/pkp-lib/issues/10573
This PR targets OJS 3.5.0 and ensures that editorial reminder emails are sent only to editors assigned to the submission.