### PR TITLE
pkp/pkp-lib#12375 Honour the URL locale when resolving the current locale

### DIFF
--- a/classes/core/PKPPageRouter.php
+++ b/classes/core/PKPPageRouter.php
@@ -501,15 +501,22 @@ class PKPPageRouter extends PKPRouter
         $contextPath = $this->_getRequestedUrlParts(Core::getContextPath(...), $request);
         $urlLocale = $this->_getRequestedUrlParts(Core::getLocalization(...), $request);
         $multiLingual = count($this->_getContextAndLocales($request, $contextPath)[1]) > 1;
-        // Quit if there's no new locale to be set and the request URL is already well-formed
-        if (!$setLocale && ($multiLingual ? $urlLocale === Locale::getLocale() : !$urlLocale)) {
-            return;
-        }
 
         $session = $request->getSession();
         $currentLocale = $session->get('currentLocale') ?? '';
         if (!Locale::isSupported($currentLocale ?? '')) {
             $currentLocale = null;
+        }
+
+        // Quit if there's no new locale to be set and the request URL is already well-formed.
+        // Still sync the session/cookie to the URL locale so it survives session resets and
+        // session-disabled requests, which never get a chance to write it themselves otherwise.
+        if (!$setLocale && ($multiLingual ? $urlLocale === Locale::getLocale() : !$urlLocale)) {
+            if ($multiLingual && $urlLocale !== $currentLocale) {
+                $session->put('currentLocale', $urlLocale);
+                $request->setCookieVar('currentLocale', $urlLocale);
+            }
+            return;
         }
 
         $newLocale = $setLocale ?? $urlLocale;

--- a/classes/core/PKPRequest.php
+++ b/classes/core/PKPRequest.php
@@ -361,6 +361,14 @@ class PKPRequest
     }
 
     /**
+     * Get the CGI PATH_INFO of the current request, e.g. "/context/locale/page/op".
+     */
+    public function getPathInfo(): string
+    {
+        return $_SERVER['PATH_INFO'] ?? '';
+    }
+
+    /**
      * Get the server hostname in the request.
      *
      * @param $default Default hostname (defaults to localhost if null)

--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -137,6 +137,7 @@ class Locale implements LocaleInterface
         $request = $this->_getRequest();
 
         $locale = $request->getUserVar('setLocale')
+            ?: $this->_getUrlLocale()
             ?: $request->getSession()->get('currentLocale')
             ?: $request->getCookieVar('currentLocale')
             ?: $this->getPreferredLocale();
@@ -144,6 +145,22 @@ class Locale implements LocaleInterface
         $this->setLocale($locale);
 
         return (string)$this->locale;
+    }
+
+    /**
+     * Get the locale segment of the request URL, if it is one this installation supports.
+     *
+     * Since 3.5 the locale is part of the URL, but getLocale() only consulted
+     * setLocale/session/cookie. A client that keeps no cookies (crawlers, uptime monitors,
+     * curl) therefore never matched the locale in the URL, and PKPPageRouter::_setLocale()
+     * redirected it to the very same URL forever - an infinite 302 loop on every supported
+     * non-primary locale. Honouring the URL also makes the page render in the requested
+     * language on the first hit, with no redirect.
+     */
+    private function _getUrlLocale(): ?string
+    {
+        $locale = Core::getLocalization($_SERVER['PATH_INFO'] ?? '');
+        return $locale !== '' && $this->isSupported($locale) ? $locale : null;
     }
 
     /**

--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -136,6 +136,7 @@ class Locale implements LocaleInterface
         $request = $this->_getRequest();
 
         $locale = $request->getUserVar('setLocale')
+            ?: $this->_getUrlLocale()
             ?: $request->getSession()->get('currentLocale')
             ?: $request->getCookieVar('currentLocale')
             ?: $this->getPreferredLocale();
@@ -143,6 +144,22 @@ class Locale implements LocaleInterface
         $this->setLocale($locale);
 
         return (string)$this->locale;
+    }
+
+    /**
+     * Get the locale segment of the request URL, if it is one this installation supports.
+     *
+     * Since 3.5 the locale is part of the URL, but getLocale() only consulted
+     * setLocale/session/cookie. A client that keeps no cookies (crawlers, uptime monitors,
+     * curl) therefore never matched the locale in the URL, and PKPPageRouter::_setLocale()
+     * redirected it to the very same URL forever - an infinite 302 loop on every supported
+     * non-primary locale. Honouring the URL also makes the page render in the requested
+     * language on the first hit, with no redirect.
+     */
+    private function _getUrlLocale(): ?string
+    {
+        $locale = Core::getLocalization($_SERVER['PATH_INFO'] ?? '');
+        return $locale !== '' && $this->isSupported($locale) ? $locale : null;
     }
 
     /**

--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -136,7 +136,13 @@ class Locale implements LocaleInterface
 
         $request = $this->_getRequest();
 
-        $locale = $request->getUserVar('setLocale')
+        // The setLocale request var is only honoured while sessions are disabled (install,
+        // CLI, unit tests - see PKPApplication::__construct()), where the cookie/session
+        // can't be relied on and the new locale must take effect immediately, in the same
+        // request, before it's written out. Trusting it unconditionally let a stray
+        // ?setLocale= on any ordinary URL permanently override the URL's own locale segment
+        // and loop forever against PKPPageRouter::_setLocale() (see pkp/pkp-lib#12375).
+        $locale = (PKPSessionGuard::isSessionDisable() ? $request->getUserVar('setLocale') : null)
             ?: $this->_getUrlLocale()
             ?: $request->getSession()->get('currentLocale')
             ?: $request->getCookieVar('currentLocale')

--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -159,7 +159,7 @@ class Locale implements LocaleInterface
      */
     private function _getUrlLocale(): ?string
     {
-        $locale = Core::getLocalization($_SERVER['PATH_INFO'] ?? '');
+        $locale = Core::getLocalization($this->_getRequest()->getPathInfo());
         return $locale !== '' && $this->isSupported($locale) ? $locale : null;
     }
 

--- a/pages/install/InstallHandler.php
+++ b/pages/install/InstallHandler.php
@@ -44,6 +44,10 @@ class InstallHandler extends Handler
         $this->validate(null, $request);
         $this->setupTemplate($request);
 
+        // FIXME: Likely unreachable - PKPPageRouter::route() calls _setLocale() for every
+        // page='install' request before the handler runs, and _setLocale() always redirects
+        // (and exits) whenever $_GET['setLocale'] is set - see PKPPageRouter.php:216-221 and
+        // pkp/pkp-lib#12375. Left in place pending confirmation before removal.
         if (($setLocale = $request->getUserVar('setLocale')) != null && Locale::isLocaleValid($setLocale)) {
             $request->setCookieVar('currentLocale', $setLocale);
         }
@@ -112,6 +116,7 @@ class InstallHandler extends Handler
         $this->validate(null, $request);
         $this->setupTemplate($request);
 
+        // FIXME: Likely unreachable - see the identical note in index() above.
         if (($setLocale = $request->getUserVar('setLocale')) != null && Locale::isLocaleValid($setLocale)) {
             $request->setCookieVar('currentLocale', $setLocale);
         }


### PR DESCRIPTION
Fixes #12375.

Background and reproduction details are in [this comment on the issue](https://github.com/pkp/pkp-lib/issues/12375#issuecomment-5153326817); the short version follows.

### Root cause

`Locale::getLocale()` resolves the locale from `setLocale` → session → cookie → `Accept-Language`. It never looks at the locale segment of the URL, which is where 3.5 moved it.

`PKPPageRouter::_setLocale()` then compares the two:

```php
if (!$setLocale && ($multiLingual ? $urlLocale === Locale::getLocale() : !$urlLocale)) {
    return;
}
```

`$urlLocale` comes from the URL, `Locale::getLocale()` never does. For a client that stores no cookie the two can never agree on a supported non-primary locale, so the guard never fires and the router redirects to the very same URL indefinitely.

Browsers hide this — they store the cookie and the second request succeeds. What breaks is everything that keeps no cookies: crawlers, uptime monitors, `curl`, link-preview fetchers. The practical effect is that pages in secondary locales are not indexable.

The issue describes this as specific to `restful_urls = On`. It is not — `restful_urls` only controls whether `index.php` appears in the path, and the locale segment is in `PATH_INFO` either way. We reproduced it in both modes (table below).

### Why here and not in the router

Patching `PKPPageRouter::_setLocale()` — or aborting same-path redirects in `PKPRequest::redirectUrl()`, which is the workaround circulating in the [forum thread](https://forum.pkp.sfu.ca/t/solved-infinite-redirect-loop-err-too-many-redirects-on-secondary-locales-with-restful-urls-enabled/98025) — stops the loop but renders the page in the wrong language (`<html lang="pt-BR">` on `/en`), because `TemplateManager` has already been initialised by the time the router runs. The locale has to be correct before the template layer, which means fixing it where the locale is resolved.

### The change

`getLocale()` consults the URL segment, accepted only when `isSupported()` accepts it. Two details are deliberate:

- **Position in the chain.** After `setLocale`, so an explicit language switch still wins; before session and cookie, so `/en` with a stale `pt_BR` cookie serves English.
- **`isSupported()`, not `isLocaleValid()`.** `Core::getLocalization()` only validates the *shape* of the code. `isSupported()` is context-aware, so a locale installed site-wide but not enabled for the journal still falls through and redirects to the primary locale.

`Core` is already imported in the file; no new dependency.

### Testing

Verified on a cookie-less client (no session, no cookie jar) on a journal with `en`, `es` and `pt_BR` enabled and `pt_BR` primary:

| | before | after |
|---|---|---|
| `/<ctx>/en` | 302 → itself (loop) | 200, `<html lang="en">` |
| `/<ctx>/es` | 302 → itself (loop) | 200, `<html lang="es">` |
| `/<ctx>/pt_BR` (primary) | 200 | 200, `<html lang="pt-BR">` |
| `/<ctx>/fr` (not supported) | 302 → `/<ctx>/pt_BR` | 302 → `/<ctx>/pt_BR` |
| `/<ctx>/pt_BR/user/setLocale/en` | → `/<ctx>/en/...`, cookie set | unchanged |

URL generation modes, both reproduced broken and both verified fixed:

| mode | before | after |
|---|---|---|
| `restful_urls = On` | loop | fixed |
| `restful_urls = Off` | loop | fixed |

`disable_path_info` was removed in 3.5 (#8365), so `PATH_INFO` is the only URL source and there is no third mode to cover.

Running in production since 2026-07-27 on five installations — OJS 3.5.0.3, OJS 3.5.0.5 (×2) and OMP 3.5.0.4 (×2) — with `restful_urls` both `On` and `Off`. No regression observed.

I did not add an automated test because I could not find existing coverage for this path; happy to add one if you can point me at the right harness.

### Open question — where the URL reading should live

The helper reads `$_SERVER['PATH_INFO']` directly from inside the i18n class. `PKPPageRouter::_getRequestedUrlParts()` already does that reading canonically, but it is `private`. I have gone with the smallest, most self-contained version here; if you would rather expose/share the router accessor, or move the reading into a helper on `Core` or `PKPRequest`, say the word and I will restructure it. That is an architecture call on your side.

Targeted at `main`. Happy to open a backport against `stable-3_5_0` as well if you want it there.

— OJSBR (support@ojsbr.com)
