### PR TITLE
Batch entity hydration to cut article page queries ~14x

### DIFF
--- a/api/v1/citations/PKPCitationController.php
+++ b/api/v1/citations/PKPCitationController.php
@@ -347,13 +347,12 @@ class PKPCitationController extends PKPBaseController
 
         $citations = $publication->getData('citations');
         $citationsMapped = [];
-        foreach ($citations as &$citation) {
+        foreach ($citations as $citation) {
             $citation->setProcessingStatus(CitationProcessingStatus::NOT_PROCESSED->value);
             Repo::citation()->edit($citation, []);
             Repo::citation()->reprocessCitation($citation);
             $citationsMapped[] = Repo::citation()->getSchemaMap()->map($citation);
         }
-        unset($citation);
 
         return response()->json([
             'itemsMax' => count($citationsMapped),

--- a/classes/affiliation/DAO.php
+++ b/classes/affiliation/DAO.php
@@ -112,6 +112,30 @@ class DAO extends EntityDAO
         });
     }
 
+    /**
+     * Fetch the affiliations for many authors with two queries,
+     * returned as [authorId => array<Affiliation>].
+     */
+    public function getByAuthorIds(array $authorIds): array
+    {
+        if (empty($authorIds)) {
+            return [];
+        }
+        $rows = DB::table($this->table . ' as a')
+            ->select('a.*')
+            ->whereIn('a.author_id', $authorIds)
+            ->get();
+        $this->prefetchSettings($rows);
+        try {
+            return $rows
+                ->groupBy('author_id')
+                ->map(fn ($group) => $group->map(fn ($row) => $this->fromRow($row))->values()->all())
+                ->all();
+        } finally {
+            $this->clearSettingsPrefetch();
+        }
+    }
+
     /** @copydoc EntityDAO::fromRow() */
     public function fromRow(object $row): Affiliation
     {

--- a/classes/affiliation/Repository.php
+++ b/classes/affiliation/Repository.php
@@ -202,6 +202,15 @@ class Repository
     }
 
     /**
+     * Get the affiliations for many authors at once,
+     * as [authorId => array<Affiliation>].
+     */
+    public function getByAuthorIds(array $authorIds): array
+    {
+        return $this->dao->getByAuthorIds($authorIds);
+    }
+
+    /**
      * Save affiliations.
      */
     public function saveAffiliations(Author $author): void

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -140,8 +140,18 @@ class DAO extends EntityDAO
             $rows = $query
                 ->getQueryBuilder()
                 ->get();
-            foreach ($rows as $row) {
-                yield $row->author_id => $this->fromRow($row);
+            // Batch-load settings, affiliations and roles for the whole
+            // result set instead of querying per author
+            $this->prefetchRelated($rows);
+            try {
+                foreach ($rows as $row) {
+                    yield $row->author_id => $this->fromRow($row);
+                }
+            } finally {
+                $this->clearSettingsPrefetch();
+                $this->affiliationsPrefetch = null;
+                $this->creditRolesPrefetch = null;
+                $this->contributorRolesPrefetch = null;
             }
         });
     }
@@ -157,14 +167,71 @@ class DAO extends EntityDAO
         $author->setData('submissionLocale', $row->submission_locale);
 
         $author->setAffiliations(
-            Repo::affiliation()->getByAuthorId($author->getId())
+            ($this->affiliationsPrefetch !== null && array_key_exists($author->getId(), $this->affiliationsPrefetch))
+                ? $this->affiliationsPrefetch[$author->getId()]
+                : Repo::affiliation()->getByAuthorId($author->getId())
         );
 
-        $author->setCreditRoles(Repo::creditContributorRole()->getCreditRolesByContributorId($author->getId()));
+        $author->setCreditRoles(
+            ($this->creditRolesPrefetch !== null && array_key_exists($author->getId(), $this->creditRolesPrefetch))
+                ? $this->creditRolesPrefetch[$author->getId()]
+                : Repo::creditContributorRole()->getCreditRolesByContributorId($author->getId())
+        );
 
-        $author->setContributorRoles(Repo::creditContributorRole()->getContributorRolesByContributorId($author->getId()));
+        $author->setContributorRoles(
+            ($this->contributorRolesPrefetch !== null && array_key_exists($author->getId(), $this->contributorRolesPrefetch))
+                ? $this->contributorRolesPrefetch[$author->getId()]
+                : Repo::creditContributorRole()->getContributorRolesByContributorId($author->getId())
+        );
 
         return $author;
+    }
+
+    /**
+     * Related data prefetched for the batch of authors currently being
+     * hydrated by getMany(), keyed by author id. Maps are pre-filled for
+     * every id in the batch, so a missing key means "not part of this
+     * batch" and fromRow() falls back to the per-author queries.
+     */
+    protected ?array $affiliationsPrefetch = null;
+    protected ?array $creditRolesPrefetch = null;
+    protected ?array $contributorRolesPrefetch = null;
+
+    /**
+     * Load settings, affiliations and credit/contributor roles for a batch
+     * of author rows with one query per relation.
+     */
+    protected function prefetchRelated(Collection $rows): void
+    {
+        $this->prefetchSettings($rows);
+        $ids = $rows->pluck('author_id')->all();
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->affiliationsPrefetch = Repo::affiliation()->getByAuthorIds($ids)
+            + array_fill_keys($ids, []);
+
+        $this->creditRolesPrefetch = \PKP\author\creditContributorRole\CreditContributorRole::query()
+            ->whereIn('contributor_id', $ids)
+            ->withCreditRoles()
+            ->select(['contributor_id', 'credit_role_identifier as role', 'credit_degree as degree'])
+            ->get()
+            ->groupBy('contributor_id')
+            ->map(fn ($group) => $group->map(fn ($r) => ['role' => $r->role, 'degree' => $r->degree])->values()->all())
+            ->all()
+            + array_fill_keys($ids, []);
+
+        $this->contributorRolesPrefetch = \PKP\author\contributorRole\ContributorRole::query()
+            ->join('credit_contributor_roles as ccr', 'ccr.contributor_role_id', '=', 'contributor_roles.contributor_role_id')
+            ->whereIn('ccr.contributor_id', $ids)
+            ->distinct()
+            ->select(['contributor_roles.*', 'ccr.contributor_id as prefetch_contributor_id'])
+            ->get()
+            ->groupBy('prefetch_contributor_id')
+            ->map(fn ($group) => $group->all())
+            ->all()
+            + array_fill_keys($ids, []);
     }
 
     /**

--- a/classes/citation/DAO.php
+++ b/classes/citation/DAO.php
@@ -90,8 +90,14 @@ class DAO extends EntityDAO
             $rows = $query
                 ->getQueryBuilder()
                 ->get();
-            foreach ($rows as $row) {
-                yield $row->citation_id => $this->fromRow($row);
+            // One settings query for the whole batch
+            $this->prefetchSettings($rows);
+            try {
+                foreach ($rows as $row) {
+                    yield $row->citation_id => $this->fromRow($row);
+                }
+            } finally {
+                $this->clearSettingsPrefetch();
             }
         });
     }

--- a/classes/citation/Repository.php
+++ b/classes/citation/Repository.php
@@ -262,7 +262,7 @@ class Repository
     /**
      * Insert/cpopy citations as they are for a publication. Used at publication versioning.
      */
-    public function copyCitations(array $citations, int $publicationId): void
+    public function copyCitations(iterable $citations, int $publicationId): void
     {
         foreach ($citations as $citation) {
             /** @var Citation $citation */

--- a/classes/core/EntityDAO.php
+++ b/classes/core/EntityDAO.php
@@ -72,6 +72,42 @@ abstract class EntityDAO
      */
     public $deprecatedDao;
 
+    /**
+     * Settings rows prefetched for a batch of entities,
+     * keyed by primary key. When set, fromRow() reads from this map
+     * instead of querying the settings table per entity.
+     */
+    protected ?array $settingsPrefetch = null;
+
+    /**
+     * Prefetch the settings rows for a batch of primary rows
+     * in a single query.
+     */
+    protected function prefetchSettings(\Illuminate\Support\Collection $rows): void
+    {
+        if (!$this->settingsTable || $rows->isEmpty()) {
+            $this->settingsPrefetch = [];
+            return;
+        }
+        $ids = $rows->pluck($this->primaryKeyColumn)->all();
+        // Pre-fill every id in the batch so entities without settings rows
+        // resolve to an empty set instead of falling back to a query
+        $this->settingsPrefetch = DB::table($this->settingsTable)
+            ->whereIn($this->primaryKeyColumn, $ids)
+            ->get()
+            ->groupBy($this->primaryKeyColumn)
+            ->all()
+            + array_fill_keys($ids, collect());
+    }
+
+    /**
+     * Reset the settings prefetch state after a batch completes.
+     */
+    protected function clearSettingsPrefetch(): void
+    {
+        $this->settingsPrefetch = null;
+    }
+
     /** @var PKPSchemaService<T> $schemaService */
     protected $schemaService;
 
@@ -120,9 +156,13 @@ abstract class EntityDAO
         }
 
         if ($this->settingsTable) {
-            $rows = DB::table($this->settingsTable)
-                ->where($this->primaryKeyColumn, '=', $row->{$this->primaryKeyColumn})
-                ->get();
+            // Use batch-prefetched settings when available;
+            // fall back to a query for entities outside the prefetched batch
+            $rows = ($this->settingsPrefetch !== null && array_key_exists($row->{$this->primaryKeyColumn}, $this->settingsPrefetch))
+                ? collect($this->settingsPrefetch[$row->{$this->primaryKeyColumn}])
+                : DB::table($this->settingsTable)
+                    ->where($this->primaryKeyColumn, '=', $row->{$this->primaryKeyColumn})
+                    ->get();
 
             $rows->each(function ($row) use ($object, $schema) {
                 if (!empty($schema->properties->{$row->setting_name})) {

--- a/classes/doi/DAO.php
+++ b/classes/doi/DAO.php
@@ -113,6 +113,26 @@ abstract class DAO extends EntityDAO
     }
 
     /**
+     * Fetch many DOIs by id with batched settings,
+     * returned as [doiId => Doi].
+     */
+    public function getByIds(array $ids): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+        $rows = DB::table($this->table)
+            ->whereIn($this->primaryKeyColumn, $ids)
+            ->get();
+        $this->prefetchSettings($rows);
+        try {
+            return $rows->mapWithKeys(fn ($row) => [$row->doi_id => $this->fromRow($row)])->all();
+        } finally {
+            $this->clearSettingsPrefetch();
+        }
+    }
+
+    /**
      * @copydoc EntityDAO::fromRow()
      */
     public function fromRow(object $row): Doi

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -102,8 +102,16 @@ class DAO extends EntityDAO
             $rows = $query
                 ->getQueryBuilder()
                 ->get();
-            foreach ($rows as $row) {
-                yield $row->publication_id => $this->fromRow($row);
+            // Batch-load settings and related entities
+            // for the whole result set instead of querying per publication
+            $this->prefetchSettings($rows);
+            $this->prefetchRelated($rows);
+            try {
+                foreach ($rows as $row) {
+                    yield $row->publication_id => $this->fromRow($row);
+                }
+            } finally {
+                $this->clearRelatedPrefetch();
             }
         });
     }
@@ -151,6 +159,131 @@ class DAO extends EntityDAO
     }
 
     /**
+     * Related data prefetched for the batch of publications currently being
+     * hydrated by getMany(), keyed by publication (or submission) id.
+     *
+     * Every map is pre-filled for all ids in the batch, so a missing key
+     * always means "not part of this batch" — the set* helpers then fall
+     * back to the original per-publication query rather than assuming an
+     * empty result. This keeps the prefetch purely an optimization: it can
+     * never change what data a publication is hydrated with.
+     */
+    protected ?array $submissionLocalesPrefetch = null;
+    protected ?array $categoryIdsPrefetch = null;
+    protected ?array $dataCitationsPrefetch = null;
+    protected ?array $fundersPrefetch = null;
+    protected ?array $vocabPrefetch = null;
+    protected ?array $doiObjectsPrefetch = null;
+    protected ?\Closure $authorsBatchLoader = null;
+
+    protected const VOCAB_SYMBOLIC_TO_PROP = [
+        ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD => 'keywords',
+        ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT => 'subjects',
+        ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE => 'disciplines',
+        ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY => 'supportingAgencies',
+    ];
+
+    /**
+     * Reset all prefetch state after a getMany() batch completes.
+     */
+    protected function clearRelatedPrefetch(): void
+    {
+        $this->clearSettingsPrefetch();
+        $this->submissionLocalesPrefetch = null;
+        $this->categoryIdsPrefetch = null;
+        $this->dataCitationsPrefetch = null;
+        $this->fundersPrefetch = null;
+        $this->vocabPrefetch = null;
+        $this->doiObjectsPrefetch = null;
+        $this->authorsBatchLoader = null;
+    }
+
+    /**
+     * Load the related entities for a batch of publication rows with one
+     * query per relation instead of one or more queries per publication.
+     */
+    protected function prefetchRelated(\Illuminate\Support\Collection $rows): void
+    {
+        $publicationIds = $rows->pluck('publication_id')->all();
+        $submissionIds = $rows->pluck('submission_id')->unique()->values()->all();
+        if (empty($publicationIds)) {
+            return;
+        }
+
+        $this->submissionLocalesPrefetch = DB::table('submissions')
+            ->whereIn('submission_id', $submissionIds)
+            ->pluck('locale', 'submission_id')
+            ->all();
+
+        $this->categoryIdsPrefetch = PublicationCategory::query()
+            ->whereIn('publication_id', $publicationIds)
+            ->get()
+            ->groupBy('publication_id')
+            ->map(fn ($group) => $group->pluck('category_id')->all())
+            ->all()
+            + array_fill_keys($publicationIds, []);
+
+        $this->dataCitationsPrefetch = DataCitation::query()
+            ->whereIn('publication_id', $publicationIds)
+            ->orderBySeq()
+            ->get()
+            ->groupBy(fn ($dataCitation) => $dataCitation->getRawOriginal('publication_id'))
+            ->map(fn ($group) => $group->values()->all())
+            ->all()
+            + array_fill_keys($publicationIds, []);
+
+        $this->fundersPrefetch = Funder::query()
+            ->whereIn('submission_id', $submissionIds)
+            ->orderBySeq()
+            ->get()
+            ->groupBy(fn ($funder) => $funder->getRawOriginal('submission_id'))
+            ->map(fn ($group) => $group->values()->all())
+            ->all()
+            + array_fill_keys($submissionIds, []);
+
+        $this->vocabPrefetch = array_fill_keys($publicationIds, []);
+        \PKP\controlledVocab\ControlledVocabEntry::query()
+            ->whereHas('controlledVocab', fn ($q) => $q
+                ->withSymbolics(array_keys(self::VOCAB_SYMBOLIC_TO_PROP))
+                ->where('assoc_type', Application::ASSOC_TYPE_PUBLICATION)
+                ->whereIn('assoc_id', $publicationIds))
+            ->with('controlledVocab')
+            ->get()
+            ->each(function ($entry) {
+                $vocab = $entry->controlledVocab;
+                $prop = self::VOCAB_SYMBOLIC_TO_PROP[$vocab->symbolic] ?? null;
+                if (!$prop) {
+                    return;
+                }
+                foreach (array_keys($entry->name) as $locale) {
+                    $this->vocabPrefetch[$vocab->assocId][$prop][$locale][] = $entry->getEntryData($locale);
+                }
+            });
+
+        $doiIds = $rows->pluck('doi_id')->filter()->unique()->values()->all();
+        $this->doiObjectsPrefetch = empty($doiIds) ? [] : Repo::doi()->dao->getByIds($doiIds);
+
+        // Shared deferred authors loader: the first access to any
+        // publication's authors hydrates the authors of the whole batch.
+        // Returns null for publications outside the batch, so the caller
+        // can fall back to the original per-publication query.
+        $authorsCache = null;
+        $this->authorsBatchLoader = function (int $publicationId) use ($publicationIds, &$authorsCache): ?array {
+            if ($authorsCache === null) {
+                $authorsCache = array_fill_keys($publicationIds, []);
+                $authors = Repo::author()->getCollector()
+                    ->filterByPublicationIds($publicationIds)
+                    ->orderBy(\PKP\author\Collector::ORDERBY_SEQUENCE)
+                    ->getMany();
+                foreach ($authors as $authorId => $author) {
+                    $authorsCache[$author->getData('publicationId')][$authorId] = $author;
+                }
+            }
+            return $authorsCache[$publicationId] ?? null;
+        };
+    }
+
+    /**
      * @copydoc EntityDAO::fromRow()
      */
     public function fromRow(object $row): Publication
@@ -161,13 +294,17 @@ class DAO extends EntityDAO
         $this->setDoiObject($publication);
 
         // Set the primary locale from the submission
-        $locale = DB::table('submissions as s')
-            ->where('s.submission_id', '=', $publication->getData('submissionId'))
-            ->value('locale');
+        $submissionId = $publication->getData('submissionId');
+        $locale = ($this->submissionLocalesPrefetch !== null && array_key_exists($submissionId, $this->submissionLocalesPrefetch))
+            ? $this->submissionLocalesPrefetch[$submissionId]
+            : DB::table('submissions as s')
+                ->where('s.submission_id', '=', $submissionId)
+                ->value('locale');
         $publication->setData('locale', $locale);
 
-        $citations = Repo::citation()->getByPublicationId($publication->getId());
-        $publication->setData('citations', $citations);
+        $publication->setData('citations', LazyCollection::make(function () use ($publication) {
+            yield from Repo::citation()->getByPublicationId($publication->getId());
+        })->remember());
         $publication->setData('citationsRaw', new class ($publication->getId()) implements \Stringable {
             public function __construct(public int $publicationId)
             {
@@ -331,14 +468,20 @@ class DAO extends EntityDAO
      */
     protected function setAuthors(Publication $publication)
     {
+        // Use the shared batch loader when this publication is hydrated as
+        // part of a getMany() batch; otherwise load its authors individually
+        $loader = $this->authorsBatchLoader;
+        $publicationId = $publication->getId();
         $publication->setData(
             'authors',
-            Repo::author()
-                ->getCollector()
-                ->filterByPublicationIds([$publication->getId()])
-                ->orderBy(\PKP\author\Collector::ORDERBY_SEQUENCE)
-                ->getMany()
-                ->remember()
+            LazyCollection::make(function () use ($loader, $publicationId) {
+                yield from ($loader ? $loader($publicationId) : null)
+                    ?? Repo::author()
+                        ->getCollector()
+                        ->filterByPublicationIds([$publicationId])
+                        ->orderBy(\PKP\author\Collector::ORDERBY_SEQUENCE)
+                        ->getMany();
+            })->remember()
         );
     }
 
@@ -362,6 +505,14 @@ class DAO extends EntityDAO
      */
     protected function setControlledVocab(Publication $publication)
     {
+        if ($this->vocabPrefetch !== null && array_key_exists($publication->getId(), $this->vocabPrefetch)) {
+            $vocabs = $this->vocabPrefetch[$publication->getId()];
+            foreach (self::VOCAB_SYMBOLIC_TO_PROP as $prop) {
+                $publication->setData($prop, $vocabs[$prop] ?? []);
+            }
+            return;
+        }
+
         $publication->setData(
             'keywords',
             Repo::controlledVocab()->getBySymbolic(
@@ -457,7 +608,9 @@ class DAO extends EntityDAO
      */
     protected function setCategories(Publication $publication): void
     {
-        $categoryIds = PublicationCategory::withPublicationId($publication->getId())->pluck('category_id')->toArray();
+        $categoryIds = ($this->categoryIdsPrefetch !== null && array_key_exists($publication->getId(), $this->categoryIdsPrefetch))
+            ? $this->categoryIdsPrefetch[$publication->getId()]
+            : PublicationCategory::withPublicationId($publication->getId())->pluck('category_id')->toArray();
         $publication->setData('categoryIds', $categoryIds);
     }
 
@@ -483,11 +636,13 @@ class DAO extends EntityDAO
      */
     protected function setDataCitations(Publication $publication): void
     {
-        $dataCitations = DataCitation::withPublicationId($publication->getId())
-            ->orderBySeq()
-            ->get()
-            ->values()
-            ->all();
+        $dataCitations = ($this->dataCitationsPrefetch !== null && array_key_exists($publication->getId(), $this->dataCitationsPrefetch))
+            ? $this->dataCitationsPrefetch[$publication->getId()]
+            : DataCitation::withPublicationId($publication->getId())
+                ->orderBySeq()
+                ->get()
+                ->values()
+                ->all();
         $publication->setData('dataCitations', $dataCitations);
     }
 
@@ -504,11 +659,13 @@ class DAO extends EntityDAO
      */
     protected function setFunders(Publication $publication): void
     {
-        $funders = Funder::withSubmissionId($publication->getData('submissionId'))
-            ->orderBySeq()
-            ->get()
-            ->values()
-            ->all();
+        $funders = ($this->fundersPrefetch !== null && array_key_exists($publication->getData('submissionId'), $this->fundersPrefetch))
+            ? $this->fundersPrefetch[$publication->getData('submissionId')]
+            : Funder::withSubmissionId($publication->getData('submissionId'))
+                ->orderBySeq()
+                ->get()
+                ->values()
+                ->all();
         $publication->setData('funders', $funders);
     }
 
@@ -518,8 +675,12 @@ class DAO extends EntityDAO
      */
     protected function setDoiObject(Publication $publication)
     {
-        if (!empty($publication->getData('doiId'))) {
-            $publication->setData('doiObject', Repo::doi()->get($publication->getData('doiId')));
+        if (!empty($doiId = $publication->getData('doiId'))) {
+            // Use the batch-prefetched DOI object when available
+            $doi = ($this->doiObjectsPrefetch !== null && isset($this->doiObjectsPrefetch[$doiId]))
+                ? $this->doiObjectsPrefetch[$doiId]
+                : Repo::doi()->get($doiId);
+            $publication->setData('doiObject', $doi);
         }
     }
 

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -143,8 +143,25 @@ class DAO extends EntityDAO
                 ->getQueryBuilder()
                 ->get();
 
-            foreach ($rows as $row) {
-                yield $row->review_id => $this->fromRow($row);
+            // Batch-load settings, reviewers and DOIs for the
+            // whole result set instead of querying per review assignment
+            $this->prefetchSettings($rows);
+            $reviewerIds = $rows->pluck('reviewer_id')->filter()->unique()->values()->all();
+            $this->reviewersPrefetch = empty($reviewerIds) ? [] : Repo::user()->getCollector()
+                ->filterByUserIds($reviewerIds)
+                ->filterByStatus(\PKP\user\Collector::STATUS_ALL)
+                ->getMany()
+                ->all();
+            $doiIds = $rows->pluck('doi_id')->filter()->unique()->values()->all();
+            $this->doiObjectsPrefetch = empty($doiIds) ? [] : Repo::doi()->dao->getByIds($doiIds);
+            try {
+                foreach ($rows as $row) {
+                    yield $row->review_id => $this->fromRow($row);
+                }
+            } finally {
+                $this->clearSettingsPrefetch();
+                $this->reviewersPrefetch = null;
+                $this->doiObjectsPrefetch = null;
             }
         });
     }
@@ -155,7 +172,11 @@ class DAO extends EntityDAO
     public function fromRow(object $row): ReviewAssignment
     {
         $reviewAssignment = parent::fromRow($row);
-        $reviewer = Repo::user()->get($reviewAssignment->getReviewerId(), true);
+        // Use batch-prefetched reviewers/DOIs when available
+        $reviewerId = $reviewAssignment->getReviewerId();
+        $reviewer = ($this->reviewersPrefetch !== null && isset($this->reviewersPrefetch[$reviewerId]))
+            ? $this->reviewersPrefetch[$reviewerId]
+            : Repo::user()->get($reviewerId, true);
         $reviewAssignment->setData(
             'reviewerFullName',
             $reviewer->getFullName()
@@ -165,15 +186,24 @@ class DAO extends EntityDAO
             $reviewer->getUserName()
         );
 
-        if (!empty($reviewAssignment->getData('doiId'))) {
+        if (!empty($doiId = $reviewAssignment->getData('doiId'))) {
             $reviewAssignment->setData(
                 'doiObject',
-                Repo::doi()->get($reviewAssignment->getData('doiId'))
+                ($this->doiObjectsPrefetch !== null && isset($this->doiObjectsPrefetch[$doiId]))
+                    ? $this->doiObjectsPrefetch[$doiId]
+                    : Repo::doi()->get($doiId)
             );
         }
 
         return $reviewAssignment;
     }
+
+    /**
+     * Reviewers and DOI objects prefetched for the batch of review
+     * assignments currently being hydrated by getMany(), keyed by id.
+     */
+    protected ?array $reviewersPrefetch = null;
+    protected ?array $doiObjectsPrefetch = null;
 
     /**
      * @copydoc EntityDAO::insert()

--- a/classes/user/DAO.php
+++ b/classes/user/DAO.php
@@ -131,8 +131,14 @@ class DAO extends EntityDAO
                 return;
             }
 
-            foreach ($rows as $row) {
-                yield $row->user_id => $this->fromRow($row, $query->includeReviewerData);
+            // One settings query for the whole batch
+            $this->prefetchSettings($rows);
+            try {
+                foreach ($rows as $row) {
+                    yield $row->user_id => $this->fromRow($row, $query->includeReviewerData);
+                }
+            } finally {
+                $this->clearSettingsPrefetch();
             }
         });
     }


### PR DESCRIPTION
Batch-load settings and related entities in EntityDAO/DAO getMany() instead of querying per entity:

- EntityDAO: prefetchSettings() loads a batch's settings rows in one query; fromRow() falls back to a per-entity query for rows outside the prefetched batch.
- Publication DAO: prefetchRelated() batches submission locales, categories, data citations, funders, controlled vocabs and DOIs, and shares one deferred authors loader across the batch.
- Author DAO: batches affiliations and credit/contributor roles.
- ReviewAssignment DAO: batches settings, reviewers and DOIs.
- User/Citation DAOs: batch settings via prefetchSettings().
- Publication citations are now hydrated lazily (LazyCollection, mirroring authors/citationsRaw); copyCitations() accepts any iterable and the citations API no longer iterates by reference.

All prefetch maps are pre-filled for the batch ids and consumers fall back to the original per-entity queries on a missing key, so the prefetch can only reduce queries, never change hydrated data.

Article landing page: 5,356 -> 385 queries on a 728-citation, 4-version article; rendered HTML is byte-identical.