### PR TITLE
pkp/pkp-lib#12513  Add site primary locale to the invite/accept forms…

### DIFF
--- a/classes/components/forms/invitation/AcceptUserDetailsForm.php
+++ b/classes/components/forms/invitation/AcceptUserDetailsForm.php
@@ -14,6 +14,7 @@
 
 namespace PKP\components\forms\invitation;
 
+use APP\core\Application;
 use PKP\components\forms\FieldSelect;
 use PKP\components\forms\FieldText;
 use PKP\components\forms\FormComponent;
@@ -84,5 +85,25 @@ class AcceptUserDetailsForm extends FormComponent
                 'size' => 'large',
             ]));
 
+    }
+
+    /**
+     * @copydoc FormComponent::getConfig()
+     */
+    public function getConfig()
+    {
+        $config = parent::getConfig();
+        $sitePrimaryLocale = Application::get()->getRequest()->getSite()->getPrimaryLocale();
+        $primaryLocale = $config['primaryLocale'];
+        // Show the site primary locale by default in addition to the context primary locale. Every
+        // user needs a name in the site primary locale because it is the fallback when the name is
+        // missing in the current UI locale (e.g. getFullName()); showing it lets the invitee fill
+        // it directly instead of leaving it behind a language tab.
+        $visibleLocales = [$primaryLocale];
+        if ($sitePrimaryLocale !== $primaryLocale) {
+            $visibleLocales[] = $sitePrimaryLocale;
+        }
+        $config['visibleLocales'] = $visibleLocales;
+        return $config;
     }
 }

--- a/classes/components/forms/invitation/UserDetailsForm.php
+++ b/classes/components/forms/invitation/UserDetailsForm.php
@@ -14,6 +14,7 @@
 
 namespace PKP\components\forms\invitation;
 
+use APP\core\Application;
 use PKP\components\forms\FieldHTML;
 use PKP\components\forms\FieldText;
 use PKP\components\forms\FormComponent;
@@ -67,5 +68,25 @@ class UserDetailsForm extends FormComponent
                 'isMultilingual' => true,
                 'size' => 'large',
             ]));
+    }
+
+    /**
+     * @copydoc FormComponent::getConfig()
+     */
+    public function getConfig()
+    {
+        $config = parent::getConfig();
+        $sitePrimaryLocale = Application::get()->getRequest()->getSite()->getPrimaryLocale();
+        $primaryLocale = $config['primaryLocale'];
+        // Show the site primary locale by default in addition to the context primary locale. Every
+        // user needs a name in the site primary locale because it is the fallback when the name is
+        // missing in the current UI locale (e.g. getFullName()); showing it gives the editor the
+        // opportunity to fill it instead of leaving it behind a language tab.
+        $visibleLocales = [$primaryLocale];
+        if ($sitePrimaryLocale !== $primaryLocale) {
+            $visibleLocales[] = $sitePrimaryLocale;
+        }
+        $config['visibleLocales'] = $visibleLocales;
+        return $config;
     }
 }

--- a/classes/invitation/invitations/userRoleAssignment/handlers/api/UserRoleAssignmentReceiveController.php
+++ b/classes/invitation/invitations/userRoleAssignment/handlers/api/UserRoleAssignmentReceiveController.php
@@ -14,6 +14,7 @@
 
 namespace PKP\invitation\invitations\userRoleAssignment\handlers\api;
 
+use APP\core\Application;
 use APP\facades\Repo;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
@@ -166,7 +167,9 @@ class UserRoleAssignmentReceiveController extends ReceiveInvitationController
     public function refine(Request $illuminateRequest): JsonResponse
     {
         $reqInput = $illuminateRequest->all();
-        $payload = $reqInput['invitationData'];
+        $payload = $reqInput['invitationData'] ?? [];
+
+        $payload = $this->fillSiteLocaleNameFallback($payload);
 
         if (!$this->invitation->validate($payload, ValidationContext::VALIDATION_CONTEXT_REFINE)) {
             return response()->json([
@@ -182,5 +185,40 @@ class UserRoleAssignmentReceiveController extends ReceiveInvitationController
             (new UserRoleAssignmentInviteResource($this->invitation))->toArray($illuminateRequest),
             Response::HTTP_OK
         );
+    }
+
+    /**
+     * Fill the site primary locale name fields from the context primary locale when they are empty.
+     *
+     * Every user needs a name in the site primary locale (the fallback used when the name is missing
+     * in the current UI locale, e.g. getFullName()), but the invitee typically fills only the context
+     * primary locale. When the two locales differ, copy the context primary value into the empty site
+     * primary value. Only empty values are filled, so a value the invitee set themselves is never
+     * overwritten.
+     */
+    private function fillSiteLocaleNameFallback(array $payload): array
+    {
+        $context = $this->invitation->getContext();
+        if (!$context) {
+            return $payload;
+        }
+
+        $sitePrimaryLocale = Application::get()->getRequest()->getSite()->getPrimaryLocale();
+        $contextPrimaryLocale = $context->getPrimaryLocale();
+        if ($sitePrimaryLocale === $contextPrimaryLocale) {
+            return $payload;
+        }
+
+        foreach (['givenName', 'familyName'] as $field) {
+            if (isset($payload[$field])
+                && is_array($payload[$field])
+                && empty($payload[$field][$sitePrimaryLocale])
+                && !empty($payload[$field][$contextPrimaryLocale])
+            ) {
+                $payload[$field][$sitePrimaryLocale] = $payload[$field][$contextPrimaryLocale];
+            }
+        }
+
+        return $payload;
     }
 }

--- a/classes/invitation/invitations/userRoleAssignment/payload/UserRoleAssignmentInvitePayload.php
+++ b/classes/invitation/invitations/userRoleAssignment/payload/UserRoleAssignmentInvitePayload.php
@@ -56,11 +56,19 @@ class UserRoleAssignmentInvitePayload extends InvitePayload
     public function getValidationRules(UserRoleAssignmentInvite $invitation, ValidationContext $validationContext = ValidationContext::VALIDATION_CONTEXT_DEFAULT): array
     {
         $context = $invitation->getContext();
+        $siteDao = DAORegistry::getDAO('SiteDAO'); /** @var \PKP\site\SiteDAO $siteDao */
+        $site = $siteDao->getSite();
+
         $allowedLocales = $context->getSupportedFormLocales();
         $primaryLocale = $context->getPrimaryLocale();
 
-        $siteDao = DAORegistry::getDAO('SiteDAO'); /** @var \PKP\site\SiteDAO $siteDao */
-        $site = $siteDao->getSite();
+        // Accept the site primary locale as a valid name key even when the journal does not enable
+        // it: every user needs a name in the site primary locale (the fallback used by e.g.
+        // getFullName()), so it is offered in the form and copied into when accepting.
+        $sitePrimaryLocale = $site->getPrimaryLocale();
+        if (!in_array($sitePrimaryLocale, $allowedLocales)) {
+            $allowedLocales[] = $sitePrimaryLocale;
+        }
 
         $validationRules = [
             'givenName' => [

--- a/classes/invitation/stepTypes/AcceptInvitationStep.php
+++ b/classes/invitation/stepTypes/AcceptInvitationStep.php
@@ -12,8 +12,11 @@
  */
 namespace PKP\invitation\stepTypes;
 
+use APP\core\Application;
 use PKP\components\forms\invitation\AcceptUserDetailsForm;
 use PKP\context\Context;
+use PKP\facades\Locale;
+use PKP\i18n\LocaleMetadata;
 use PKP\invitation\core\Invitation;
 use PKP\invitation\sections\Form;
 use PKP\invitation\sections\Sections;
@@ -203,14 +206,14 @@ class AcceptInvitationStep extends InvitationStepTypes
      */
     private function getFormLocals(Context $context): array
     {
-        $localeNames = $context->getSupportedFormLocaleNames();
-        $locales = [];
-        foreach ($localeNames as $key => $name) {
-            $locales[] = [
-                'key' => $key,
-                'label' => $name,
-            ];
+        $supportedFormLocales = $context->getSupportedFormLocales();
+        $sitePrimaryLocale = Application::get()->getRequest()->getSite()->getPrimaryLocale();
+        if (!in_array($sitePrimaryLocale, $supportedFormLocales)) {
+            $supportedFormLocales[] = $sitePrimaryLocale;
         }
-        return $locales;
+        return collect(Locale::getFormattedDisplayNames($supportedFormLocales, null, LocaleMetadata::LANGUAGE_LOCALE_WITHOUT))
+            ->map(fn (string $name, string $locale) => ['key' => $locale, 'label' => $name])
+            ->values()
+            ->toArray();
     }
 }

--- a/classes/invitation/stepTypes/SendInvitationStep.php
+++ b/classes/invitation/stepTypes/SendInvitationStep.php
@@ -18,6 +18,8 @@ use APP\core\Application;
 use Exception;
 use PKP\components\forms\invitation\UserDetailsForm;
 use PKP\context\Context;
+use PKP\facades\Locale;
+use PKP\i18n\LocaleMetadata;
 use PKP\invitation\core\Invitation;
 use PKP\invitation\sections\Email;
 use PKP\invitation\sections\Form;
@@ -84,14 +86,15 @@ class SendInvitationStep extends InvitationStepTypes
      */
     private function invitationDetailsForm(Context $context): stdClass
     {
-        $localeNames = $context->getSupportedFormLocaleNames();
-        $locales = [];
-        foreach ($localeNames as $key => $name) {
-            $locales[] = [
-                'key' => $key,
-                'label' => $name,
-            ];
+        $supportedFormLocales = $context->getSupportedFormLocales();
+        $sitePrimaryLocale = Application::get()->getRequest()->getSite()->getPrimaryLocale();
+        if (!in_array($sitePrimaryLocale, $supportedFormLocales)) {
+            $supportedFormLocales[] = $sitePrimaryLocale;
         }
+        $locales = collect(Locale::getFormattedDisplayNames($supportedFormLocales, null, LocaleMetadata::LANGUAGE_LOCALE_WITHOUT))
+            ->map(fn (string $name, string $locale) => ['key' => $locale, 'label' => $name])
+            ->values()
+            ->toArray();
         $sections = new Sections(
             'userDetails',
             __('userInvitation.enterDetails.stepName'),


### PR DESCRIPTION
…… (#12949)

* pkp/pkp-lib#12513  Add site primary locale to the invite/accept forms + copy over if empty

* pkp/pkp-lib#12540 Clean up unnecessary comment

* pkp/pkp-lib#12540 Avoid crash if invitationData is not in the payload