### PR TITLE
pkp/pkp-lib#13084: Use default error template to show 404 error messages

### DIFF
--- a/classes/core/Dispatcher.inc.php
+++ b/classes/core/Dispatcher.inc.php
@@ -250,7 +250,15 @@ class Dispatcher {
 	 */
 	function handle404() {
 		header('HTTP/1.0 404 Not Found');
-		fatalError('404 Not Found');
+		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_API);
+		$templateMgr = TemplateManager::getManager(Application::get()->getRequest());
+		$templateMgr->assign([
+				'pageTitle' => 'api.404.resourceNotFound',
+				'errorMsg' => '',
+				'errorParams' => [],
+		]);
+		$templateMgr->display('frontend/pages/error.tpl');
+		die();
 	}
 }
 


### PR DESCRIPTION
To avoid introducing new locale keys in a stable version, I have re-used the only existing message appropriate for a 404 page. I think this is still an improvement on before and theme's can override it however they want.