### PR TITLE
Fix Intl locale initialization on PHP 8.4

### DIFF
--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -159,8 +159,7 @@ class Locale implements LocaleInterface
 
         $this->locale = $locale;
         setlocale(LC_ALL, 'C.utf8', 'C');
-        $locales = array_keys($this->getWeblateLocaleNames());
-        \Locale::setDefault(\Locale::lookup($locales, $locale, true));
+        \Locale::setDefault($locale);
     }
 
     /**

--- a/tests/classes/i18n/LocaleTest.php
+++ b/tests/classes/i18n/LocaleTest.php
@@ -89,6 +89,19 @@ class LocaleTest extends PKPTestCase
             ->getMock();
     }
 
+    public function testSetLocaleSetsIntlDefault()
+    {
+        $defaultLocale = \Locale::getDefault();
+
+        try {
+            Locale::setLocale('pt_BR');
+
+            self::assertSame('pt_BR', \Locale::getDefault());
+        } finally {
+            \Locale::setDefault($defaultLocale);
+        }
+    }
+
     public function testIsLocaleComplete()
     {
         self::assertTrue(Locale::getMetadata('en')->isComplete());


### PR DESCRIPTION
Fixes #13139

### Summary

- Pass the already validated and supported OJS locale directly to `\Locale::setDefault()`.
- Remove the redundant `\Locale::lookup()` call, which received 799 language tags despite PHP documenting a maximum of 100.
- Add a test that verifies that the PKP locale is propagated to PHP Intl.

### Why

`setLocale()` already validates the locale against the Weblate locale list and the locales supported by the application. A second lookup across all Weblate locales is therefore unnecessary.

Under PHP 8.4, the oversized `\Locale::lookup()` call returns `null`. Passing that value to `\Locale::setDefault()` causes a `TypeError` and prevents theme plugins from being initialized.

### Testing

Tested with:

- PHP 8.4.24
- Intl 8.4.24
- ICU 76.1
- PHPUnit 11.5.11

Targeted test:

```text
php lib/vendor/bin/phpunit --configuration tests/phpunit.xml classes/i18n/LocaleTest.php
```

Result after the fix: `Tests: 7, Assertions: 18`

The test was also run against the previous implementation and reproduced the reported `Locale::setDefault() TypeError`.