### PR TITLE
pkp/pkp-lib#5887 Index author_settings by setting name and value

### DIFF
--- a/classes/migration/install/SubmissionsMigration.php
+++ b/classes/migration/install/SubmissionsMigration.php
@@ -132,6 +132,14 @@ class SubmissionsMigration extends \PKP\migration\Migration
 
             $table->unique(['author_id', 'locale', 'setting_name'], 'author_settings_unique');
         });
+        // Add partial index (DBMS-specific). Author names are looked up by value
+        // (Author\Collector::filterByName), which without this scans the table.
+        match (DB::getDriverName()) {
+            'mysql', 'mariadb' =>
+                DB::unprepared('CREATE INDEX author_settings_name_value ON author_settings (setting_name(50), setting_value(150))'),
+            'pgsql' =>
+                DB::unprepared("CREATE INDEX author_settings_name_value ON author_settings (setting_name, setting_value) WHERE setting_name IN ('givenName', 'familyName', 'orcid')")
+        };
 
         // Credit roles listing table
         Schema::create('credit_roles', function (Blueprint $table) {

--- a/classes/migration/upgrade/v3_6_0/I5887_AddAuthorSettingsNameValueIndex.php
+++ b/classes/migration/upgrade/v3_6_0/I5887_AddAuthorSettingsNameValueIndex.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_6_0/I5887_AddAuthorSettingsNameValueIndex.php
+ *
+ * Copyright (c) 2026 Simon Fraser University
+ * Copyright (c) 2026 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I5887_AddAuthorSettingsNameValueIndex
+ *
+ * @brief Index author_settings by setting name and value.
+ *
+ * Author names are looked up by value rather than by author: given a name,
+ * find the authors called that (Author\Collector::filterByName, used by the
+ * Recommend Articles by Author plugin and by author queries in the API).
+ * The only indexes on the table are on author_id and the (author_id, locale,
+ * setting_name) unique key, so that lookup reads the whole table.
+ *
+ * This mirrors the index publication_settings already carries.
+ */
+
+namespace PKP\migration\upgrade\v3_6_0;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PKP\install\DowngradeNotSupportedException;
+
+class I5887_AddAuthorSettingsNameValueIndex extends Migration
+{
+    private const INDEX = 'author_settings_name_value';
+
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        if ($this->indexExists()) {
+            return;
+        }
+
+        match (DB::getDriverName()) {
+            'mysql', 'mariadb' =>
+                DB::unprepared('CREATE INDEX ' . self::INDEX . ' ON author_settings (setting_name(50), setting_value(150))'),
+            'pgsql' =>
+                DB::unprepared('CREATE INDEX ' . self::INDEX . " ON author_settings (setting_name, setting_value) WHERE setting_name IN ('givenName', 'familyName', 'orcid')")
+        };
+    }
+
+    /**
+     * Reverse the migration.
+     */
+    public function down(): void
+    {
+        throw new DowngradeNotSupportedException();
+    }
+
+    private function indexExists(): bool
+    {
+        return Schema::hasIndex('author_settings', self::INDEX);
+    }
+}


### PR DESCRIPTION
Refs #5887.

`author_settings` is looked up **by value** rather than by author: given a name, find the authors called that. `Author\Collector::filterByName()` does it with a subquery on `setting_name`/`setting_value`, and the only indexes on that table are `author_settings_author_id` and the `(author_id, locale, setting_name)` unique key — so that lookup reads the whole table.

The Recommend Articles by Author plugin makes that lookup **twice per author** of the article being read, which is what makes #5887 visible, but the index helps any caller of `filterByName()`.

### Measured

On a live journal with 4,823 published articles and 25,877 authors (401,286 rows in `author_settings`), MariaDB 11.4:

```
EXPLAIN SELECT author_id FROM author_settings
 WHERE setting_name='familyName' AND setting_value='Silva'

before   type=ALL   rows=401286
after    type=ref   rows=443     key=author_settings_name_value
```

With the plugin enabled and **no other change**:

| article | before | after |
|---|---|---|
| 32 authors | 12.6 s | 0.57 s |
| 21 authors | 6.4 s | 0.15 s |
| 16 authors | 5.2 s | 0.20 s |
| average of 25 articles | 0.80 s | 0.07 s |

Creating the index took 0.9 s there.

### What this does and does not do

It removes the table scan. It does **not** make the plugin cheap — it still runs a query per author on every page view, and #5887 is about that too. But the scan is what takes an article page from fast to unusable as a journal grows, and this is the cheap half of the fix.

### Notes

- The index mirrors the one `publication_settings` already carries in `SubmissionsMigration`, including the partial variant for PostgreSQL, restricted here to the settings that are searched by value (`givenName`, `familyName`, `orcid`).
- The upgrade migration is a no-op when the index is already present.
- It needs registering in the applications' `upgrade.xml`; OJS is pkp/ojs#5743. Happy to do the same for OMP and OPS.
