### PR TITLE
pkp/pkp-lib#12955 Treat undecodable unsubscribe tokens as invalid

### DIFF
--- a/classes/notification/PKPNotificationOperationManager.php
+++ b/classes/notification/PKPNotificationOperationManager.php
@@ -32,6 +32,7 @@ use PKP\db\DAORegistry;
 use PKP\facades\Locale;
 use PKP\linkAction\LinkAction;
 use stdClass;
+use Throwable;
 
 abstract class PKPNotificationOperationManager implements INotificationInfoProvider
 {
@@ -331,7 +332,11 @@ abstract class PKPNotificationOperationManager implements INotificationInfoProvi
         }
 
         $headers = new stdClass();
-        $jwt = ((array)JWT::decode($token, new Key($secret, 'HS256'), $headers))[0]; /** @var string $jwt */
+        try {
+            $jwt = ((array)JWT::decode($token, new Key($secret, 'HS256'), $headers))[0]; /** @var string $jwt */
+        } catch (Throwable $exception) {
+            return false;
+        }
         return $jwt === $this->createUnsubscribeUniqueKey($notification);
     }
 


### PR DESCRIPTION
Fixes pkp/pkp-lib#12955. validateUnsubscribeToken() passes the user-supplied validate parameter straight to JWT::decode(), so a garbage or truncated token throws an uncaught DomainException (or UnexpectedValueException) and the unsubscribe page dies with a fatal error instead of the 404 that _validateUnsubscribeRequest() intends. Wrapped the decode in try/catch like DecodeApiTokenWithValidation already does for the same call, returning false so a bad token now takes the existing NotFoundHttpException path.