### PR TITLE
fix: preserve timezone when building stats chart labels

### DIFF
--- a/classes/services/PKPStatsServiceTrait.php
+++ b/classes/services/PKPStatsServiceTrait.php
@@ -103,7 +103,7 @@ trait PKPStatsServiceTrait
         while ($startDate->format($dateFormat) <= $endDate->format($dateFormat)) {
             $timelineIntervals[] = [
                 'date' => $startDate->format($dateFormat),
-                'label' => (new \Carbon\Carbon($startDate->getTimestamp()))->locale(Locale::getLocale())->translatedFormat($labelFormat),
+                'label' => \Carbon\Carbon::instance($startDate)->locale(Locale::getLocale())->translatedFormat($labelFormat),
                 'value' => 0,
             ];
             $startDate->add(new \DateInterval($interval));


### PR DESCRIPTION
Carbon::instance() preserves the timezone of the DateTime object. The previous new Carbon($startDate->getTimestamp()) converted through a UTC timestamp, causing a one-month label offset in servers with UTC+ timezones (e.g. Europe/Madrid in summer).

Fixes #10813

Resubmission of #13016, which was closed because it was based on an outdated copy of the codebase instead of the current main. This PR contains only the one-line fix.                                         
