### PR TITLE
Improve registration form error accessibility

### DIFF
--- a/templates/common/formErrors.tpl
+++ b/templates/common/formErrors.tpl
@@ -8,18 +8,20 @@
  * List errors that occurred during form processing.
  *}
 {if $isError}
-	<div id="formErrors">
-		<span class="pkp_form_error">{translate key="form.errorsOccurred"}:</span>
+	<div id="formErrors" tabindex="-1" role="alert" aria-labelledby="formErrorsLabel">
+		<span id="formErrorsLabel" class="pkp_form_error">{translate key="form.errorsOccurred"}:</span>
 		<ul class="pkp_form_error_list">
 		{foreach key=field item=message from=$errors}
-			<li><a href="#{$field|escape}">{$message}</a></li>
+			<li id="formError-{$field|escape}"><a href="#{$field|escape}">{$message}</a></li>
 		{/foreach}
 		</ul>
 	</div>
 	<script>{literal}
 		<!--
-		// Jump to form errors.
+		// Move focus to form errors so assistive technology users land
+		// where the validation feedback is displayed.
 		window.location.hash="formErrors";
+		document.getElementById("formErrors").focus();
 		// -->
 	{/literal}</script>
 {/if}

--- a/templates/frontend/components/registrationForm.tpl
+++ b/templates/frontend/components/registrationForm.tpl
@@ -29,7 +29,7 @@
 						{translate key="common.required"}
 					</span>
 				</span>
-				<input type="text" name="givenName" autocomplete="given-name" id="givenName" value="{$givenName|default:""|escape}" maxlength="255" required aria-required="true">
+				<input type="text" name="givenName" autocomplete="given-name" id="givenName" value="{$givenName|default:""|escape}" maxlength="255" required aria-required="true"{if isset($errors.givenName)} aria-invalid="true" aria-describedby="formError-givenName"{/if}>
 			</label>
 		</div>
 		<div class="family_name">
@@ -61,7 +61,7 @@
 						{translate key="common.required"}
 					</span>
 				</span>
-				<select name="country" id="country" autocomplete="country-name" required aria-required="true">
+				<select name="country" id="country" autocomplete="country-name" required aria-required="true"{if isset($errors.country)} aria-invalid="true" aria-describedby="formError-country"{/if}>
 					<option></option>
 					{html_options options=$countries selected=$country}
 				</select>
@@ -84,7 +84,7 @@
 						{translate key="common.required"}
 					</span>
 				</span>
-				<input type="email" name="email" id="email" value="{$email|default:""|escape}" maxlength="90" required aria-required="true" autocomplete="email">
+				<input type="email" name="email" id="email" value="{$email|default:""|escape}" maxlength="90" required aria-required="true" autocomplete="email"{if isset($errors.email)} aria-invalid="true" aria-describedby="formError-email"{/if}>
 			</label>
 		</div>
 		<div class="username">
@@ -96,7 +96,7 @@
 						{translate key="common.required"}
 					</span>
 				</span>
-				<input type="text" name="username" id="username" value="{$username|default:""|escape}" maxlength="32" required aria-required="true" autocomplete="username">
+				<input type="text" name="username" id="username" value="{$username|default:""|escape}" maxlength="32" required aria-required="true" autocomplete="username"{if isset($errors.username)} aria-invalid="true" aria-describedby="formError-username"{/if}>
 			</label>
 		</div>
 		<div class="password">
@@ -108,7 +108,7 @@
 						{translate key="common.required"}
 					</span>
 				</span>
-				<input type="password" name="password" id="password" password="true" maxlength="32" required aria-required="true" autocomplete="new-password">
+				<input type="password" name="password" id="password" password="true" maxlength="32" required aria-required="true" autocomplete="new-password"{if isset($errors.password)} aria-invalid="true" aria-describedby="formError-password"{/if}>
 			</label>
 		</div>
 		<div class="password">
@@ -120,7 +120,7 @@
 						{translate key="common.required"}
 					</span>
 				</span>
-				<input type="password" name="password2" id="password2" password="true" maxlength="32" required aria-required="true" autocomplete="new-password">
+				<input type="password" name="password2" id="password2" password="true" maxlength="32" required aria-required="true" autocomplete="new-password"{if isset($errors.password2)} aria-invalid="true" aria-describedby="formError-password2"{/if}>
 			</label>
 		</div>
 	</div>

--- a/templates/frontend/pages/userRegister.tpl
+++ b/templates/frontend/pages/userRegister.tpl
@@ -48,7 +48,7 @@
 					<div class="fields">
 						<div class="optin optin-privacy">
 							<label>
-								<input type="checkbox" name="privacyConsent" value="1"{if $privacyConsent} checked="checked"{/if}>
+								<input type="checkbox" name="privacyConsent" id="privacyConsent" value="1"{if $privacyConsent} checked="checked"{/if}{if isset($errors.privacyConsent)} aria-invalid="true" aria-describedby="formError-privacyConsent"{/if}>
 								{capture assign="privacyUrl"}{url router=PKP\core\PKPApplication::ROUTE_PAGE page="about" op="privacy"}{/capture}
 								{translate key="user.register.form.privacyConsent" privacyUrl=$privacyUrl}
 							</label>


### PR DESCRIPTION
## Summary

- Moves keyboard focus to the rendered form error summary when server-side validation errors are shown.
- Makes the shared Smarty error summary focusable and labels it for assistive technology.
- Adds ids to individual error list items so registration fields can reference their error messages.
- Adds `aria-invalid="true"` and `aria-describedby` to the registration form controls when server validation has returned an error for that field.

## Related issue

Fixes #12635

## Verification

- Confirmed the public registration form is rendered by `templates/frontend/pages/userRegister.tpl` and `templates/frontend/components/registrationForm.tpl`, not the legacy JavaScript `FormHandler`.
- `git diff --check` — passed.
- Static template check verified the focus target, error summary label, and `aria-describedby` references added by this PR.

Note: I could not run PHP/Smarty runtime checks in this local environment because `php` is not installed.
