### PR TITLE
Backport #12742 to stable-3_5_0: bulk delete of incomplete submissions restricts managers who also hold the Author role

### DIFF
--- a/api/v1/_submissions/PKPBackendSubmissionsController.php
+++ b/api/v1/_submissions/PKPBackendSubmissionsController.php
@@ -471,9 +471,8 @@ abstract class PKPBackendSubmissionsController extends PKPBaseController
         $context = $this->getRequest()->getContext();
         $user = $request->getUser();
 
-        if ($user->hasRole([Role::ROLE_ID_AUTHOR], $context->getId())) {
-            $userId = $request->getUser()->getId();
-            $collector->assignedTo([$userId]);
+        if (!$this->canAccessAllSubmissions()) {
+            $collector->assignedTo([$user->getId()]);
         }
 
         $submissions = $collector->getMany()->all();


### PR DESCRIPTION
Fixes #13125.

Straight cherry-pick of f133ab9de (from #12742, under #6528 — milestone **3.5.0 LTS**), which landed on `main` on 2026-06-25 but was never backported. Every 3.5.x release still carries the bug; reproduced on **OJS 3.5.0-5**.

## What breaks today

`bulkDeleteIncompleteSubmissions()` narrows the collector whenever the user merely **has** the Author role, rather than when they are *only* an Author:

```php
if ($user->hasRole([Role::ROLE_ID_AUTHOR], $context->getId())) {
    $userId = $request->getUser()->getId();
    $collector->assignedTo([$userId]);
}
```

A Journal Manager who also holds an Author role — a very common setup — therefore only ever sees submissions assigned to them. Incomplete submissions usually have no stage assignment at all, so the collector comes back empty, `array_diff()` reports a mismatch, and the caller gets `404 api.404.resourceNotFound`. The UI then tells the user the resource does not exist, when in fact it does and they were silently filtered out.

It also contradicts `Repo::submission()::canCurrentUserDelete()` — *"Only allow admins and journal managers to delete submissions, except for authors who can delete their own incomplete submissions"* — which the single-submission route already defers to. Only the bulk route rolled its own check.

## The change

```diff
-        if ($user->hasRole([Role::ROLE_ID_AUTHOR], $context->getId())) {
-            $userId = $request->getUser()->getId();
-            $collector->assignedTo([$userId]);
+        if (!$this->canAccessAllSubmissions()) {
+            $collector->assignedTo([$user->getId()]);
         }
```

Self-contained on this branch: `canAccessAllSubmissions()` already exists here and is already used in the same file (line 275). No new helper, no signature change, nothing else touched.

## Why it is safe

The per-submission guard further down is untouched and still runs on every deletion:

```php
if (!Repo::submission()->canCurrentUserDelete($submission)) {
    return response()->json(['error' => __('api.submissions.403.unauthorizedDeleteSubmission')], Response::HTTP_FORBIDDEN);
}
```

So authors remain limited to their own incomplete submissions; this only stops managers and site admins from being wrongly narrowed before that check ever runs.

## Verified

On OJS 3.5.0-5 with a Journal Manager who also holds the Author role, and an incomplete submission (`submission_progress <> ''`) with no stage assignment: `DELETE /api/v1/_submissions?ids[]=<id>` returned `404` before, and deletes correctly after.

---
Contributed by [OJSBR](https://ojsbr.com), found while auditing an OJS 3.4.0.9 → 3.5.0-5 upgrade.