### PR TITLE
[stable-3_4_0] pkp/pkp-lib#10486 adds validation to prevent an author of a rejected submission from editing metadata in the submission.

### DIFF
--- a/api/v1/submissions/PKPSubmissionHandler.php
+++ b/api/v1/submissions/PKPSubmissionHandler.php
@@ -1113,7 +1113,7 @@ class PKPSubmissionHandler extends APIHandler
 
         // Prevent users from editing publications if they do not have permission. Except for admins.
         $userRoles = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_USER_ROLES);
-        if (!in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) && !Repo::submission()->canEditPublication($submission->getId(), $currentUser->getId())) {
+        if (!in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) && !Repo::submission()->canEditPublication($submission, $currentUser->getId())) {
             return $response->withStatus(403)->withJsonError('api.submissions.403.userCantEdit');
         }
 
@@ -1527,7 +1527,7 @@ class PKPSubmissionHandler extends APIHandler
 
         // Prevent users from editing publications if they do not have permission. Except for admins.
         $userRoles = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_USER_ROLES);
-        if (!in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) && !Repo::submission()->canEditPublication($submission->getId(), $currentUser->getId())) {
+        if (!in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) && !Repo::submission()->canEditPublication($submission, $currentUser->getId())) {
             return $response->withStatus(403)->withJsonError('api.submissions.403.userCantEdit');
         }
 

--- a/classes/security/authorization/internal/PublicationCanBeEditedPolicy.php
+++ b/classes/security/authorization/internal/PublicationCanBeEditedPolicy.php
@@ -45,7 +45,7 @@ class PublicationCanBeEditedPolicy extends AuthorizationPolicy
 
         // Prevent users from editing publications if they do not have permission. Except for admins.
         $userRoles = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_USER_ROLES);
-        if (in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) || Repo::submission()->canEditPublication($submission->getId(), $this->_currentUser->getId())) {
+        if (in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) || Repo::submission()->canEditPublication($submission, $this->_currentUser->getId())) {
             return AuthorizationPolicy::AUTHORIZATION_PERMIT;
         }
 

--- a/classes/submission/Repository.php
+++ b/classes/submission/Repository.php
@@ -482,10 +482,26 @@ abstract class Repository
     /**
      * Check if a user can edit the publication metadata of a submission
      */
-    public function canEditPublication(int $submissionId, int $userId): bool
+    public function canEditPublication(Submission $submission, int $userId): bool
     {
+        $contextId = $submission->getData('contextId');
         $stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO'); /** @var StageAssignmentDAO $stageAssignmentDao */
-        $stageAssignments = $stageAssignmentDao->getBySubmissionAndUserIdAndStageId($submissionId, $userId, null)->toArray();
+        $stageAssignments = $stageAssignmentDao->getBySubmissionAndUserIdAndStageId($submission->getId(), $userId, null)->toArray();
+        $userIsAuthor = !empty($stageAssignmentDao->getBySubmissionAndRoleId($submission->getId(), Role::ROLE_ID_AUTHOR, null, $userId)->toArray());
+        if ($submission->getData('status') == Submission::STATUS_DECLINED && $userIsAuthor) {
+            $userIsOnlyAuthorOrReader = true;
+            $roleDao = DAORegistry::getDAO('RoleDAO'); /** @var RoleDAO $roleDao */
+            $roles = $roleDao->getByUserId($userId, $contextId);
+            foreach ($roles as $role) {
+                if ($role->getRoleId() != Role::ROLE_ID_AUTHOR && $role->getRoleId() != Role::ROLE_ID_READER) {
+                    $userIsOnlyAuthorOrReader = false;
+                    break;
+                }
+            }
+            if ($userIsOnlyAuthorOrReader) {
+                return false;
+            }
+        }
         // Check for permission from stage assignments
         foreach ($stageAssignments as $stageAssignment) {
             if ($stageAssignment->getCanChangeMetadata()) {
@@ -493,8 +509,7 @@ abstract class Repository
             }
         }
         // If user has no stage assigments, check if user can edit anyway ie. is manager
-        $context = Application::get()->getRequest()->getContext();
-        if (count($stageAssignments) == 0 && $this->_canUserAccessUnassignedSubmissions($context->getId(), $userId)) {
+        if (count($stageAssignments) == 0 && $this->_canUserAccessUnassignedSubmissions($contextId, $userId)) {
             return true;
         }
         // Else deny access

--- a/controllers/grid/users/author/AuthorGridHandler.php
+++ b/controllers/grid/users/author/AuthorGridHandler.php
@@ -290,7 +290,7 @@ class AuthorGridHandler extends GridHandler
         }
 
         // The user may not be allowed to edit the metadata
-        if (Repo::submission()->canEditPublication($submission->getId(), $user->getId())) {
+        if (Repo::submission()->canEditPublication($submission, $user->getId())) {
             return true;
         }
 

--- a/pages/authorDashboard/PKPAuthorDashboardHandler.php
+++ b/pages/authorDashboard/PKPAuthorDashboardHandler.php
@@ -279,7 +279,7 @@ abstract class PKPAuthorDashboardHandler extends Handler
         // Check if current author can edit metadata
         $userRoles = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_USER_ROLES);
         $canEditPublication = true;
-        if (!in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) && !Repo::submission()->canEditPublication($submission->getId(), $user->getId())) {
+        if (!in_array(Role::ROLE_ID_SITE_ADMIN, $userRoles) && !Repo::submission()->canEditPublication($submission, $user->getId())) {
             $canEditPublication = false;
         }
 

--- a/pages/workflow/PKPWorkflowHandler.php
+++ b/pages/workflow/PKPWorkflowHandler.php
@@ -170,7 +170,7 @@ abstract class PKPWorkflowHandler extends Handler
         $currentStageId = $submission->getStageId();
         $accessibleWorkflowStages = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_ACCESSIBLE_WORKFLOW_STAGES);
         $canAccessPublication = false; // View title, metadata, etc.
-        $canEditPublication = Repo::submission()->canEditPublication($submission->getId(), $request->getUser()->getId());
+        $canEditPublication = Repo::submission()->canEditPublication($submission, $request->getUser()->getId());
         $canAccessProduction = false; // Access to galleys and issue entry
         $canPublish = false; // Ability to publish, unpublish and create versions
         $canAccessEditorialHistory = false; // Access to activity log


### PR DESCRIPTION
Related issue: #10486

This implementation was ported from PR: https://github.com/pkp/pkp-lib/pull/10693