### PR TITLE
pkp/pkp-lib#13003 Add support for batch loading

### DIFF
--- a/api/v1/dataCitations/PKPDataCitationController.php
+++ b/api/v1/dataCitations/PKPDataCitationController.php
@@ -12,7 +12,7 @@
  * @ingroup api_v1_data_citations
  *
  * @brief Controller class to handle API requests for data citation operations.
- * 
+ *
  */
 
 namespace pkp\api\v1\dataCitations;
@@ -23,9 +23,9 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
-use PKP\dataCitation\DataCitation;
 use PKP\core\PKPBaseController;
 use PKP\core\PKPRequest;
+use PKP\dataCitation\DataCitation;
 use PKP\plugins\Hook;
 use PKP\security\authorization\ContextAccessPolicy;
 use PKP\security\authorization\PublicationAccessPolicy;
@@ -147,7 +147,7 @@ class PKPDataCitationController extends PKPBaseController
     public function getMany(Request $illuminateRequest): JsonResponse
     {
         $publication = $this->getAuthorizedContextObject(Application::ASSOC_TYPE_PUBLICATION);
-        $dataCitations = DataCitation::withPublicationId($publication->getId())->orderBySeq();
+        $dataCitations = DataCitation::withPublicationIds([$publication->getId()])->orderBySeq();
 
         Hook::run('API::dataCitations::params', [$dataCitations, $illuminateRequest]);
 
@@ -221,7 +221,8 @@ class PKPDataCitationController extends PKPBaseController
         $dataCitation = DataCitation::find($dataCitation->id);
 
         return response()->json(
-            Repo::dataCitation()->getSchemaMap()->map($dataCitation), Response::HTTP_OK
+            Repo::dataCitation()->getSchemaMap()->map($dataCitation),
+            Response::HTTP_OK
         );
     }
 
@@ -248,7 +249,8 @@ class PKPDataCitationController extends PKPBaseController
         $dataCitation->delete();
 
         return response()->json(
-            Repo::dataCitation()->getSchemaMap()->map($dataCitation), Response::HTTP_OK
+            Repo::dataCitation()->getSchemaMap()->map($dataCitation),
+            Response::HTTP_OK
         );
     }
 

--- a/api/v1/orcid/OrcidController.php
+++ b/api/v1/orcid/OrcidController.php
@@ -84,15 +84,15 @@ class OrcidController extends PKPBaseController
         }
 
         $author = $validate['author']; /** @var Author $author */
-        try {
-            $author->setData('orcidVerificationRequested', true);
-            Repo::author()->edit($author, ['orcidVerificationRequested']);
-            dispatch(new SendAuthorMail($author, $context, true));
-        } catch (\Exception $exception) {
-            return response()->json([
-                'error' => __('api.orcid.404.contextRequired'),
-            ], Response::HTTP_NOT_FOUND);
-        }
+        //        try {
+        $author->setData('orcidVerificationRequested', true);
+        Repo::author()->edit($author, ['orcidVerificationRequested']);
+        dispatch(new SendAuthorMail($author, $context, true));
+        /*        } catch (\Exception $exception) {
+                    return response()->json([
+                        'error' => __('api.orcid.404.contextRequired'),
+                    ], Response::HTTP_NOT_FOUND);
+                }*/
 
         return response()->json([], Response::HTTP_OK);
     }

--- a/classes/affiliation/Affiliation.php
+++ b/classes/affiliation/Affiliation.php
@@ -18,7 +18,6 @@
 
 namespace PKP\affiliation;
 
-use APP\facades\Repo;
 use PKP\core\DataObject;
 use PKP\i18n\LocaleConversion;
 use PKP\ror\Ror;
@@ -31,7 +30,7 @@ class Affiliation extends DataObject
      */
     public function getDefaultLocale(): ?string
     {
-        return Repo::author()->get($this->getAuthorId())->getDefaultLocale();
+        return $this->getData('submissionLocale');
     }
 
     /**

--- a/classes/affiliation/Collector.php
+++ b/classes/affiliation/Collector.php
@@ -97,7 +97,10 @@ class Collector implements CollectorInterface
     public function getQueryBuilder(): Builder
     {
         $qb = DB::table($this->dao->table . ' as a')
-            ->select('a.*');
+            ->select(['a.*', 's.locale AS submission_locale'])
+            ->join('authors AS au', 'a.author_id', 'au.author_id')
+            ->join('publications as p', 'au.publication_id', '=', 'p.publication_id')
+            ->join('submissions as s', 'p.submission_id', '=', 's.submission_id');
 
         if (!is_null($this->count)) {
             $qb->limit($this->count);

--- a/classes/affiliation/Collector.php
+++ b/classes/affiliation/Collector.php
@@ -32,7 +32,7 @@ class Collector implements CollectorInterface
 
     public ?int $offset = null;
 
-    public ?int $authorId = null;
+    public ?array $authorIds = null;
 
     public function __construct(DAO $dao)
     {
@@ -68,9 +68,9 @@ class Collector implements CollectorInterface
     /**
      * Filter by single author
      */
-    public function filterByAuthorId(?int $authorId): self
+    public function filterByAuthorIds(?array $authorIds): self
     {
-        $this->authorId = $authorId;
+        $this->authorIds = $authorIds;
         return $this;
     }
 
@@ -107,8 +107,8 @@ class Collector implements CollectorInterface
             $qb->offset($this->offset);
         }
 
-        if (!is_null($this->authorId)) {
-            $qb->where('a.author_id', '=', $this->authorId);
+        if (!is_null($this->authorIds)) {
+            $qb->whereIn('a.author_id', $this->authorIds);
         }
 
         // Add app-specific query statements

--- a/classes/affiliation/DAO.php
+++ b/classes/affiliation/DAO.php
@@ -102,24 +102,49 @@ class DAO extends EntityDAO
     public function getMany(Collector $query): LazyCollection
     {
         return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
+            $queryBuilder = $query->getQueryBuilder();
+            $settings = $rorObjects = null;
+
+            $rows = $queryBuilder->get();
+            $authorAffiliationIds = $rows->pluck('author_affiliation_id')->toArray();
 
             foreach ($rows as $row) {
-                yield $row->author_affiliation_id => $this->fromRow($row);
+                yield $row->author_affiliation_id => $this->fromRow(
+                    $row,
+                    function (object $row, object $schema, Affiliation $affiliation) use ($queryBuilder, $authorAffiliationIds, &$settings, &$rorObjects): void {
+                        $settings ??= DB::table('author_affiliation_settings')
+                            ->whereIn('author_affiliation_id', $authorAffiliationIds)
+                            ->get()
+                            ->groupBy('author_affiliation_id');
+
+                        $rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($authorAffiliationIds)
+                            ->getMany()
+                            ->collect()
+                            ->groupBy(fn ($rorObject) => $rorObject->getRor());
+
+                        $settings->get($row->author_affiliation_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $affiliation, $schema));
+
+                        $affiliation->setData('rorObject', $rorObjects->get($row->ror)?->first());
+                    }
+                );
             }
         });
     }
 
-    /** @copydoc EntityDAO::fromRow() */
-    public function fromRow(object $row): Affiliation
+    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
     {
-        $affiliation = parent::fromRow($row);
+        parent::individualPopulator($row, $schema, $object);
+
         if (!empty($affiliation->getRor())) {
             $affiliation->setData('rorObject', Repo::ror()->getCollector()->filterByRor($affiliation->getRor())->getMany()->first());
         }
-        return $affiliation;
+    }
+
+    /** @copydoc EntityDAO::fromRow() */
+    public function fromRow(object $row, ?callable $populator = null): Affiliation
+    {
+        return parent::fromRow($row, $populator);
     }
 
     /** @copydoc EntityDAO::insert() */

--- a/classes/affiliation/DAO.php
+++ b/classes/affiliation/DAO.php
@@ -22,8 +22,8 @@ use APP\facades\Repo;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 use PKP\services\PKPSchemaService;
 
@@ -94,56 +94,21 @@ class DAO extends EntityDAO
             ->pluck('a.' . $this->primaryKeyColumn);
     }
 
-    /**
-     * Get a collection of affiliations matching the configured query.
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
+    public function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
     {
-        return LazyCollection::make(function () use ($query) {
-            $queryBuilder = $query->getQueryBuilder();
+        parent::populate($row, $schema, $object, $ids, $cache);
 
-            $rows = $queryBuilder->get();
-            $authorAffiliationIds = $rows->pluck('author_affiliation_id')->toArray();
-
-            $cache = (object) [];
-
-            foreach ($rows as $row) {
-                yield $row->author_affiliation_id => $this->fromRow(
-                    $row,
-                    function (object $row, object $schema, Affiliation $affiliation) use ($authorAffiliationIds, $cache): void {
-                        $cache->settings ??= DB::table('author_affiliation_settings')
-                            ->whereIn('author_affiliation_id', $authorAffiliationIds)
-                            ->get()
-                            ->groupBy('author_affiliation_id');
-                        $cache->settings->get($row->author_affiliation_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $affiliation, $schema));
-
-                        $cache->rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($authorAffiliationIds)
-                            ->getMany()
-                            ->collect()
-                            ->groupBy(fn ($rorObject) => $rorObject->getRor());
-                        $affiliation->setData('rorObject', $cache->rorObjects->get($row->ror)?->first());
-                    }
-                );
-            }
-        });
-    }
-
-    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
-    {
-        parent::individualPopulator($row, $schema, $object);
-
-        if (!empty($affiliation->getRor())) {
-            $affiliation->setData('rorObject', Repo::ror()->getCollector()->filterByRor($affiliation->getRor())->getMany()->first());
-        }
+        $cache->rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($ids)
+            ->getMany()
+            ->collect()
+            ->groupBy(fn ($rorObject) => $rorObject->getRor());
+        $object->setData('rorObject', $cache->rorObjects->get($row->ror)?->first());
     }
 
     /** @copydoc EntityDAO::fromRow() */
-    public function fromRow(object $row, ?callable $populator = null): Affiliation
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Affiliation
     {
-        return parent::fromRow($row, $populator);
+        return parent::fromRow($row, $ids, $cache, $query);
     }
 
     /** @copydoc EntityDAO::insert() */

--- a/classes/affiliation/DAO.php
+++ b/classes/affiliation/DAO.php
@@ -82,6 +82,27 @@ class DAO extends EntityDAO
     }
 
     /**
+     * Get an affiliation.
+     *
+     * Optionally, pass the author ID to only get an affiliation
+     * if it exists and is assigned to that author.
+     */
+    public function get(int $id, ?int $authorId = null): ?Author
+    {
+        // This is overridden due to the need to include submission_locale
+        // to the fromRow function
+        $row = DB::table('author_affiliations as a')
+            ->join('authors as au', 'a.author_id', '=', 'au.author_id')
+            ->join('publications as p', 'a.publication_id', '=', 'p.publication_id')
+            ->join('submissions as s', 'p.submission_id', '=', 's.submission_id')
+            ->where('a.affiliation_id', '=', $id)
+            ->when($authorId !== null, fn (Builder $query) => $query->where('a.author_id', '=', $authorId))
+            ->select(['a.*', 's.locale AS submission_locale'])
+            ->first();
+        return $row ? $this->fromRow($row, [$id], (object) []) : null;
+    }
+
+    /**
      * Get a list of ids matching the configured query
      *
      * @return Collection<int,int>
@@ -98,6 +119,9 @@ class DAO extends EntityDAO
     public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Affiliation
     {
         $affiliation = parent::fromRow($row, $ids, $cache, $query);
+
+        // Set the primary locale from the submission
+        $affiliation->setData('submissionLocale', $row->submission_locale);
 
         $cache->rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($ids)
             ->getMany()

--- a/classes/affiliation/DAO.php
+++ b/classes/affiliation/DAO.php
@@ -94,21 +94,18 @@ class DAO extends EntityDAO
             ->pluck('a.' . $this->primaryKeyColumn);
     }
 
-    public function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
+    /** @copydoc EntityDAO::fromRow() */
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Affiliation
     {
-        parent::populate($row, $schema, $object, $ids, $cache);
+        $affiliation = parent::fromRow($row, $ids, $cache, $query);
 
         $cache->rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($ids)
             ->getMany()
             ->collect()
             ->groupBy(fn ($rorObject) => $rorObject->getRor());
-        $object->setData('rorObject', $cache->rorObjects->get($row->ror)?->first());
-    }
+        $affiliation->setData('rorObject', $cache->rorObjects->get($row->ror)?->first());
 
-    /** @copydoc EntityDAO::fromRow() */
-    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Affiliation
-    {
-        return parent::fromRow($row, $ids, $cache, $query);
+        return $affiliation;
     }
 
     /** @copydoc EntityDAO::insert() */

--- a/classes/affiliation/DAO.php
+++ b/classes/affiliation/DAO.php
@@ -111,19 +111,18 @@ class DAO extends EntityDAO
             foreach ($rows as $row) {
                 yield $row->author_affiliation_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, Affiliation $affiliation) use ($queryBuilder, $authorAffiliationIds, &$settings, &$rorObjects): void {
+                    function (object $row, object $schema, Affiliation $affiliation) use ($authorAffiliationIds, &$settings, &$rorObjects): void {
                         $settings ??= DB::table('author_affiliation_settings')
                             ->whereIn('author_affiliation_id', $authorAffiliationIds)
                             ->get()
                             ->groupBy('author_affiliation_id');
+                        $settings->get($row->author_affiliation_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $affiliation, $schema));
 
                         $rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($authorAffiliationIds)
                             ->getMany()
                             ->collect()
                             ->groupBy(fn ($rorObject) => $rorObject->getRor());
-
-                        $settings->get($row->author_affiliation_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $affiliation, $schema));
 
                         $affiliation->setData('rorObject', $rorObjects->get($row->ror)?->first());
                     }

--- a/classes/affiliation/DAO.php
+++ b/classes/affiliation/DAO.php
@@ -103,28 +103,28 @@ class DAO extends EntityDAO
     {
         return LazyCollection::make(function () use ($query) {
             $queryBuilder = $query->getQueryBuilder();
-            $settings = $rorObjects = null;
 
             $rows = $queryBuilder->get();
             $authorAffiliationIds = $rows->pluck('author_affiliation_id')->toArray();
 
+            $cache = (object) [];
+
             foreach ($rows as $row) {
                 yield $row->author_affiliation_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, Affiliation $affiliation) use ($authorAffiliationIds, &$settings, &$rorObjects): void {
-                        $settings ??= DB::table('author_affiliation_settings')
+                    function (object $row, object $schema, Affiliation $affiliation) use ($authorAffiliationIds, $cache): void {
+                        $cache->settings ??= DB::table('author_affiliation_settings')
                             ->whereIn('author_affiliation_id', $authorAffiliationIds)
                             ->get()
                             ->groupBy('author_affiliation_id');
-                        $settings->get($row->author_affiliation_id)
+                        $cache->settings->get($row->author_affiliation_id)
                             ?->each(fn ($row) => $this->populateSetting($row, $affiliation, $schema));
 
-                        $rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($authorAffiliationIds)
+                        $cache->rorObjects ??= Repo::ror()->getCollector()->filterByAuthorAffiliationIds($authorAffiliationIds)
                             ->getMany()
                             ->collect()
                             ->groupBy(fn ($rorObject) => $rorObject->getRor());
-
-                        $affiliation->setData('rorObject', $rorObjects->get($row->ror)?->first());
+                        $affiliation->setData('rorObject', $cache->rorObjects->get($row->ror)?->first());
                     }
                 );
             }

--- a/classes/affiliation/Repository.php
+++ b/classes/affiliation/Repository.php
@@ -189,14 +189,14 @@ class Repository
     }
 
     /**
-     * Get all affiliations for a given author.
+     * Get all affiliations for the given author IDs.
      *
      * @return array<Affiliation>
      */
-    public function getByAuthorId(int $authorId): array
+    public function getByAuthorIds(array $authorIds): array
     {
         return $this->getCollector()
-            ->filterByAuthorId($authorId)
+            ->filterByAuthorIds($authorIds)
             ->getMany()
             ->all();
     }
@@ -217,7 +217,7 @@ class Repository
 
         // deleted affiliations not in param $affiliations
         // do this before insert/update, otherwise inserted will be deleted
-        $currentAffiliations = $this->getByAuthorId($authorId);
+        $currentAffiliations = $this->getByAuthorIds([$authorId]);
         foreach ($currentAffiliations as $currentAffiliation) {
             $rowFound = false;
             $currentAffiliationId = $currentAffiliation->getId();

--- a/classes/announcement/DAO.php
+++ b/classes/announcement/DAO.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/announcement/DAO.php
  *
@@ -15,7 +16,6 @@ namespace PKP\announcement;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 
 /**
@@ -96,23 +96,6 @@ class DAO extends EntityDAO
         return $query
             ->getQueryBuilder()
             ->pluck('a.' . $this->primaryKeyColumn);
-    }
-
-    /**
-     * Get a collection of announcements matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-            foreach ($rows as $row) {
-                yield $row->announcement_id => $this->fromRow($row);
-            }
-        });
     }
 
     /**

--- a/classes/author/Author.php
+++ b/classes/author/Author.php
@@ -18,10 +18,9 @@
 
 namespace PKP\author;
 
-use APP\facades\Repo;
+use PKP\affiliation\Affiliation;
 use PKP\author\contributorRole\ContributorRole;
 use PKP\author\contributorRole\ContributorType;
-use PKP\affiliation\Affiliation;
 use PKP\facades\Locale;
 use PKP\identity\Identity;
 
@@ -222,10 +221,8 @@ class Author extends Identity
 
     /**
      * Get affiliations (position, institution, etc.).
-     *
-     * @return array<Affiliation>
      */
-    public function getAffiliations(): array
+    public function getAffiliations(): iterable
     {
         return $this->getData('affiliations') ?? [];
     }
@@ -235,7 +232,7 @@ class Author extends Identity
      *
      * @param array<Affiliation>
      */
-    public function setAffiliations(?array $affiliations): void
+    public function setAffiliations(?iterable $affiliations): void
     {
         $this->setData('affiliations', $affiliations);
     }
@@ -253,7 +250,7 @@ class Author extends Identity
      */
     public function getLocalizedAffiliationNames(?string $preferredLocale = null): array
     {
-        return array_map(fn ($affiliation) => $affiliation->getLocalizedName($preferredLocale), $this->getAffiliations());
+        return array_map(fn ($affiliation) => $affiliation->getLocalizedName($preferredLocale), iterator_to_array($this->getAffiliations()));
     }
 
     /**
@@ -350,6 +347,7 @@ class Author extends Identity
 
     /**
      * Set contributor roles using ContributorRole-objects.
+     *
      * @param array<ContributorRole>
      */
     public function setContributorRoles(array $roles): void

--- a/classes/author/Author.php
+++ b/classes/author/Author.php
@@ -291,15 +291,15 @@ class Author extends Identity
     /**
      * Get contributor credit roles and degrees.
      */
-    public function getCreditRoles(): array
+    public function getCreditRoles(): iterable
     {
-        return $this->getData('creditRoles') ?? [];
+        return $this->getData('creditRoles') ?? collect();
     }
 
     /**
      * Set contributor credit roles and degrees.
      */
-    public function setCreditRoles(?array $creditRoles): void
+    public function setCreditRoles(?iterable $creditRoles): void
     {
         $this->setData('creditRoles', $creditRoles);
     }
@@ -307,9 +307,9 @@ class Author extends Identity
     /**
      * Get contributor roles as ContributorRole[].
      */
-    public function getContributorRoles(): array
+    public function getContributorRoles(): iterable
     {
-        return $this->getData('contributorRoles') ?? [];
+        return $this->getData('contributorRoles') ?? collect();
     }
 
     /**
@@ -350,7 +350,7 @@ class Author extends Identity
      *
      * @param array<ContributorRole>
      */
-    public function setContributorRoles(array $roles): void
+    public function setContributorRoles(iterable $roles): void
     {
         $this->setData('contributorRoles', $roles);
     }

--- a/classes/author/Collector.php
+++ b/classes/author/Collector.php
@@ -32,9 +32,6 @@ class Collector implements CollectorInterface
     /** @var string The default orderBy value for authors collector */
     public $orderBy = self::ORDERBY_SEQUENCE;
 
-    /** @var DAO */
-    public $dao;
-
     /** @var int[]|null */
     public $contextIds = null;
 
@@ -56,9 +53,10 @@ class Collector implements CollectorInterface
 
     public ?bool $includeInBrowse = null;
 
-    public function __construct(DAO $dao)
+    public ?array $authorIds = null;
+
+    public function __construct(public DAO $dao)
     {
-        $this->dao = $dao;
     }
 
     public function getCount(): int
@@ -99,6 +97,15 @@ class Collector implements CollectorInterface
     public function filterByPublicationIds(?array $publicationIds): self
     {
         $this->publicationIds = $publicationIds;
+        return $this;
+    }
+
+    /**
+     * Filter by author IDs
+     */
+    public function filterByAuthorIds(?array $authorIds): self
+    {
+        $this->authorIds = $authorIds;
         return $this;
     }
 
@@ -173,54 +180,37 @@ class Collector implements CollectorInterface
         $q = DB::table('authors as a')
             ->select(['a.*', 's.locale AS submission_locale'])
             ->join('publications as p', 'a.publication_id', '=', 'p.publication_id')
-            ->join('submissions as s', 'p.submission_id', '=', 's.submission_id');
-
-        if (isset($this->contextIds)) {
-            $q->whereIn('s.context_id', $this->contextIds);
-        }
-
-        $q->when($this->familyName !== null, function (Builder $q) {
-            $q->whereIn('a.author_id', function (Builder $q) {
-                $q->select('author_id')
-                    ->from($this->dao->settingsTable)
-                    ->where('setting_name', '=', 'familyName')
-                    ->where('setting_value', $this->familyName);
-            });
-        });
-
-        $q->when($this->givenName !== null, function (Builder $q) {
-            $q->whereIn('a.author_id', function (Builder $q) {
-                $q->select('author_id')
-                    ->from($this->dao->settingsTable)
-                    ->where('setting_name', '=', 'givenName')
-                    ->where('setting_value', $this->givenName);
-            });
-        });
-
-        if (isset($this->publicationIds)) {
-            $q->whereIn('a.publication_id', $this->publicationIds);
-        }
-
-        $q->when($this->country !== null, function (Builder $q) {
-            $q->whereIn('a.author_id', function (Builder $q) {
-                $q->select('author_id')
-                    ->from($this->dao->settingsTable)
-                    ->where('setting_name', '=', 'country')
-                    ->where('setting_value', $this->country);
-            });
-        });
-
-        if ($this->includeInBrowse) {
-            $q->where('a.include_in_browse', $this->includeInBrowse);
-        }
-
-        if (isset($this->count)) {
-            $q->limit($this->count);
-        }
-
-        if (isset($this->offset)) {
-            $q->offset($this->offset);
-        }
+            ->join('submissions as s', 'p.submission_id', '=', 's.submission_id')
+            ->when($this->contextIds !== null, fn (Builder $q) => $q->whereIn('s.context_id', $this->contextIds))
+            ->when($this->familyName !== null, function (Builder $q) {
+                $q->whereIn('a.author_id', function (Builder $q) {
+                    $q->select('author_id')
+                        ->from($this->dao->settingsTable)
+                        ->where('setting_name', '=', 'familyName')
+                        ->where('setting_value', $this->familyName);
+                });
+            })
+            ->when($this->givenName !== null, function (Builder $q) {
+                $q->whereIn('a.author_id', function (Builder $q) {
+                    $q->select('author_id')
+                        ->from($this->dao->settingsTable)
+                        ->where('setting_name', '=', 'givenName')
+                        ->where('setting_value', $this->givenName);
+                });
+            })
+            ->when($this->publicationIds !== null, fn (Builder $q) => $q->whereIn('a.publication_id', $this->publicationIds))
+            ->when($this->authorIds !== null, fn (Builder $q) => $q->whereIn('a.author_id', $this->authorIds))
+            ->when($this->country !== null, function (Builder $q) {
+                $q->whereIn('a.author_id', function (Builder $q) {
+                    $q->select('author_id')
+                        ->from($this->dao->settingsTable)
+                        ->where('setting_name', '=', 'country')
+                        ->where('setting_value', $this->country);
+                });
+            })
+            ->when($this->includeInBrowse !== null, fn (Builder $q) => $q->where('a.include_in_browse', $this->includeInBrowse))
+            ->when($this->count !== null, fn (Builder $q) => $q->limit($this->count))
+            ->when($this->offset !== null, fn (Builder $q) => $q->offset($this->offset));
 
         switch ($this->orderBy) {
             case self::ORDERBY_SEQUENCE:

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\facades\Repo;
 use PKP\services\PKPSchemaService;
 
@@ -89,7 +90,7 @@ class DAO extends EntityDAO
             ->when($publicationId !== null, fn (Builder $query) => $query->where('a.publication_id', '=', $publicationId))
             ->select(['a.*', 's.locale AS submission_locale'])
             ->first();
-        return $row ? $this->fromRow($row) : null;
+        return $row ? $this->fromRow($row, [$id], (object) []) : null;
     }
 
     /**
@@ -129,52 +130,21 @@ class DAO extends EntityDAO
             ->pluck('a.' . $this->primaryKeyColumn);
     }
 
-    protected function batchPopulator(object $row, object $schema, Author $author, array $authorIds, object $cache)
+    protected function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
     {
-        $cache->settings ??= DB::table('author_settings')
-            ->whereIn('author_id', $authorIds)
-            ->get()
-            ->groupBy('author_id');
-        $cache->settings->get($row->author_id)
-            ?->each(fn ($row) => $this->populateSetting($row, $author, $schema));
+        parent::populate($row, $schema, $object, $ids, $cache);
 
-        $author->setAffiliations(LazyCollection::make(function () use ($row, $authorIds, $cache) {
-            $cache->affiliations ??= collect(Repo::affiliation()->getByAuthorIds($authorIds))
+        $object->setAffiliations(LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->affiliations ??= collect(Repo::affiliation()->getByAuthorIds($ids))
                 ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
             yield from $cache->affiliations->get($row->author_id) ?? collect();
         }));
 
-        $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($authorIds);
-        $author->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? []);
+        $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($ids);
+        $object->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? []);
 
-        $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($authorIds);
-        $author->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? []);
-    }
-
-    /**
-     * Get a collection of publications matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $queryBuilder = $query->getQueryBuilder();
-
-            $rows = $queryBuilder->get();
-            $authorIds = $rows->pluck('author_id')->all();
-
-            $cache = (object) [];
-
-            foreach ($rows as $row) {
-                yield $row->author_id => $this->fromRow(
-                    $row,
-                    function (object $row, object $schema, Author $author) use ($authorIds, $cache): void {
-                        $this->batchPopulator($row, $schema, $author, $authorIds, $cache);
-                    }
-                );
-            }
-        });
+        $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($ids);
+        $object->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? []);
     }
 
     protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
@@ -185,9 +155,9 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): Author
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Author
     {
-        $author = parent::fromRow($row, $populator);
+        $author = parent::fromRow($row, $ids, $cache, $query);
 
         // Set the primary locale from the submission
         $author->setData('submissionLocale', $row->submission_locale);

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -130,28 +130,6 @@ class DAO extends EntityDAO
             ->pluck('a.' . $this->primaryKeyColumn);
     }
 
-    protected function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
-    {
-        parent::populate($row, $schema, $object, $ids, $cache);
-
-        $object->setAffiliations(LazyCollection::make(function () use ($row, $ids, $cache) {
-            $cache->affiliations ??= collect(Repo::affiliation()->getByAuthorIds($ids))
-                ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
-            yield from $cache->affiliations->get($row->author_id) ?? collect();
-        }));
-
-        $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($ids);
-        $object->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? []);
-
-        $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($ids);
-        $object->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? []);
-    }
-
-    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
-    {
-        $this->batchPopulator($row, $schema, $object, [$row->author_id], (object) []);
-    }
-
     /**
      * @copydoc EntityDAO::fromRow()
      */
@@ -161,6 +139,18 @@ class DAO extends EntityDAO
 
         // Set the primary locale from the submission
         $author->setData('submissionLocale', $row->submission_locale);
+
+        $author->setAffiliations(LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->affiliations ??= collect(Repo::affiliation()->getByAuthorIds($ids))
+                ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
+            yield from $cache->affiliations->get($row->author_id) ?? collect();
+        }));
+
+        $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($ids);
+        $author->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? []);
+
+        $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($ids);
+        $author->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? []);
 
         return $author;
     }

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -129,6 +129,28 @@ class DAO extends EntityDAO
             ->pluck('a.' . $this->primaryKeyColumn);
     }
 
+    protected function batchPopulator(object $row, object $schema, Author $author, array $authorIds, object $cache)
+    {
+        $cache->settings ??= DB::table('author_settings')
+            ->whereIn('author_id', $authorIds)
+            ->get()
+            ->groupBy('author_id');
+        $cache->settings->get($row->author_id)
+            ?->each(fn ($row) => $this->populateSetting($row, $author, $schema));
+
+        $author->setAffiliations(LazyCollection::make(function () use ($row, $authorIds, $cache) {
+            $cache->affiliations ??= collect(Repo::affiliation()->getByAuthorIds($authorIds))
+                ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
+            yield from $cache->affiliations->get($row->author_id) ?? collect();
+        }));
+
+        $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($authorIds);
+        $author->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? []);
+
+        $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($authorIds);
+        $author->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? []);
+    }
+
     /**
      * Get a collection of publications matching the configured query
      *
@@ -138,33 +160,17 @@ class DAO extends EntityDAO
     {
         return LazyCollection::make(function () use ($query) {
             $queryBuilder = $query->getQueryBuilder();
-            $settings = $affiliations = $creditRoles = $contributorRoles = null;
 
             $rows = $queryBuilder->get();
             $authorIds = $rows->pluck('author_id')->all();
 
+            $cache = (object) [];
+
             foreach ($rows as $row) {
                 yield $row->author_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, Author $author) use ($authorIds, &$settings, &$affiliations, &$creditRoles, &$contributorRoles): void {
-                        $settings ??= DB::table('author_settings')
-                            ->whereIn('author_id', $authorIds)
-                            ->get()
-                            ->groupBy('author_id');
-                        $settings->get($row->author_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $author, $schema));
-
-                        $author->setAffiliations(LazyCollection::make(function () use ($row, $authorIds, &$affiliations) {
-                            $affiliations ??= collect(Repo::affiliation()->getByAuthorIds($authorIds))
-                                ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
-                            yield from $affiliations->get($row->author_id) ?? collect();
-                        }));
-
-                        $creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($authorIds);
-                        $author->setCreditRoles($creditRoles->get($row->author_id)?->toArray() ?? []);
-
-                        $contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($authorIds);
-                        $author->setContributorRoles($contributorRoles->get($row->author_id)?->all() ?? []);
+                    function (object $row, object $schema, Author $author) use ($authorIds, $cache): void {
+                        $this->batchPopulator($row, $schema, $author, $authorIds, $cache);
                     }
                 );
             }
@@ -173,11 +179,7 @@ class DAO extends EntityDAO
 
     protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
     {
-        parent::individualPopulator($row, $schema, $object);
-
-        $object->setAffiliations(Repo::affiliation()->getByAuthorIds([$object->getId()]));
-        $object->setCreditRoles(Repo::creditContributorRole()->getCreditRolesByContributorId($object->getId()));
-        $object->setContributorRoles(Repo::creditContributorRole()->getContributorRolesByContributorId($object->getId()));
+        $this->batchPopulator($row, $schema, $object, [$row->author_id], (object) []);
     }
 
     /**

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -146,7 +146,7 @@ class DAO extends EntityDAO
             foreach ($rows as $row) {
                 yield $row->author_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, Author $author) use ($queryBuilder, $authorIds, &$settings, &$affiliations, &$creditRoles, &$contributorRoles): void {
+                    function (object $row, object $schema, Author $author) use ($authorIds, &$settings, &$affiliations, &$creditRoles, &$contributorRoles): void {
                         $settings ??= DB::table('author_settings')
                             ->whereIn('author_id', $authorIds)
                             ->get()

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -147,10 +147,10 @@ class DAO extends EntityDAO
         }));
 
         $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($ids);
-        $author->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? []);
+        $author->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? collect());
 
         $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($ids);
-        $author->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? []);
+        $author->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? collect());
 
         return $author;
     }

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -142,15 +142,20 @@ class DAO extends EntityDAO
 
         $author->setAffiliations(LazyCollection::make(function () use ($row, $ids, $cache) {
             $cache->affiliations ??= collect(Repo::affiliation()->getByAuthorIds($ids))
+                ->collect()
                 ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
-            yield from $cache->affiliations->get($row->author_id) ?? collect();
+            yield from $cache->affiliations->get($row->author_id) ?? [];
         }));
 
-        $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($ids);
-        $author->setCreditRoles($cache->creditRoles->get($row->author_id)?->toArray() ?? collect());
+        $author->setCreditRoles(LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($ids);
+            yield from $cache->creditRoles->get($row->author_id) ?? [];
+        }));
 
-        $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($ids);
-        $author->setContributorRoles($cache->contributorRoles->get($row->author_id)?->all() ?? collect());
+        $author->setContributorRoles(LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($ids);
+            yield from $cache->contributorRoles->get($row->author_id) ?? [];
+        }));
 
         return $author;
     }

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -137,32 +137,56 @@ class DAO extends EntityDAO
     public function getMany(Collector $query): LazyCollection
     {
         return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
+            $queryBuilder = $query->getQueryBuilder();
+            $settings = $affiliations = $creditRoles = $contributorRoles = null;
+
+            $rows = $queryBuilder->get();
+            $authorIds = $rows->pluck('author_id')->all();
+
             foreach ($rows as $row) {
-                yield $row->author_id => $this->fromRow($row);
+                yield $row->author_id => $this->fromRow(
+                    $row,
+                    function (object $row, object $schema, Author $author) use ($queryBuilder, $authorIds, &$settings, &$affiliations, &$creditRoles, &$contributorRoles): void {
+                        $settings ??= DB::table('author_settings')
+                            ->whereIn('author_id', $authorIds)
+                            ->get()
+                            ->groupBy('author_id');
+                        $settings->get($row->author_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $author, $schema));
+
+                        $affiliations ??= collect(Repo::affiliation()->getByAuthorIds($authorIds))
+                            ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
+                        $author->setAffiliations($affiliations->get($row->author_id)?->toArray() ?? []);
+
+                        $creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($authorIds);
+                        $author->setCreditRoles($creditRoles->get($row->author_id)?->toArray() ?? []);
+
+                        $contributorRoles ??= Repo::creditContributorRole()->getContributorRolesGroupedByContributorIds($authorIds);
+                        $author->setContributorRoles($contributorRoles->get($row->author_id)?->all() ?? []);
+                    }
+                );
             }
         });
+    }
+
+    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
+    {
+        parent::individualPopulator($row, $schema, $object);
+
+        $object->setAffiliations(Repo::affiliation()->getByAuthorIds([$object->getId()]));
+        $object->setCreditRoles(Repo::creditContributorRole()->getCreditRolesByContributorId($object->getId()));
+        $object->setContributorRoles(Repo::creditContributorRole()->getContributorRolesByContributorId($object->getId()));
     }
 
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): Author
+    public function fromRow(object $row, ?callable $populator = null): Author
     {
-        $author = parent::fromRow($row);
+        $author = parent::fromRow($row, $populator);
 
         // Set the primary locale from the submission
         $author->setData('submissionLocale', $row->submission_locale);
-
-        $author->setAffiliations(
-            Repo::affiliation()->getByAuthorId($author->getId())
-        );
-
-        $author->setCreditRoles(Repo::creditContributorRole()->getCreditRolesByContributorId($author->getId()));
-
-        $author->setContributorRoles(Repo::creditContributorRole()->getContributorRolesByContributorId($author->getId()));
 
         return $author;
     }

--- a/classes/author/DAO.php
+++ b/classes/author/DAO.php
@@ -154,9 +154,11 @@ class DAO extends EntityDAO
                         $settings->get($row->author_id)
                             ?->each(fn ($row) => $this->populateSetting($row, $author, $schema));
 
-                        $affiliations ??= collect(Repo::affiliation()->getByAuthorIds($authorIds))
-                            ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
-                        $author->setAffiliations($affiliations->get($row->author_id)?->toArray() ?? []);
+                        $author->setAffiliations(LazyCollection::make(function () use ($row, $authorIds, &$affiliations) {
+                            $affiliations ??= collect(Repo::affiliation()->getByAuthorIds($authorIds))
+                                ->groupBy(fn ($affiliation) => $affiliation->getData('authorId'));
+                            yield from $affiliations->get($row->author_id) ?? collect();
+                        }));
 
                         $creditRoles ??= Repo::creditContributorRole()->getCreditRolesGroupedByContributorIds($authorIds);
                         $author->setCreditRoles($creditRoles->get($row->author_id)?->toArray() ?? []);

--- a/classes/author/creditContributorRole/Repository.php
+++ b/classes/author/creditContributorRole/Repository.php
@@ -22,7 +22,7 @@ use PKP\author\creditRole\CreditRole;
 class Repository
 {
     /** Add contributor roles for a contributor */
-    public function addContributorRoles(array $contributorRoles, int $contributorId): void
+    public function addContributorRoles(iterable $contributorRoles, int $contributorId): void
     {
         $roleIds = collect($contributorRoles)
             ->map(fn (ContributorRole $role) => $role->contributorRoleId);
@@ -47,7 +47,7 @@ class Repository
     }
 
     /** Add CRediT roles for a contributor */
-    public function addCreditRoles(array $newRoles, int $contributorId): void
+    public function addCreditRoles(iterable $newRoles, int $contributorId): void
     {
         $identifiersWithIds = CreditRole::withCreditRoleIdentifiers(Arr::pluck($newRoles, 'role'))
             ->get()

--- a/classes/author/creditContributorRole/Repository.php
+++ b/classes/author/creditContributorRole/Repository.php
@@ -95,6 +95,7 @@ class Repository
             ->whereIn('credit_contributor_roles.contributor_id', $contributorIds)
             ->orderBy('contributor_roles.contributor_role_id')
             ->get()
+            ->collect()
             ->groupBy('contributor_id');
     }
 
@@ -121,6 +122,7 @@ class Repository
             ->withCreditRoles()
             ->select(['credit_role_identifier as role', 'credit_degree as degree', 'contributor_id'])
             ->get()
+            ->collect()
             ->groupBy('contributor_id');
     }
 }

--- a/classes/author/creditContributorRole/Repository.php
+++ b/classes/author/creditContributorRole/Repository.php
@@ -15,6 +15,7 @@
 namespace PKP\author\creditContributorRole;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use PKP\author\contributorRole\ContributorRole;
 use PKP\author\creditRole\CreditRole;
 
@@ -85,6 +86,19 @@ class Repository
     }
 
     /**
+     * Get all contributor's contributor roles as objects.
+     */
+    public function getContributorRolesGroupedByContributorIds(array $contributorIds): Collection
+    {
+        return ContributorRole::query()
+            ->join('credit_contributor_roles', 'contributor_roles.contributor_role_id', 'credit_contributor_roles.contributor_role_id')
+            ->whereIn('credit_contributor_roles.contributor_id', $contributorIds)
+            ->orderBy('contributor_roles.contributor_role_id')
+            ->get()
+            ->groupBy('contributor_id');
+    }
+
+    /**
      * Get all contributor's credit roles.
      */
     public function getCreditRolesByContributorId(int $contributorId): array
@@ -95,5 +109,18 @@ class Repository
             ->select(['credit_role_identifier as role', 'credit_degree as degree'])
             ->get()
             ->toArray();
+    }
+
+    /**
+     * Get all contributor's credit roles.
+     */
+    public function getCreditRolesGroupedByContributorIds(array $contributorIds): Collection
+    {
+        return CreditContributorRole::query()
+            ->whereIn('contributor_id', $contributorIds)
+            ->withCreditRoles()
+            ->select(['credit_role_identifier as role', 'credit_degree as degree', 'contributor_id'])
+            ->get()
+            ->groupBy('contributor_id');
     }
 }

--- a/classes/category/DAO.php
+++ b/classes/category/DAO.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/category/DAO.php
  *
@@ -106,9 +107,9 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): Category
+    public function fromRow(object $row, ?callable $populator = null): Category
     {
-        return parent::fromRow($row);
+        return parent::fromRow($row, $populator);
     }
 
     /**

--- a/classes/category/DAO.php
+++ b/classes/category/DAO.php
@@ -16,8 +16,8 @@ namespace PKP\category;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 
 /**
@@ -88,28 +88,11 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get a collection of categories matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-            foreach ($rows as $row) {
-                yield $row->category_id => $this->fromRow($row);
-            }
-        });
-    }
-
-    /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): Category
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Category
     {
-        return parent::fromRow($row, $populator);
+        return parent::fromRow($row, $ids, $cache, $query);
     }
 
     /**

--- a/classes/citation/Collector.php
+++ b/classes/citation/Collector.php
@@ -38,7 +38,7 @@ class Collector implements CollectorInterface
 
     public ?int $offset = null;
 
-    public ?int $publicationId = null;
+    public ?array $publicationIds = null;
 
     public ?string $rawCitation = null;
 
@@ -65,9 +65,9 @@ class Collector implements CollectorInterface
     /**
      * Filter by single publication
      */
-    public function filterByPublicationId(?int $publicationId): self
+    public function filterByPublicationIds(?array $publicationIds): self
     {
-        $this->publicationId = $publicationId;
+        $this->publicationIds = $publicationIds;
         return $this;
     }
 
@@ -110,27 +110,17 @@ class Collector implements CollectorInterface
 
     /**
      * @copydoc CollectorInterface::getQueryBuilder()
+     *
+     * @hook Citation::Collector [[&$qb, $this]]
      */
     public function getQueryBuilder(): Builder
     {
         $qb = DB::table($this->dao->table . ' as c')
-            ->select('c.*');
-
-        if (!is_null($this->count)) {
-            $qb->limit($this->count);
-        }
-
-        if (!is_null($this->offset)) {
-            $qb->offset($this->offset);
-        }
-
-        if (!is_null($this->publicationId)) {
-            $qb->where('c.publication_id', $this->publicationId);
-        }
-
-        if (!is_null($this->rawCitation)) {
-            $qb->where('c.raw_citation', $this->rawCitation);
-        }
+            ->select('c.*')
+            ->when(!is_null($this->count), fn ($q) => $q->limit($this->count))
+            ->when(!is_null($this->offset), fn ($q) => $q->offset($this->offset))
+            ->when(!is_null($this->publicationIds), fn ($q) => $q->whereIn('c.publication_id', $this->publicationIds))
+            ->when(!is_null($this->rawCitation), fn ($q) => $q->where('c.raw_citation', $this->rawCitation));
 
         switch ($this->orderBy) {
             case self::ORDERBY_SEQUENCE:

--- a/classes/citation/DAO.php
+++ b/classes/citation/DAO.php
@@ -88,20 +88,21 @@ class DAO extends EntityDAO
     {
         return LazyCollection::make(function () use ($query) {
             $queryBuilder = $query->getQueryBuilder();
-            $settings = null;
 
             $rows = $queryBuilder->get();
             $citationIds = $rows->pluck('citation_id')->all();
 
+            $cache = (object) [];
+
             foreach ($rows as $row) {
                 yield $row->citation_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, Citation $citation) use ($citationIds, &$settings): void {
-                        $settings ??= DB::table('citation_settings')
+                    function (object $row, object $schema, Citation $citation) use ($citationIds, $cache): void {
+                        $cache->settings ??= DB::table('citation_settings')
                             ->whereIn('citation_id', $citationIds)
                             ->get()
                             ->groupBy('citation_id');
-                        $settings->get($row->citation_id)
+                        $cache->settings->get($row->citation_id)
                             ?->each(fn ($row) => $this->populateSetting($row, $citation, $schema));
                     }
                 );

--- a/classes/citation/DAO.php
+++ b/classes/citation/DAO.php
@@ -87,11 +87,24 @@ class DAO extends EntityDAO
     public function getMany(Collector $query): LazyCollection
     {
         return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
+            $queryBuilder = $query->getQueryBuilder();
+            $settings = null;
+
+            $rows = $queryBuilder->get();
+            $citationIds = $rows->pluck('citation_id')->all();
+
             foreach ($rows as $row) {
-                yield $row->citation_id => $this->fromRow($row);
+                yield $row->citation_id => $this->fromRow(
+                    $row,
+                    function (object $row, object $schema, Citation $citation) use ($citationIds, &$settings): void {
+                        $settings ??= DB::table('citation_settings')
+                            ->whereIn('citation_id', $citationIds)
+                            ->get()
+                            ->groupBy('citation_id');
+                        $settings->get($row->citation_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $citation, $schema));
+                    }
+                );
             }
         });
     }

--- a/classes/citation/DAO.php
+++ b/classes/citation/DAO.php
@@ -19,7 +19,6 @@ namespace PKP\citation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 use PKP\core\traits\EntityWithParent;
 use PKP\services\PKPSchemaService;
@@ -77,37 +76,6 @@ class DAO extends EntityDAO
         return $query
             ->getQueryBuilder()
             ->getCountForPagination();
-    }
-
-    /**
-     * Get a collection of citations matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $queryBuilder = $query->getQueryBuilder();
-
-            $rows = $queryBuilder->get();
-            $citationIds = $rows->pluck('citation_id')->all();
-
-            $cache = (object) [];
-
-            foreach ($rows as $row) {
-                yield $row->citation_id => $this->fromRow(
-                    $row,
-                    function (object $row, object $schema, Citation $citation) use ($citationIds, $cache): void {
-                        $cache->settings ??= DB::table('citation_settings')
-                            ->whereIn('citation_id', $citationIds)
-                            ->get()
-                            ->groupBy('citation_id');
-                        $cache->settings->get($row->citation_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $citation, $schema));
-                    }
-                );
-            }
-        });
     }
 
     /** @copydoc EntityDAO::insert() */

--- a/classes/citation/Repository.php
+++ b/classes/citation/Repository.php
@@ -176,14 +176,14 @@ class Repository
     }
 
     /**
-     * Get all citations for a given publication.
+     * Get all citations for the given publication IDs.
      *
      * @return array<Citation>
      */
-    public function getByPublicationId(int $publicationId): LazyCollection
+    public function getByPublicationIds(array $publicationIds): LazyCollection
     {
         return $this->getCollector()
-            ->filterByPublicationId($publicationId)
+            ->filterByPublicationIds($publicationIds)
             ->getMany()
             ->remember();
     }
@@ -220,7 +220,7 @@ class Repository
         $citationsMetadataLookup = $context->getData('citationsMetadataLookup');
         $publicationId = $publication->getId();
 
-        $existingCitations = $this->getByPublicationId($publicationId);
+        $existingCitations = $this->getByPublicationIds([$publicationId]);
         Hook::call('Citation::importCitations::before', [$publicationId, $existingCitations, $rawCitationList]);
 
         $citationTokenizer = new CitationListTokenizerFilter();

--- a/classes/components/forms/submission/ForTheEditors.php
+++ b/classes/components/forms/submission/ForTheEditors.php
@@ -111,7 +111,7 @@ class ForTheEditors extends PKPMetadataForm
             ->values()
             ->all();
 
-        $categoryValues = (array) $this->publication->getData('categoryIds');
+        $categoryValues = $this->publication->getData('categoryIds')->toArray();
         // Check if all categories have a breadcrumb; categories with circular references are filtered out
         $hasAllBreadcrumbs = $categories->count() === count($categoryOptions);
 

--- a/classes/context/SubEditorsDAO.php
+++ b/classes/context/SubEditorsDAO.php
@@ -88,7 +88,7 @@ class SubEditorsDAO extends \PKP\db\DAO
      *
      * @return \Illuminate\Support\Collection<int, \stdClass> result rows with userId and userGroupId properties
      */
-    public function getBySubmissionGroupIds(array $assocIds, int $assocType, int $contextId, bool $allowDisabled = false): Collection
+    public function getBySubmissionGroupIds(iterable $assocIds, int $assocType, int $contextId, bool $allowDisabled = false): Collection
     {
         return DB::table('subeditor_submission_group')
             ->where('subeditor_submission_group.assoc_type', '=', $assocType)

--- a/classes/controlledVocab/ControlledVocab.php
+++ b/classes/controlledVocab/ControlledVocab.php
@@ -15,13 +15,12 @@
 namespace PKP\controlledVocab;
 
 use Eloquence\Behaviours\HasCamelCasing;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Builder;
-use PKP\controlledVocab\ControlledVocabEntry;
 use PKP\facades\Locale;
 
 class ControlledVocab extends Model
@@ -99,7 +98,7 @@ class ControlledVocab extends Model
      */
     public function controlledVocabEntries(): HasMany
     {
-        return $this->hasMany(ControlledVocabEntry::class, 'controlled_vocab_id', 'controlled_vocab_id');
+        return $this->hasMany(ControlledVocabEntry::class, 'controlled_vocab_id', 'controlled_vocab_id')->chaperone();
     }
 
     /**
@@ -111,11 +110,12 @@ class ControlledVocab extends Model
     }
 
     /**
-     * Scope a query to only include vocabs with a specific assoc type and assoc ID.
+     * Scope a query to only include vocabs with a specific assoc type(s) and assoc ID(s).
      */
-    public function scopeWithAssoc(Builder $query, int $assocType, ?int $assocId): Builder
+    public function scopeWithAssoc(Builder $query, int|array $assocType, int|array|null $assocId): Builder
     {
-        return $query->where('assoc_type', $assocType)->where('assoc_id', $assocId);
+        return $query->whereIn('assoc_type', (array) $assocType)
+            ->when($assocId !== null, fn ($q) => $q->whereIn('assoc_id', (array) $assocId));
     }
 
     /**
@@ -138,7 +138,7 @@ class ControlledVocab extends Model
                         ),
                         '=',
                         'submissions.submission_id'
-                    ), 
+                    ),
                 $contextId
             );
     }
@@ -149,7 +149,7 @@ class ControlledVocab extends Model
      * @return array $controlledVocabEntryId => name
      */
     public function enumerate(string $settingName = 'name'): array
-    {    
+    {
         return DB::table('controlled_vocab_entries AS e')
             ->leftJoin(
                 'controlled_vocab_entry_settings AS l',

--- a/classes/core/EntityDAO.php
+++ b/classes/core/EntityDAO.php
@@ -94,12 +94,37 @@ abstract class EntityDAO
         throw new Exception('Not implemented');
     }
 
+    protected function individualPopulator(object $row, object $schema, DataObject $object): void
+    {
+        if ($this->settingsTable) {
+            DB::table($this->settingsTable)
+                ->where($this->primaryKeyColumn, '=', $row->{$this->primaryKeyColumn})
+                ->get()
+                ->each(fn ($row) => $this->populateSetting($row, $object, $schema));
+        }
+    }
+
+    protected function populateSetting(object $row, DataObject $object, object $schema)
+    {
+        if (!empty($schema->properties->{$row->setting_name})) {
+            $object->setData(
+                $row->setting_name,
+                $this->convertFromDB(
+                    value: $row->setting_value,
+                    type: $schema->properties->{$row->setting_name}->type,
+                    decrypt: $schema->properties->{$row->setting_name}->encrypt ?? false
+                ),
+                empty($row->locale) ? null : $row->locale
+            );
+        }
+    }
+
     /**
      * Convert a row from the database query into a DataObject
      *
      * @return T
      */
-    public function fromRow(object $row): DataObject
+    public function fromRow(object $row, callable $populator = null): DataObject
     {
         $schema = $this->schemaService->get($this->schema);
 
@@ -119,26 +144,8 @@ abstract class EntityDAO
             }
         }
 
-        if ($this->settingsTable) {
-            $rows = DB::table($this->settingsTable)
-                ->where($this->primaryKeyColumn, '=', $row->{$this->primaryKeyColumn})
-                ->get();
-
-            $rows->each(function ($row) use ($object, $schema) {
-                if (!empty($schema->properties->{$row->setting_name})) {
-                    $object->setData(
-                        $row->setting_name,
-                        $this->convertFromDB(
-                            value: $row->setting_value,
-                            type: $schema->properties->{$row->setting_name}->type,
-                            decrypt: $schema->properties->{$row->setting_name}->encrypt ?? false
-                        ),
-                        empty($row->locale) ? null : $row->locale
-                    );
-                }
-            });
-        }
-
+        $populator ??= static::individualPopulator(...);
+        $populator($row, $schema, $object);
         return $object;
     }
 

--- a/classes/core/EntityDAO.php
+++ b/classes/core/EntityDAO.php
@@ -144,6 +144,7 @@ abstract class EntityDAO
             $cache->settings ??= DB::table($this->settingsTable)
                 ->whereIn($this->primaryKeyColumn, $ids)
                 ->get()
+                ->collect()
                 ->groupBy($this->primaryKeyColumn);
             $cache->settings->get($row->{$this->primaryKeyColumn})
                 ?->each(function ($row) use ($object, $schema) {

--- a/classes/core/EntityDAO.php
+++ b/classes/core/EntityDAO.php
@@ -96,18 +96,6 @@ abstract class EntityDAO
         throw new Exception('Not implemented');
     }
 
-    protected function populate(object $row, object $schema, DataObject $object, array $ids, object $cache): void
-    {
-        if ($this->settingsTable) {
-            $cache->settings ??= DB::table($this->settingsTable)
-                ->whereIn($this->primaryKeyColumn, $ids)
-                ->get()
-                ->groupBy($this->primaryKeyColumn);
-            $cache->settings->get($row->{$this->primaryKeyColumn})
-                ?->each(fn ($row) => $this->populateSetting($row, $object, $schema));
-        }
-    }
-
     protected function populateSetting(object $row, DataObject $object, object $schema)
     {
         if (!empty($schema->properties->{$row->setting_name})) {
@@ -167,7 +155,15 @@ abstract class EntityDAO
             }
         }
 
-        $this->populate($row, $schema, $object, $ids, $cache);
+        if ($this->settingsTable) {
+            $cache->settings ??= DB::table($this->settingsTable)
+                ->whereIn($this->primaryKeyColumn, $ids)
+                ->get()
+                ->groupBy($this->primaryKeyColumn);
+            $cache->settings->get($row->{$this->primaryKeyColumn})
+                ?->each(fn ($row) => $this->populateSetting($row, $object, $schema));
+        }
+
         return $object;
     }
 

--- a/classes/core/EntityDAO.php
+++ b/classes/core/EntityDAO.php
@@ -96,21 +96,6 @@ abstract class EntityDAO
         throw new Exception('Not implemented');
     }
 
-    protected function populateSetting(object $row, DataObject $object, object $schema)
-    {
-        if (!empty($schema->properties->{$row->setting_name})) {
-            $object->setData(
-                $row->setting_name,
-                $this->convertFromDB(
-                    value: $row->setting_value,
-                    type: $schema->properties->{$row->setting_name}->type,
-                    decrypt: $schema->properties->{$row->setting_name}->encrypt ?? false
-                ),
-                empty($row->locale) ? null : $row->locale
-            );
-        }
-    }
-
     /**
      * Get a collection of DataObject instances matching the configured query
      *
@@ -161,7 +146,19 @@ abstract class EntityDAO
                 ->get()
                 ->groupBy($this->primaryKeyColumn);
             $cache->settings->get($row->{$this->primaryKeyColumn})
-                ?->each(fn ($row) => $this->populateSetting($row, $object, $schema));
+                ?->each(function ($row) use ($object, $schema) {
+                    if (!empty($schema->properties->{$row->setting_name})) {
+                        $object->setData(
+                            $row->setting_name,
+                            $this->convertFromDB(
+                                value: $row->setting_value,
+                                type: $schema->properties->{$row->setting_name}->type,
+                                decrypt: $schema->properties->{$row->setting_name}->encrypt ?? false
+                            ),
+                            empty($row->locale) ? null : $row->locale
+                        );
+                    }
+                });
         }
 
         return $object;

--- a/classes/core/EntityDAO.php
+++ b/classes/core/EntityDAO.php
@@ -16,6 +16,8 @@ namespace PKP\core;
 
 use Exception;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\LazyCollection;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityUpdate;
 use PKP\db\DAO;
 use PKP\services\PKPSchemaService;
@@ -94,13 +96,15 @@ abstract class EntityDAO
         throw new Exception('Not implemented');
     }
 
-    protected function individualPopulator(object $row, object $schema, DataObject $object): void
+    protected function populate(object $row, object $schema, DataObject $object, array $ids, object $cache): void
     {
         if ($this->settingsTable) {
-            DB::table($this->settingsTable)
-                ->where($this->primaryKeyColumn, '=', $row->{$this->primaryKeyColumn})
+            $cache->settings ??= DB::table($this->settingsTable)
+                ->whereIn($this->primaryKeyColumn, $ids)
                 ->get()
-                ->each(fn ($row) => $this->populateSetting($row, $object, $schema));
+                ->groupBy($this->primaryKeyColumn);
+            $cache->settings->get($row->{$this->primaryKeyColumn})
+                ?->each(fn ($row) => $this->populateSetting($row, $object, $schema));
         }
     }
 
@@ -120,11 +124,30 @@ abstract class EntityDAO
     }
 
     /**
+     * Get a collection of DataObject instances matching the configured query
+     *
+     * @return LazyCollection<int,T>
+     */
+    public function getMany(CollectorInterface $query): LazyCollection
+    {
+        return LazyCollection::make(function () use ($query) {
+            $queryBuilder = $query->getQueryBuilder();
+            $rows = $queryBuilder->get();
+            $ids = $rows->pluck($this->primaryKeyColumn)->all();
+            $cache = (object) [];
+
+            foreach ($rows as $row) {
+                yield $row->{$this->primaryKeyColumn} => $this->fromRow($row, $ids, $cache, $query);
+            }
+        });
+    }
+
+    /**
      * Convert a row from the database query into a DataObject
      *
      * @return T
      */
-    public function fromRow(object $row, callable $populator = null): DataObject
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): DataObject
     {
         $schema = $this->schemaService->get($this->schema);
 
@@ -144,8 +167,7 @@ abstract class EntityDAO
             }
         }
 
-        $populator ??= static::individualPopulator(...);
-        $populator($row, $schema, $object);
+        $this->populate($row, $schema, $object, $ids, $cache);
         return $object;
     }
 

--- a/classes/core/PKPApplication.php
+++ b/classes/core/PKPApplication.php
@@ -122,7 +122,9 @@ abstract class PKPApplication implements PKPApplicationInfoProvider
         Hook::addUnsupportedHooks('TemplateResource::getFilename'); // pkp/pkp-lib#12088 Replaced with View::resolveName
 
         // QueuedPayment instances may be serialized
-        class_alias(\PKP\payment\QueuedPayment::class, '\QueuedPayment');
+        if (!class_exists('\QueuedPayment')) {
+            class_alias(\PKP\payment\QueuedPayment::class, '\QueuedPayment');
+        }
 
         ini_set('display_errors', Config::getVar('debug', 'display_errors', ini_get('display_errors')));
 

--- a/classes/core/traits/EntityWithParent.php
+++ b/classes/core/traits/EntityWithParent.php
@@ -20,6 +20,7 @@ namespace PKP\core\traits;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use PKP\core\DataObject;
+use PKP\core\interfaces\CollectorInterface;
 
 /**
  * @template T of DataObject
@@ -36,7 +37,7 @@ trait EntityWithParent
      *
      * @return T
      */
-    abstract public function fromRow(object $row, array $ids, object $cache): DataObject;
+    abstract public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): DataObject;
 
     /**
      * Check if an object exists.

--- a/classes/core/traits/EntityWithParent.php
+++ b/classes/core/traits/EntityWithParent.php
@@ -36,7 +36,7 @@ trait EntityWithParent
      *
      * @return T
      */
-    abstract public function fromRow(object $row): DataObject;
+    abstract public function fromRow(object $row, ?callable $populator = null): DataObject;
 
     /**
      * Check if an object exists.

--- a/classes/core/traits/EntityWithParent.php
+++ b/classes/core/traits/EntityWithParent.php
@@ -36,7 +36,7 @@ trait EntityWithParent
      *
      * @return T
      */
-    abstract public function fromRow(object $row, ?callable $populator = null): DataObject;
+    abstract public function fromRow(object $row, array $ids, object $cache): DataObject;
 
     /**
      * Check if an object exists.
@@ -66,6 +66,6 @@ trait EntityWithParent
             ->where($this->primaryKeyColumn, $id)
             ->when($parentId !== null, fn (Builder $query) => $query->where($this->getParentColumn(), $parentId))
             ->first();
-        return $row ? $this->fromRow($row) : null;
+        return $row ? $this->fromRow($row, [$id], (object) []) : null;
     }
 }

--- a/classes/dataCitation/DataCitation.php
+++ b/classes/dataCitation/DataCitation.php
@@ -10,7 +10,7 @@
  * @class DataCitation
  *
  * @brief Basic class describing Data Citation existing in the system.
- * 
+ *
  */
 
 namespace PKP\dataCitation;
@@ -22,7 +22,7 @@ use PKP\dataCitation\pid\PidResolver;
 use PKP\services\PKPSchemaService;
 
 /**
- * @method static \Illuminate\Database\Eloquent\Builder withPublicationId (int $publicationId) accepts valid publication ID
+ * @method static \Illuminate\Database\Eloquent\Builder withPublicationIds (array $publicationId) accepts valid publication IDs
  */
 class DataCitation extends Model
 {
@@ -59,9 +59,9 @@ class DataCitation extends Model
 
     /**
      * Override saving to strip known prefixes and Base URL's from identifier
-     * 
+     *
      * @return static
-     * 
+     *
      */
     protected static function boot()
     {
@@ -88,21 +88,19 @@ class DataCitation extends Model
     }
 
     /**
-     * Filter by publication ID
-     * 
-     * @return EloquentBuilder
-     * 
+     * Filter by publication IDs
+     *
+     *
      */
-    protected function scopeWithPublicationId(EloquentBuilder $builder, int $publicationId): EloquentBuilder
+    protected function scopeWithPublicationIds(EloquentBuilder $builder, array $publicationIds): EloquentBuilder
     {
-        return $builder->where('publication_id', $publicationId);
+        return $builder->whereIn('publication_id', $publicationIds);
     }
 
     /**
      * Order by seq
-     * 
-     * @return EloquentBuilder
-     * 
+     *
+     *
      */
     protected function scopeOrderBySeq(EloquentBuilder $builder): EloquentBuilder
     {

--- a/classes/decision/DAO.php
+++ b/classes/decision/DAO.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/decision/DAO.php
  *
@@ -113,9 +114,9 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): Decision
+    public function fromRow(object $row, ?callable $populator = null): Decision
     {
-        return parent::fromRow($row);
+        return parent::fromRow($row, $populator);
     }
 
     /**

--- a/classes/decision/DAO.php
+++ b/classes/decision/DAO.php
@@ -18,8 +18,8 @@ use APP\decision\Decision;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 
 /**
@@ -95,28 +95,11 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get a collection of decisions matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-            foreach ($rows as $row) {
-                yield $row->edit_decision_id => $this->fromRow($row);
-            }
-        });
-    }
-
-    /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): Decision
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Decision
     {
-        return parent::fromRow($row, $populator);
+        return parent::fromRow($row, $ids, $cache, $query);
     }
 
     /**

--- a/classes/doi/Collector.php
+++ b/classes/doi/Collector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/doi/Collector.php
  *
@@ -38,6 +39,8 @@ class Collector implements CollectorInterface
     public ?array $statuses = null;
 
     public ?string $identifier = null;
+
+    public ?array $reviewAssignments = null;
 
     public function __construct(DAO $dao)
     {
@@ -94,6 +97,14 @@ class Collector implements CollectorInterface
         return $this;
     }
 
+    /**
+     * Filter by review assignment IDs
+     */
+    public function filterByReviewIds(array $reviewIds): self
+    {
+        $this->reviewIds = $reviewIds;
+        return $this;
+    }
 
     /**
      * Limit the number of objects retrieved
@@ -121,6 +132,7 @@ class Collector implements CollectorInterface
      */
     public function getQueryBuilder(): Builder
     {
+        $collector = $this;
         $q = DB::table($this->dao->table, 'd')
             ->select(['d.*'])
             ->when($this->contextIds != null, function (Builder $q) {
@@ -131,6 +143,9 @@ class Collector implements CollectorInterface
             })
             ->when($this->identifier !== null, function (Builder $q) {
                 $q->where('d.doi', '=', $this->identifier);
+            })
+            ->when($this->reviewIds !== null, function (Builder $q) use ($collector) {
+                $q->whereIn('d.doi_id', DB::table('review_assignments')->whereIn('review_id', $collector->reviewIds)->select(['doi_id']));
             })
             ->when(!empty($this->count), function (Builder $q) {
                 $q->limit($this->count);

--- a/classes/doi/DAO.php
+++ b/classes/doi/DAO.php
@@ -104,20 +104,21 @@ abstract class DAO extends EntityDAO
     {
         return LazyCollection::make(function () use ($query) {
             $queryBuilder = $query->getQueryBuilder();
-            $settings = null;
 
             $rows = $queryBuilder->get();
             $doiIds = $rows->pluck('doi_id')->all();
 
+            $cache = (object) [];
+
             foreach ($rows as $row) {
                 yield $row->doi_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, Doi $doi) use ($doiIds, &$settings): void {
-                        $settings ??= DB::table('doi_settings')
+                    function (object $row, object $schema, Doi $doi) use ($doiIds, $cache): void {
+                        $cache->settings ??= DB::table('doi_settings')
                             ->whereIn('doi_id', $doiIds)
                             ->get()
                             ->groupBy('doi_id');
-                        $settings->get($row->doi_id)
+                        $cache->settings->get($row->doi_id)
                             ?->each(fn ($row) => $this->populateSetting($row, $doi, $schema));
                     }
                 );

--- a/classes/doi/DAO.php
+++ b/classes/doi/DAO.php
@@ -103,11 +103,24 @@ abstract class DAO extends EntityDAO
     public function getMany(Collector $query): LazyCollection
     {
         return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
+            $queryBuilder = $query->getQueryBuilder();
+            $settings = null;
+
+            $rows = $queryBuilder->get();
+            $doiIds = $rows->pluck('doi_id')->all();
+
             foreach ($rows as $row) {
-                yield $row->doi_id => $this->fromRow($row);
+                yield $row->doi_id => $this->fromRow(
+                    $row,
+                    function (object $row, object $schema, Doi $doi) use ($doiIds, &$settings): void {
+                        $settings ??= DB::table('doi_settings')
+                            ->whereIn('doi_id', $doiIds)
+                            ->get()
+                            ->groupBy('doi_id');
+                        $settings->get($row->doi_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $doi, $schema));
+                    }
+                );
             }
         });
     }

--- a/classes/doi/DAO.php
+++ b/classes/doi/DAO.php
@@ -115,10 +115,10 @@ abstract class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): Doi
+    public function fromRow(object $row, ?callable $populator = null): Doi
     {
         /** @var Doi */
-        $doi = parent::fromRow($row);
+        $doi = parent::fromRow($row, $populator);
         if (empty($doi->getData('doi'))) {
             $doi->setData('resolvingUrl', '');
         } else {

--- a/classes/doi/DAO.php
+++ b/classes/doi/DAO.php
@@ -21,9 +21,9 @@ namespace PKP\doi;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\context\Context;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 use PKP\services\PKPSchemaService;
 
@@ -96,43 +96,12 @@ abstract class DAO extends EntityDAO
     }
 
     /**
-     * Get a collection of DOIs matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $queryBuilder = $query->getQueryBuilder();
-
-            $rows = $queryBuilder->get();
-            $doiIds = $rows->pluck('doi_id')->all();
-
-            $cache = (object) [];
-
-            foreach ($rows as $row) {
-                yield $row->doi_id => $this->fromRow(
-                    $row,
-                    function (object $row, object $schema, Doi $doi) use ($doiIds, $cache): void {
-                        $cache->settings ??= DB::table('doi_settings')
-                            ->whereIn('doi_id', $doiIds)
-                            ->get()
-                            ->groupBy('doi_id');
-                        $cache->settings->get($row->doi_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $doi, $schema));
-                    }
-                );
-            }
-        });
-    }
-
-    /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): Doi
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Doi
     {
         /** @var Doi */
-        $doi = parent::fromRow($row, $populator);
+        $doi = parent::fromRow($row, $ids, $cache, $query);
         if (empty($doi->getData('doi'))) {
             $doi->setData('resolvingUrl', '');
         } else {

--- a/classes/emailTemplate/DAO.php
+++ b/classes/emailTemplate/DAO.php
@@ -20,6 +20,7 @@ use Exception;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\PKPApplication;
 use PKP\db\DAORegistry;
 use PKP\db\XMLDAO;
@@ -136,10 +137,10 @@ class DAO extends EntityDAO
      *
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, array $ids, object $cache): EmailTemplate
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): EmailTemplate
     {
         /** @var EmailTemplate $emailTemplate */
-        $emailTemplate = parent::fromRow($row, $ids, $cache);
+        $emailTemplate = parent::fromRow($row, $ids, $cache, $query);
         $schema = $this->schemaService->get($this->schema);
         $contextDao = Application::getContextDAO();
 

--- a/classes/emailTemplate/DAO.php
+++ b/classes/emailTemplate/DAO.php
@@ -113,7 +113,7 @@ class DAO extends EntityDAO
     /**
      * Get a single email template that matches the given key
      */
-    public function getByKey(?int $contextId = null, string $key): ?EmailTemplate
+    public function getByKey(?int $contextId, string $key): ?EmailTemplate
     {
         $results = Repo::emailTemplate()->getCollector($contextId)
             ->filterByKeys([$key])

--- a/classes/emailTemplate/DAO.php
+++ b/classes/emailTemplate/DAO.php
@@ -155,10 +155,10 @@ class DAO extends EntityDAO
      *
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): EmailTemplate
+    public function fromRow(object $row, ?callable $populator = null): EmailTemplate
     {
         /** @var EmailTemplate $emailTemplate */
-        $emailTemplate = parent::fromRow($row);
+        $emailTemplate = parent::fromRow($row, $populator);
         $schema = $this->schemaService->get($this->schema);
         $contextDao = Application::getContextDAO();
 

--- a/classes/emailTemplate/DAO.php
+++ b/classes/emailTemplate/DAO.php
@@ -18,7 +18,6 @@ use APP\core\Application;
 use APP\facades\Repo;
 use Exception;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use PKP\core\EntityDAO;
 use PKP\core\PKPApplication;
@@ -111,24 +110,6 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get a collection of Email Templates matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $this->fromRow($row);
-            }
-        });
-    }
-
-    /**
      * Get a single email template that matches the given key
      */
     public function getByKey(?int $contextId = null, string $key): ?EmailTemplate
@@ -155,10 +136,10 @@ class DAO extends EntityDAO
      *
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): EmailTemplate
+    public function fromRow(object $row, array $ids, object $cache): EmailTemplate
     {
         /** @var EmailTemplate $emailTemplate */
-        $emailTemplate = parent::fromRow($row, $populator);
+        $emailTemplate = parent::fromRow($row, $ids, $cache);
         $schema = $this->schemaService->get($this->schema);
         $contextDao = Application::getContextDAO();
 

--- a/classes/emailTemplate/Repository.php
+++ b/classes/emailTemplate/Repository.php
@@ -51,7 +51,7 @@ class Repository
     }
 
     /** @copydoc DAO::getByKey() */
-    public function getByKey(?int $contextId = null, string $key): ?EmailTemplate
+    public function getByKey(?int $contextId, string $key): ?EmailTemplate
     {
         return $this->dao->getByKey($contextId, $key);
     }
@@ -200,7 +200,7 @@ class Repository
             ->getMany();
 
         $deletedKeys = [];
-        $results->each(function ($emailTemplate) use ($deletedKeys){
+        $results->each(function ($emailTemplate) use ($deletedKeys) {
             $deletedKeys[] = $emailTemplate->getData('key');
             $this->delete($emailTemplate);
         });

--- a/classes/funder/Funder.php
+++ b/classes/funder/Funder.php
@@ -62,11 +62,11 @@ class Funder extends Model
     }
 
     /**
-     * Filter by submission ID
+     * Filter by submission IDs
      */
-    protected function scopeWithSubmissionId(EloquentBuilder $builder, int $submissionId): EloquentBuilder
+    protected function scopeWithSubmissionIds(EloquentBuilder $builder, array $submissionIds): EloquentBuilder
     {
-        return $builder->where('submission_id', $submissionId);
+        return $builder->whereIn('submission_id', $submissionIds);
     }
 
     /**

--- a/classes/galley/DAO.php
+++ b/classes/galley/DAO.php
@@ -148,7 +148,7 @@ class DAO extends EntityDAO implements RepresentationDAOInterface
         if (!$row) {
             return null;
         }
-        return $this->fromRow($row);
+        return $this->fromRow($row, [$id], (object) []);
     }
 
     /** @copydoc RepresentationDAOInterface::getByPublicationId() */
@@ -341,6 +341,14 @@ class DAO extends EntityDAO implements RepresentationDAOInterface
         );
 
         $result = $this->deprecatedDao->retrieveRange($q, [], $rangeInfo);
-        return new DAOResultFactory($result, $this, 'fromRow', [], $q, [], $rangeInfo);
+        return new DAOResultFactory($result, $this, 'fromRowDeprecated', [], $q, [], $rangeInfo);
+    }
+
+    /**
+     * DEPRECATED: Remove me once getExportable is refactored/removed
+     */
+    public function fromRowDeprecated($row): Galley
+    {
+        return $this->fromRow($row, [$row->galley_id], (object) []);
     }
 }

--- a/classes/galley/DAO.php
+++ b/classes/galley/DAO.php
@@ -21,8 +21,8 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 use PKP\db\DAOResultFactory;
 use PKP\identity\Identity;
@@ -85,7 +85,7 @@ class DAO extends EntityDAO implements RepresentationDAOInterface
             ->where('publication_id', $publication->getId())
             ->where('url_path', $urlPath)
             ->first();
-        return $row ? $this->fromRow($row) : null;
+        return $row ? $this->fromRow($row, [$row->publication_id], (object) []) : null;
     }
 
     /**
@@ -111,27 +111,9 @@ class DAO extends EntityDAO implements RepresentationDAOInterface
             ->pluck('g.' . $this->primaryKeyColumn);
     }
 
-    /**
-     * Get a collection of galleys matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Galley
     {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->galley_id = $this->fromRow($row);
-            }
-        });
-    }
-
-    public function fromRow(object $row, ?callable $populator = null): Galley
-    {
-        $galley = parent::fromRow($row, $populator);
+        $galley = parent::fromRow($row, $ids, $cache, $query);
 
         if (!empty($galley->getData('doiId'))) {
             $galley->setData('doiObject', Repo::doi()->get($galley->getData('doiId')));

--- a/classes/galley/DAO.php
+++ b/classes/galley/DAO.php
@@ -129,9 +129,9 @@ class DAO extends EntityDAO implements RepresentationDAOInterface
         });
     }
 
-    public function fromRow(object $row): Galley
+    public function fromRow(object $row, ?callable $populator = null): Galley
     {
-        $galley = parent::fromRow($row);
+        $galley = parent::fromRow($row, $populator);
 
         if (!empty($galley->getData('doiId'))) {
             $galley->setData('doiObject', Repo::doi()->get($galley->getData('doiId')));

--- a/classes/highlight/DAO.php
+++ b/classes/highlight/DAO.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/highlight/DAO.php
  *
@@ -15,7 +16,6 @@ namespace PKP\highlight;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 
 /**
@@ -91,24 +91,6 @@ class DAO extends EntityDAO
             ->pluck('a.' . $this->primaryKeyColumn);
     }
 
-    /**
-     * Get a collection of highlights matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->highlight_id => $this->fromRow($row);
-            }
-        });
-    }
-
     public function insert(Highlight $highlight): int
     {
         return parent::_insert($highlight);
@@ -130,7 +112,7 @@ class DAO extends EntityDAO
     public function getLastSequence(?int $contextId = null): ?int
     {
         return DB::table($this->table)
-            ->where(DB::raw("COALESCE(context_id, 0)"), (int) $contextId)
+            ->where(DB::raw('COALESCE(context_id, 0)'), (int) $contextId)
             ->orderBy('sequence', 'desc')
             ->first('sequence')
             ?->sequence;

--- a/classes/institution/DAO.php
+++ b/classes/institution/DAO.php
@@ -137,10 +137,10 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): Institution
+    public function fromRow(object $row, ?callable $populator = null): Institution
     {
         /** @var Institution */
-        $institution = parent::fromRow($row);
+        $institution = parent::fromRow($row, $populator);
 
         $ipRanges = DB::table('institution_ip')
             ->where($this->primaryKeyColumn, '=', $institution->getId())

--- a/classes/institution/DAO.php
+++ b/classes/institution/DAO.php
@@ -97,25 +97,6 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get a collection of institutions matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->select(['i.*'])
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->institution_id => $this->fromRow($row);
-            }
-        });
-    }
-
-    /**
      * Get a collection of deleted institutions matching the configured query
      */
     public function getSoftDeleted(Collector $query): LazyCollection
@@ -137,10 +118,10 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): Institution
+    public function fromRow(object $row, array $ids, object $cache): Institution
     {
         /** @var Institution */
-        $institution = parent::fromRow($row, $populator);
+        $institution = parent::fromRow($row, $ids, $cache);
 
         $ipRanges = DB::table('institution_ip')
             ->where($this->primaryKeyColumn, '=', $institution->getId())

--- a/classes/log/event/DAO.php
+++ b/classes/log/event/DAO.php
@@ -114,40 +114,6 @@ class DAO extends EntityDAO
     }
 
     /**
-     * @copydoc EntityDAO::fromRow()
-     */
-    public function fromRow(object $row, ?callable $populator = null): EventLogEntry
-    {
-        $logEntry = parent::fromRow($row, $populator);
-        $schema = $this->schemaService->get($this->schema);
-
-        // FIXME Why is this here?
-
-        DB::table($this->settingsTable)
-            ->where($this->primaryKeyColumn, '=', $row->{$this->primaryKeyColumn})
-            ->get()
-            ->each(function ($row) use ($logEntry, $schema) {
-                if (!empty($schema->properties->{$row->setting_name})) {
-                    return;
-                }
-
-                // Retrieve custom properties
-                if (!empty($row->setting_type)) {
-                    $logEntry->setData(
-                        $row->setting_name,
-                        $this->convertFromDB(
-                            $row->setting_value,
-                            $row->setting_type
-                        ),
-                        empty($row->locale) ? null : $row->locale
-                    );
-                }
-            });
-
-        return $logEntry;
-    }
-
-    /**
      * @copydoc EntityDAO::insert()
      */
     public function insert(EventLogEntry $eventLog): int

--- a/classes/log/event/DAO.php
+++ b/classes/log/event/DAO.php
@@ -16,7 +16,6 @@ namespace PKP\log\event;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 use PKP\services\PKPSchemaService;
 
@@ -95,22 +94,6 @@ class DAO extends EntityDAO
             ->getQueryBuilder()
             ->select('e.' . $this->primaryKeyColumn)
             ->pluck('e.' . $this->primaryKeyColumn);
-    }
-
-    /**
-     * Get a collection of log entries matching the configured query
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->log_id => $this->fromRow($row);
-            }
-        });
     }
 
     /**

--- a/classes/log/event/DAO.php
+++ b/classes/log/event/DAO.php
@@ -116,10 +116,12 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): EventLogEntry
+    public function fromRow(object $row, ?callable $populator = null): EventLogEntry
     {
-        $logEntry = parent::fromRow($row);
+        $logEntry = parent::fromRow($row, $populator);
         $schema = $this->schemaService->get($this->schema);
+
+        // FIXME Why is this here?
 
         DB::table($this->settingsTable)
             ->where($this->primaryKeyColumn, '=', $row->{$this->primaryKeyColumn})

--- a/classes/publication/Collector.php
+++ b/classes/publication/Collector.php
@@ -90,7 +90,6 @@ class Collector implements CollectorInterface
     /**
      * Filter by publication Ids
      *
-     * @param ?int[] $publicationIDs Publication IDs
      */
     public function filterByPublicationIds(?array $publicationIds): self
     {
@@ -155,10 +154,10 @@ class Collector implements CollectorInterface
     public function getQueryBuilder(): Builder
     {
         $qb = DB::table('publications as p')
-            ->select(['p.*']);
+            ->join('submissions as s', 'p.submission_id', '=', 's.submission_id')
+            ->select(['p.*', 's.locale AS submission_locale']); // see DAO::fromRow for use of submission_locale
 
         if (isset($this->contextIds)) {
-            $qb->join('submissions as s', 'p.submission_id', '=', 's.submission_id');
             $qb->whereIn('s.context_id', $this->contextIds);
         }
 

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -201,6 +201,7 @@ class DAO extends EntityDAO
         $cache->controlledVocabs ??= ControlledVocabEntry::query()
             ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $ids))
             ->get()
+            ->collect()
             ->groupBy(fn ($cve) => $cve->controlledVocab->assocId);
         $publicationControlledVocabs = $cache->controlledVocabs->get($row->publication_id) ?? collect();
         $symbolicControlledVocabs = $publicationControlledVocabs->groupBy(fn ($cve) => $cve->controlledVocab->symbolic);
@@ -228,7 +229,9 @@ class DAO extends EntityDAO
         }));
 
         $publication->setData('citations', LazyCollection::make(function () use ($row, $ids, $cache) {
-            $cache->citations ??= Repo::citation()->getByPublicationIds($ids)->groupBy(fn ($citation) => $citation->getData('publicationId'));
+            $cache->citations ??= Repo::citation()->getByPublicationIds($ids)
+                ->collect()
+                ->groupBy(fn ($citation) => $citation->getData('publicationId'));
             yield from $cache->citations->get($row->publication_id) ?? [];
         }));
 

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -123,12 +123,12 @@ class DAO extends EntityDAO
             $rows = $queryBuilder->get();
             $publicationIds = $rows->pluck('publication_id')->all();
 
-            $settings = $authors = $categoryIds = $controlledVocabs = $dataCitations = null;
+            $settings = $authors = $categoryIds = $controlledVocabs = $dataCitations = $citations = null;
 
             foreach ($rows as $row) {
                 yield $row->publication_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, PKPPublication $publication) use ($queryBuilder, $publicationIds, &$settings, &$authors, &$categoryIds, &$controlledVocabs, &$dataCitations): void {
+                    function (object $row, object $schema, PKPPublication $publication) use ($publicationIds, &$settings, &$authors, &$categoryIds, &$controlledVocabs, &$dataCitations, &$citations): void {
                         $settings ??= DB::table('publication_settings')
                             ->whereIn('publication_id', $publicationIds)
                             ->get()
@@ -174,6 +174,9 @@ class DAO extends EntityDAO
                             ->collect()
                             ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
                         $publication->setData('dataCitations', $dataCitations->get($row->publication_id)?->toArray() ?? []);
+
+                        $citations ??= Repo::citation()->getByPublicationIds($publicationIds)->groupBy(fn ($citation) => $citation->getData('publicationId'));
+                        $publication->setData('citations', $citations->get($row->publication_id)?->toArray() ?? []);
                     }
                 );
             }
@@ -261,6 +264,8 @@ class DAO extends EntityDAO
             'dataCitations',
             DataCitation::withPublicationIds([$object->getId()])->orderBySeq()->get()->values()->all()
         );
+
+        $object->setData('citations', Repo::citation()->getByPublicationIds($object->getId()));
     }
 
     /**
@@ -276,8 +281,11 @@ class DAO extends EntityDAO
         // Set the primary locale from the submission
         $publication->setData('locale', $row->submission_locale);
 
-        $citations = Repo::citation()->getByPublicationId($publication->getId());
-        $publication->setData('citations', $citations);
+        $publicationVersionString = Repo::publication()->getVersionString($publication);
+        $publication->setData('versionString', $publicationVersionString);
+
+        $this->setFunders($publication);
+
         $publication->setData('citationsRaw', new class ($publication->getId()) implements \Stringable {
             public function __construct(public int $publicationId)
             {
@@ -287,11 +295,6 @@ class DAO extends EntityDAO
                 return Repo::citation()->getRawCitationsByPublicationId($this->publicationId)->implode(PHP_EOL);
             }
         });
-
-        $publicationVersionString = Repo::publication()->getVersionString($publication);
-        $publication->setData('versionString', $publicationVersionString);
-
-        $this->setFunders($publication);
 
         return $publication;
     }

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -26,6 +26,7 @@ use Illuminate\Support\LazyCollection;
 use PKP\controlledVocab\ControlledVocab;
 use PKP\controlledVocab\ControlledVocabEntry;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 use PKP\dataCitation\DataCitation;
 use PKP\funder\Funder;
@@ -108,28 +109,23 @@ class DAO extends EntityDAO
             ->when($submissionId !== null, fn (Builder $query) => $query->where('s.submission_id', '=', $submissionId))
             ->select(['p.*', 's.locale AS submission_locale'])
             ->first();
-        return $row ? $this->fromRow($row) : null;
+        return $row ? $this->fromRow($row, [$id], (object) []) : null;
     }
 
-    protected function batchPopulator(object $row, object $schema, PKPPublication $publication, array $publicationIds, object $cache): void
+    protected function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
     {
-        $cache->settings ??= DB::table('publication_settings')
-            ->whereIn('publication_id', $publicationIds)
-            ->get()
-            ->groupBy('publication_id');
-        $cache->settings->get($row->publication_id)
-            ?->each(fn ($row) => $this->populateSetting($row, $publication, $schema));
+        parent::populate($row, $schema, $object, $ids, $cache);
 
-        $publication->setData('authors', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
-            $cache->authors ??= Repo::author()->getCollector()->filterByPublicationIds($publicationIds)
+        $object->setData('authors', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->authors ??= Repo::author()->getCollector()->filterByPublicationIds($ids)
                 ->getMany()
                 ->collect()
                 ->groupBy(fn ($author) => $author->getData('publicationId'));
             yield from $cache->authors->get($row->publication_id) ?? [];
         })->remember());
 
-        $publication->setData('categoryIds', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
-            $cache->categoryIds ??= PublicationCategory::withPublicationIds($publicationIds)
+        $object->setData('categoryIds', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->categoryIds ??= PublicationCategory::withPublicationIds($ids)
                 ->get()
                 ->collect()
                 ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
@@ -137,7 +133,7 @@ class DAO extends EntityDAO
         })->remember());
 
         $cache->controlledVocabs ??= ControlledVocabEntry::query()
-            ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $publicationIds))
+            ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $ids))
             ->get()
             ->groupBy(fn ($cve) => $cve->controlledVocab->assocId);
         $publicationControlledVocabs = $cache->controlledVocabs->get($row->publication_id) ?? collect();
@@ -154,46 +150,21 @@ class DAO extends EntityDAO
                     $entries[$locale][] = $entry->getEntryData($locale);
                 }
             }
-            $publication->setData($dataName, $entries);
+            $object->setData($dataName, $entries);
         }
 
-        $publication->setData('dataCitations', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
-            $cache->dataCitations ??= DataCitation::withPublicationIds($publicationIds)
+        $object->setData('dataCitations', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->dataCitations ??= DataCitation::withPublicationIds($ids)
                 ->get()
                 ->collect()
                 ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
             yield from $cache->dataCitations->get($row->publication_id) ?? [];
         }));
 
-        $publication->setData('citations', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
-            $cache->citations ??= Repo::citation()->getByPublicationIds($publicationIds)->groupBy(fn ($citation) => $citation->getData('publicationId'));
+        $object->setData('citations', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->citations ??= Repo::citation()->getByPublicationIds($ids)->groupBy(fn ($citation) => $citation->getData('publicationId'));
             yield from $cache->citations->get($row->publication_id) ?? [];
         }));
-    }
-
-    /**
-     * Get a collection of publications matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $queryBuilder = $query->getQueryBuilder();
-            $rows = $queryBuilder->get();
-            $publicationIds = $rows->pluck('publication_id')->all();
-
-            $cache = (object) [];
-
-            foreach ($rows as $row) {
-                yield $row->publication_id => $this->fromRow(
-                    $row,
-                    function (object $row, object $schema, PKPPublication $publication) use ($publicationIds, $cache): void {
-                        $this->batchPopulator($row, $schema, $publication, $publicationIds, $cache);
-                    }
-                );
-            }
-        });
     }
 
     /**
@@ -246,10 +217,10 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): Publication
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Publication
     {
         /** @var Publication $publication */
-        $publication = parent::fromRow($row, $populator);
+        $publication = parent::fromRow($row, $ids, $cache, $query);
 
         $this->setDoiObject($publication);
 

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -154,11 +154,6 @@ class DAO extends EntityDAO
             ->count();
     }
 
-    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
-    {
-        $this->batchPopulator($row, $schema, $object, [$row->publication_id], (object) []);
-    }
-
     /**
      * @copydoc EntityDAO::fromRow()
      */
@@ -456,7 +451,7 @@ class DAO extends EntityDAO
      */
     protected function saveCategories(Publication $publication): void
     {
-        $categoryIds = (array) $publication->getData('categoryIds');
+        $categoryIds = iterator_to_array($publication->getData('categoryIds') ?? []);
         Repo::publication()->assignCategoriesToPublication($publication->getId(), $categoryIds);
     }
 

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -92,6 +92,25 @@ class DAO extends EntityDAO
     }
 
     /**
+     * Get a publication.
+     *
+     * Optionally, pass the submission ID to only get a publication
+     * if it exists and is assigned to that submission.
+     */
+    public function get(int $id, ?int $submissionId = null): ?Publication
+    {
+        // This is overridden due to the need to include submission_locale
+        // to the fromRow function
+        $row = DB::table('publications as p')
+            ->join('submissions as s', 'p.submission_id', '=', 's.submission_id')
+            ->where('p.publication_id', '=', $id)
+            ->when($submissionId !== null, fn (Builder $query) => $query->where('s.submission_id', '=', $submissionId))
+            ->select(['p.*', 's.locale AS submission_locale'])
+            ->first();
+        return $row ? $this->fromRow($row) : null;
+    }
+
+    /**
      * Get a collection of publications matching the configured query
      *
      * @return LazyCollection<int,T>
@@ -161,10 +180,7 @@ class DAO extends EntityDAO
         $this->setDoiObject($publication);
 
         // Set the primary locale from the submission
-        $locale = DB::table('submissions as s')
-            ->where('s.submission_id', '=', $publication->getData('submissionId'))
-            ->value('locale');
-        $publication->setData('locale', $locale);
+        $publication->setData('locale', $row->submission_locale);
 
         $citations = Repo::citation()->getByPublicationId($publication->getId());
         $publication->setData('citations', $citations);

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -29,7 +29,6 @@ use PKP\core\EntityDAO;
 use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 use PKP\dataCitation\DataCitation;
-use PKP\funder\Funder;
 use PKP\notification\Notification;
 use PKP\services\PKPSchemaService;
 
@@ -169,8 +168,6 @@ class DAO extends EntityDAO
 
         $publicationVersionString = Repo::publication()->getVersionString($publication);
         $publication->setData('versionString', $publicationVersionString);
-
-        $this->setFunders($publication);
 
         $publication->setData('citationsRaw', new class ($publication->getId()) implements \Stringable {
             public function __construct(public int $publicationId)
@@ -472,20 +469,6 @@ class DAO extends EntityDAO
     protected function deleteDataCitations(int $publicationId): void
     {
         DataCitation::where('publication_id', $publicationId)->delete();
-    }
-
-    /**
-     * Set a publication's Funders
-     */
-    protected function setFunders(Publication $publication): void
-    {
-        $publication->setData(
-            'funders',
-            Funder::withSubmissionId($publication->getData('submissionId'))
-                ->orderBySeq()
-                ->lazy()
-                ->remember()
-        );
     }
 
     /**

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\controlledVocab\ControlledVocab;
+use PKP\controlledVocab\ControlledVocabEntry;
 use PKP\core\EntityDAO;
 use PKP\core\traits\EntityWithParent;
 use PKP\dataCitation\DataCitation;
@@ -118,11 +119,63 @@ class DAO extends EntityDAO
     public function getMany(Collector $query): LazyCollection
     {
         return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
+            $queryBuilder = $query->getQueryBuilder();
+            $rows = $queryBuilder->get();
+            $publicationIds = $rows->pluck('publication_id')->all();
+
+            $settings = $authors = $categoryIds = $controlledVocabs = $dataCitations = null;
+
             foreach ($rows as $row) {
-                yield $row->publication_id => $this->fromRow($row);
+                yield $row->publication_id => $this->fromRow(
+                    $row,
+                    function (object $row, object $schema, PKPPublication $publication) use ($queryBuilder, $publicationIds, &$settings, &$authors, &$categoryIds, &$controlledVocabs, &$dataCitations): void {
+                        $settings ??= DB::table('publication_settings')
+                            ->whereIn('publication_id', $publicationIds)
+                            ->get()
+                            ->groupBy('publication_id');
+                        $settings->get($row->publication_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $publication, $schema));
+
+                        $authors ??= Repo::author()->getCollector()->filterByPublicationIds($publicationIds)
+                            ->getMany()
+                            ->collect()
+                            ->groupBy(fn ($author) => $author->getData('publicationId'));
+                        $publication->setData('authors', $authors->get($row->publication_id) ?? collect([]));
+
+                        $categoryIds ??= PublicationCategory::withPublicationIds($publicationIds)
+                            ->get()
+                            ->collect()
+                            ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
+                        $publication->setData('categoryIds', $categoryIds->get($row->publication_id)?->all() ?? []);
+
+                        $controlledVocabs ??= ControlledVocabEntry::query()
+                            ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $publicationIds))
+                            ->get()
+                            ->groupBy(fn ($cve) => $cve->controlledVocab->assocId);
+                        $publicationControlledVocabs = $controlledVocabs->get($row->publication_id) ?? collect();
+                        $symbolicControlledVocabs = $publicationControlledVocabs->groupBy(fn ($cve) => $cve->controlledVocab->symbolic);
+                        foreach ([
+                            'keywords' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
+                            'subjects' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
+                            'disciplines' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
+                            'supportingAgencies' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
+                        ] as $dataName => $symbolicName) {
+                            $entries = [];
+                            foreach ($symbolicControlledVocabs->get($symbolicName) ?? [] as $entry) {
+                                foreach ($entry->name as $locale => $value) {
+                                    $entries[$locale][] = $entry->getEntryData($locale);
+                                }
+                            }
+                            $publication->setData($dataName, $entries);
+                        }
+
+                        $dataCitations ??= DataCitation::withPublicationIds($publicationIds)
+                            ->get()
+                            ->collect()
+                            ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
+                        $publication->setData('dataCitations', $dataCitations->get($row->publication_id)?->toArray() ?? []);
+                    }
+                );
             }
         });
     }
@@ -169,13 +222,54 @@ class DAO extends EntityDAO
             ->count();
     }
 
+    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
+    {
+        parent::individualPopulator($row, $schema, $object);
+
+        $object->setData(
+            'authors',
+            Repo::author()
+                ->getCollector()
+                ->filterByPublicationIds([$object->getId()])
+                ->orderBy(\PKP\author\Collector::ORDERBY_SEQUENCE)
+                ->getMany()
+                ->remember()
+        );
+
+        $object->setData(
+            'categoryIds',
+            PublicationCategory::withPublicationIds([$object->getId()])->pluck('category_id')->toArray()
+        );
+
+        foreach ([
+            'keywords' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
+            'subjects' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
+            'disciplines' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
+            'supportingAgencies' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
+        ] as $dataName => $symbolicName) {
+            $object->setData(
+                $dataName,
+                Repo::controlledVocab()->getBySymbolic(
+                    $symbolicName,
+                    Application::ASSOC_TYPE_PUBLICATION,
+                    $object->getId()
+                )
+            );
+        }
+
+        $object->setData(
+            'dataCitations',
+            DataCitation::withPublicationIds([$object->getId()])->orderBySeq()->get()->values()->all()
+        );
+    }
+
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): Publication
+    public function fromRow(object $row, ?callable $populator = null): Publication
     {
         /** @var Publication $publication */
-        $publication = parent::fromRow($row);
+        $publication = parent::fromRow($row, $populator);
 
         $this->setDoiObject($publication);
 
@@ -197,10 +291,6 @@ class DAO extends EntityDAO
         $publicationVersionString = Repo::publication()->getVersionString($publication);
         $publication->setData('versionString', $publicationVersionString);
 
-        $this->setAuthors($publication);
-        $this->setCategories($publication);
-        $this->setControlledVocab($publication);
-        $this->setDataCitations($publication);
         $this->setFunders($publication);
 
         return $publication;
@@ -343,22 +433,6 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Set a publication's author properties
-     */
-    protected function setAuthors(Publication $publication)
-    {
-        $publication->setData(
-            'authors',
-            Repo::author()
-                ->getCollector()
-                ->filterByPublicationIds([$publication->getId()])
-                ->orderBy(\PKP\author\Collector::ORDERBY_SEQUENCE)
-                ->getMany()
-                ->remember()
-        );
-    }
-
-    /**
      * Delete a publication's authors
      */
     protected function deleteAuthors(int $publicationId)
@@ -378,41 +452,6 @@ class DAO extends EntityDAO
      */
     protected function setControlledVocab(Publication $publication)
     {
-        $publication->setData(
-            'keywords',
-            Repo::controlledVocab()->getBySymbolic(
-                ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
-                Application::ASSOC_TYPE_PUBLICATION,
-                $publication->getId()
-            )
-        );
-
-        $publication->setData(
-            'subjects',
-            Repo::controlledVocab()->getBySymbolic(
-                ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
-                Application::ASSOC_TYPE_PUBLICATION,
-                $publication->getId()
-            )
-        );
-
-        $publication->setData(
-            'disciplines',
-            Repo::controlledVocab()->getBySymbolic(
-                ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
-                Application::ASSOC_TYPE_PUBLICATION,
-                $publication->getId()
-            )
-        );
-
-        $publication->setData(
-            'supportingAgencies',
-            Repo::controlledVocab()->getBySymbolic(
-                ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
-                Application::ASSOC_TYPE_PUBLICATION,
-                $publication->getId()
-            )
-        );
     }
 
     /**
@@ -469,15 +508,6 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Set a publication's category property
-     */
-    protected function setCategories(Publication $publication): void
-    {
-        $categoryIds = PublicationCategory::withPublicationId($publication->getId())->pluck('category_id')->toArray();
-        $publication->setData('categoryIds', $categoryIds);
-    }
-
-    /**
      * Save the assigned categories
      */
     protected function saveCategories(Publication $publication): void
@@ -492,19 +522,6 @@ class DAO extends EntityDAO
     protected function deleteCategories(int $publicationId): void
     {
         PublicationCategory::where('publication_id', $publicationId)->delete();
-    }
-
-    /**
-     * Set a publication's Data Citations
-     */
-    protected function setDataCitations(Publication $publication): void
-    {
-        $dataCitations = DataCitation::withPublicationId($publication->getId())
-            ->orderBySeq()
-            ->get()
-            ->values()
-            ->all();
-        $publication->setData('dataCitations', $dataCitations);
     }
 
     /**

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -265,7 +265,7 @@ class DAO extends EntityDAO
             DataCitation::withPublicationIds([$object->getId()])->orderBySeq()->get()->values()->all()
         );
 
-        $object->setData('citations', Repo::citation()->getByPublicationIds($object->getId()));
+        $object->setData('citations', Repo::citation()->getByPublicationIds([$object->getId()]));
     }
 
     /**

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -548,12 +548,13 @@ class DAO extends EntityDAO
      */
     protected function setFunders(Publication $publication): void
     {
-        $funders = Funder::withSubmissionId($publication->getData('submissionId'))
-            ->orderBySeq()
-            ->get()
-            ->values()
-            ->all();
-        $publication->setData('funders', $funders);
+        $publication->setData(
+            'funders',
+            Funder::withSubmissionId($publication->getData('submissionId'))
+                ->orderBySeq()
+                ->lazy()
+                ->remember()
+        );
     }
 
     /**

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -112,61 +112,6 @@ class DAO extends EntityDAO
         return $row ? $this->fromRow($row, [$id], (object) []) : null;
     }
 
-    protected function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
-    {
-        parent::populate($row, $schema, $object, $ids, $cache);
-
-        $object->setData('authors', LazyCollection::make(function () use ($row, $ids, $cache) {
-            $cache->authors ??= Repo::author()->getCollector()->filterByPublicationIds($ids)
-                ->getMany()
-                ->collect()
-                ->groupBy(fn ($author) => $author->getData('publicationId'));
-            yield from $cache->authors->get($row->publication_id) ?? [];
-        })->remember());
-
-        $object->setData('categoryIds', LazyCollection::make(function () use ($row, $ids, $cache) {
-            $cache->categoryIds ??= PublicationCategory::withPublicationIds($ids)
-                ->get()
-                ->collect()
-                ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
-            yield from $cache->categoryIds->get($row->publication_id) ?? [];
-        })->remember());
-
-        $cache->controlledVocabs ??= ControlledVocabEntry::query()
-            ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $ids))
-            ->get()
-            ->groupBy(fn ($cve) => $cve->controlledVocab->assocId);
-        $publicationControlledVocabs = $cache->controlledVocabs->get($row->publication_id) ?? collect();
-        $symbolicControlledVocabs = $publicationControlledVocabs->groupBy(fn ($cve) => $cve->controlledVocab->symbolic);
-        foreach ([
-            'keywords' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
-            'subjects' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
-            'disciplines' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
-            'supportingAgencies' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
-        ] as $dataName => $symbolicName) {
-            $entries = [];
-            foreach ($symbolicControlledVocabs->get($symbolicName) ?? [] as $entry) {
-                foreach ($entry->name as $locale => $value) {
-                    $entries[$locale][] = $entry->getEntryData($locale);
-                }
-            }
-            $object->setData($dataName, $entries);
-        }
-
-        $object->setData('dataCitations', LazyCollection::make(function () use ($row, $ids, $cache) {
-            $cache->dataCitations ??= DataCitation::withPublicationIds($ids)
-                ->get()
-                ->collect()
-                ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
-            yield from $cache->dataCitations->get($row->publication_id) ?? [];
-        }));
-
-        $object->setData('citations', LazyCollection::make(function () use ($row, $ids, $cache) {
-            $cache->citations ??= Repo::citation()->getByPublicationIds($ids)->groupBy(fn ($citation) => $citation->getData('publicationId'));
-            yield from $cache->citations->get($row->publication_id) ?? [];
-        }));
-    }
-
     /**
      * Get the publication dates of the first and last publications
      * matching the passed query
@@ -241,6 +186,56 @@ class DAO extends EntityDAO
                 return Repo::citation()->getRawCitationsByPublicationId($this->publicationId)->implode(PHP_EOL);
             }
         });
+
+        $publication->setData('authors', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->authors ??= Repo::author()->getCollector()->filterByPublicationIds($ids)
+                ->getMany()
+                ->collect()
+                ->groupBy(fn ($author) => $author->getData('publicationId'));
+            yield from $cache->authors->get($row->publication_id) ?? [];
+        })->remember());
+
+        $publication->setData('categoryIds', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->categoryIds ??= PublicationCategory::withPublicationIds($ids)
+                ->get()
+                ->collect()
+                ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
+            yield from $cache->categoryIds->get($row->publication_id) ?? [];
+        })->remember());
+
+        $cache->controlledVocabs ??= ControlledVocabEntry::query()
+            ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $ids))
+            ->get()
+            ->groupBy(fn ($cve) => $cve->controlledVocab->assocId);
+        $publicationControlledVocabs = $cache->controlledVocabs->get($row->publication_id) ?? collect();
+        $symbolicControlledVocabs = $publicationControlledVocabs->groupBy(fn ($cve) => $cve->controlledVocab->symbolic);
+        foreach ([
+            'keywords' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
+            'subjects' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
+            'disciplines' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
+            'supportingAgencies' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
+        ] as $dataName => $symbolicName) {
+            $entries = [];
+            foreach ($symbolicControlledVocabs->get($symbolicName) ?? [] as $entry) {
+                foreach ($entry->name as $locale => $value) {
+                    $entries[$locale][] = $entry->getEntryData($locale);
+                }
+            }
+            $publication->setData($dataName, $entries);
+        }
+
+        $publication->setData('dataCitations', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->dataCitations ??= DataCitation::withPublicationIds($ids)
+                ->get()
+                ->collect()
+                ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
+            yield from $cache->dataCitations->get($row->publication_id) ?? [];
+        }));
+
+        $publication->setData('citations', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->citations ??= Repo::citation()->getByPublicationIds($ids)->groupBy(fn ($citation) => $citation->getData('publicationId'));
+            yield from $cache->citations->get($row->publication_id) ?? [];
+        }));
 
         return $publication;
     }

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -136,17 +136,21 @@ class DAO extends EntityDAO
                         $settings->get($row->publication_id)
                             ?->each(fn ($row) => $this->populateSetting($row, $publication, $schema));
 
-                        $authors ??= Repo::author()->getCollector()->filterByPublicationIds($publicationIds)
-                            ->getMany()
-                            ->collect()
-                            ->groupBy(fn ($author) => $author->getData('publicationId'));
-                        $publication->setData('authors', $authors->get($row->publication_id) ?? collect([]));
+                        $publication->setData('authors', LazyCollection::make(function () use ($row, $publicationIds, &$authors) {
+                            $authors ??= Repo::author()->getCollector()->filterByPublicationIds($publicationIds)
+                                ->getMany()
+                                ->collect()
+                                ->groupBy(fn ($author) => $author->getData('publicationId'));
+                            yield from $authors->get($row->publication_id) ?? [];
+                        })->remember());
 
-                        $categoryIds ??= PublicationCategory::withPublicationIds($publicationIds)
-                            ->get()
-                            ->collect()
-                            ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
-                        $publication->setData('categoryIds', $categoryIds->get($row->publication_id)?->all() ?? []);
+                        $publication->setData('categoryIds', LazyCollection::make(function () use ($row, $publicationIds, &$categoryIds) {
+                            $categoryIds ??= PublicationCategory::withPublicationIds($publicationIds)
+                                ->get()
+                                ->collect()
+                                ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
+                            yield from $categoryIds->get($row->publication_id) ?? [];
+                        })->remember());
 
                         $controlledVocabs ??= ControlledVocabEntry::query()
                             ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $publicationIds))
@@ -169,14 +173,18 @@ class DAO extends EntityDAO
                             $publication->setData($dataName, $entries);
                         }
 
-                        $dataCitations ??= DataCitation::withPublicationIds($publicationIds)
-                            ->get()
-                            ->collect()
-                            ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
-                        $publication->setData('dataCitations', $dataCitations->get($row->publication_id)?->toArray() ?? []);
+                        $publication->setData('dataCitations', LazyCollection::make(function () use ($row, $publicationIds, &$dataCitations) {
+                            $dataCitations ??= DataCitation::withPublicationIds($publicationIds)
+                                ->get()
+                                ->collect()
+                                ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
+                            yield from $dataCitations->get($row->publication_id) ?? [];
+                        }));
 
-                        $citations ??= Repo::citation()->getByPublicationIds($publicationIds)->groupBy(fn ($citation) => $citation->getData('publicationId'));
-                        $publication->setData('citations', $citations->get($row->publication_id)?->toArray() ?? []);
+                        $publication->setData('citations', LazyCollection::make(function () use ($row, $publicationIds, &$citations) {
+                            $citations ??= Repo::citation()->getByPublicationIds($publicationIds)->groupBy(fn ($citation) => $citation->getData('publicationId'));
+                            yield from $citations->get($row->publication_id) ?? [];
+                        }));
                     }
                 );
             }

--- a/classes/publication/DAO.php
+++ b/classes/publication/DAO.php
@@ -111,6 +111,66 @@ class DAO extends EntityDAO
         return $row ? $this->fromRow($row) : null;
     }
 
+    protected function batchPopulator(object $row, object $schema, PKPPublication $publication, array $publicationIds, object $cache): void
+    {
+        $cache->settings ??= DB::table('publication_settings')
+            ->whereIn('publication_id', $publicationIds)
+            ->get()
+            ->groupBy('publication_id');
+        $cache->settings->get($row->publication_id)
+            ?->each(fn ($row) => $this->populateSetting($row, $publication, $schema));
+
+        $publication->setData('authors', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
+            $cache->authors ??= Repo::author()->getCollector()->filterByPublicationIds($publicationIds)
+                ->getMany()
+                ->collect()
+                ->groupBy(fn ($author) => $author->getData('publicationId'));
+            yield from $cache->authors->get($row->publication_id) ?? [];
+        })->remember());
+
+        $publication->setData('categoryIds', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
+            $cache->categoryIds ??= PublicationCategory::withPublicationIds($publicationIds)
+                ->get()
+                ->collect()
+                ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
+            yield from $cache->categoryIds->get($row->publication_id) ?? [];
+        })->remember());
+
+        $cache->controlledVocabs ??= ControlledVocabEntry::query()
+            ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $publicationIds))
+            ->get()
+            ->groupBy(fn ($cve) => $cve->controlledVocab->assocId);
+        $publicationControlledVocabs = $cache->controlledVocabs->get($row->publication_id) ?? collect();
+        $symbolicControlledVocabs = $publicationControlledVocabs->groupBy(fn ($cve) => $cve->controlledVocab->symbolic);
+        foreach ([
+            'keywords' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
+            'subjects' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
+            'disciplines' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
+            'supportingAgencies' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
+        ] as $dataName => $symbolicName) {
+            $entries = [];
+            foreach ($symbolicControlledVocabs->get($symbolicName) ?? [] as $entry) {
+                foreach ($entry->name as $locale => $value) {
+                    $entries[$locale][] = $entry->getEntryData($locale);
+                }
+            }
+            $publication->setData($dataName, $entries);
+        }
+
+        $publication->setData('dataCitations', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
+            $cache->dataCitations ??= DataCitation::withPublicationIds($publicationIds)
+                ->get()
+                ->collect()
+                ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
+            yield from $cache->dataCitations->get($row->publication_id) ?? [];
+        }));
+
+        $publication->setData('citations', LazyCollection::make(function () use ($row, $publicationIds, $cache) {
+            $cache->citations ??= Repo::citation()->getByPublicationIds($publicationIds)->groupBy(fn ($citation) => $citation->getData('publicationId'));
+            yield from $cache->citations->get($row->publication_id) ?? [];
+        }));
+    }
+
     /**
      * Get a collection of publications matching the configured query
      *
@@ -123,68 +183,13 @@ class DAO extends EntityDAO
             $rows = $queryBuilder->get();
             $publicationIds = $rows->pluck('publication_id')->all();
 
-            $settings = $authors = $categoryIds = $controlledVocabs = $dataCitations = $citations = null;
+            $cache = (object) [];
 
             foreach ($rows as $row) {
                 yield $row->publication_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, PKPPublication $publication) use ($publicationIds, &$settings, &$authors, &$categoryIds, &$controlledVocabs, &$dataCitations, &$citations): void {
-                        $settings ??= DB::table('publication_settings')
-                            ->whereIn('publication_id', $publicationIds)
-                            ->get()
-                            ->groupBy('publication_id');
-                        $settings->get($row->publication_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $publication, $schema));
-
-                        $publication->setData('authors', LazyCollection::make(function () use ($row, $publicationIds, &$authors) {
-                            $authors ??= Repo::author()->getCollector()->filterByPublicationIds($publicationIds)
-                                ->getMany()
-                                ->collect()
-                                ->groupBy(fn ($author) => $author->getData('publicationId'));
-                            yield from $authors->get($row->publication_id) ?? [];
-                        })->remember());
-
-                        $publication->setData('categoryIds', LazyCollection::make(function () use ($row, $publicationIds, &$categoryIds) {
-                            $categoryIds ??= PublicationCategory::withPublicationIds($publicationIds)
-                                ->get()
-                                ->collect()
-                                ->mapToGroups(fn ($publicationCategory, $key) => [$publicationCategory->publicationId => $publicationCategory->categoryId]);
-                            yield from $categoryIds->get($row->publication_id) ?? [];
-                        })->remember());
-
-                        $controlledVocabs ??= ControlledVocabEntry::query()
-                            ->withWhereHas('controlledVocab', fn ($query) => $query->withSymbolics([ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE, ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY])->withAssoc(Application::ASSOC_TYPE_PUBLICATION, $publicationIds))
-                            ->get()
-                            ->groupBy(fn ($cve) => $cve->controlledVocab->assocId);
-                        $publicationControlledVocabs = $controlledVocabs->get($row->publication_id) ?? collect();
-                        $symbolicControlledVocabs = $publicationControlledVocabs->groupBy(fn ($cve) => $cve->controlledVocab->symbolic);
-                        foreach ([
-                            'keywords' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
-                            'subjects' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
-                            'disciplines' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
-                            'supportingAgencies' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
-                        ] as $dataName => $symbolicName) {
-                            $entries = [];
-                            foreach ($symbolicControlledVocabs->get($symbolicName) ?? [] as $entry) {
-                                foreach ($entry->name as $locale => $value) {
-                                    $entries[$locale][] = $entry->getEntryData($locale);
-                                }
-                            }
-                            $publication->setData($dataName, $entries);
-                        }
-
-                        $publication->setData('dataCitations', LazyCollection::make(function () use ($row, $publicationIds, &$dataCitations) {
-                            $dataCitations ??= DataCitation::withPublicationIds($publicationIds)
-                                ->get()
-                                ->collect()
-                                ->groupBy(fn ($dataCitation) => $dataCitation->publicationId);
-                            yield from $dataCitations->get($row->publication_id) ?? [];
-                        }));
-
-                        $publication->setData('citations', LazyCollection::make(function () use ($row, $publicationIds, &$citations) {
-                            $citations ??= Repo::citation()->getByPublicationIds($publicationIds)->groupBy(fn ($citation) => $citation->getData('publicationId'));
-                            yield from $citations->get($row->publication_id) ?? [];
-                        }));
+                    function (object $row, object $schema, PKPPublication $publication) use ($publicationIds, $cache): void {
+                        $this->batchPopulator($row, $schema, $publication, $publicationIds, $cache);
                     }
                 );
             }
@@ -235,45 +240,7 @@ class DAO extends EntityDAO
 
     protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
     {
-        parent::individualPopulator($row, $schema, $object);
-
-        $object->setData(
-            'authors',
-            Repo::author()
-                ->getCollector()
-                ->filterByPublicationIds([$object->getId()])
-                ->orderBy(\PKP\author\Collector::ORDERBY_SEQUENCE)
-                ->getMany()
-                ->remember()
-        );
-
-        $object->setData(
-            'categoryIds',
-            PublicationCategory::withPublicationIds([$object->getId()])->pluck('category_id')->toArray()
-        );
-
-        foreach ([
-            'keywords' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_KEYWORD,
-            'subjects' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_SUBJECT,
-            'disciplines' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_DISCIPLINE,
-            'supportingAgencies' => ControlledVocab::CONTROLLED_VOCAB_SUBMISSION_AGENCY,
-        ] as $dataName => $symbolicName) {
-            $object->setData(
-                $dataName,
-                Repo::controlledVocab()->getBySymbolic(
-                    $symbolicName,
-                    Application::ASSOC_TYPE_PUBLICATION,
-                    $object->getId()
-                )
-            );
-        }
-
-        $object->setData(
-            'dataCitations',
-            DataCitation::withPublicationIds([$object->getId()])->orderBySeq()->get()->values()->all()
-        );
-
-        $object->setData('citations', Repo::citation()->getByPublicationIds([$object->getId()]));
+        $this->batchPopulator($row, $schema, $object, [$row->publication_id], (object) []);
     }
 
     /**

--- a/classes/publication/PublicationCategory.php
+++ b/classes/publication/PublicationCategory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/publication/PublicationCategory.php
  *
@@ -14,8 +15,8 @@
 namespace PKP\publication;
 
 use Eloquence\Behaviours\HasCamelCasing;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class PublicationCategory extends Model
 {
@@ -32,9 +33,9 @@ class PublicationCategory extends Model
     /**
      * Scope a query to only include records with a specific publicationId
      */
-    public function scopeWithPublicationId(Builder $query, int $publicationId): Builder
+    public function scopeWithPublicationIds(Builder $query, array $publicationIds): Builder
     {
-        return $query->where('publication_id', $publicationId);
+        return $query->whereIn('publication_id', $publicationIds);
     }
 
     /**

--- a/classes/publication/maps/Schema.php
+++ b/classes/publication/maps/Schema.php
@@ -184,7 +184,7 @@ class Schema extends \PKP\core\maps\Schema
                     $data = [];
 
                     if (!$anonymizeAuthors) {
-                        foreach ($publication->getData('funders') as $funder) {
+                        foreach ($this->submission->getData('funders') as $funder) {
                             $data[] = Repo::funder()->getSchemaMap()->map($funder);
                         }
                     }

--- a/classes/publication/maps/Schema.php
+++ b/classes/publication/maps/Schema.php
@@ -146,7 +146,7 @@ class Schema extends \PKP\core\maps\Schema
                     $output[$prop] = $anonymizeAuthors ? '' : $publication->getShortAuthorString();
                     break;
                 case 'categoryIds':
-                    $output[$prop] = $publication->getData('categoryIds');
+                    $output[$prop] = iterator_to_array($publication->getData('categoryIds'));
                     break;
                 case 'citations':
                     $data = [];

--- a/classes/ror/Collector.php
+++ b/classes/ror/Collector.php
@@ -39,6 +39,8 @@ class Collector implements CollectorInterface
     /** Get rors with given ROR */
     public ?string $ror = null;
 
+    public ?array $authorAffiliationIds = null;
+
     public ?int $count = null;
 
     public ?int $offset = null;
@@ -92,6 +94,12 @@ class Collector implements CollectorInterface
         return $this;
     }
 
+    public function filterByAuthorAffiliationIds(?array $authorAffiliationIds): self
+    {
+        $this->authorAffiliationIds = $authorAffiliationIds;
+        return $this;
+    }
+
     /**
      * Filter rors by those matching given ror
      */
@@ -132,42 +140,29 @@ class Collector implements CollectorInterface
     /**@copydoc CollectorInterface::getQueryBuilder() */
     public function getQueryBuilder(): Builder
     {
-        $qb = DB::table($this->dao->table . ' as r')->select('r.*')->distinct();
-
-        if ($this->searchPhrase !== null) {
-            $words = explode(' ', $this->searchPhrase);
-            if (count($words)) {
-                foreach ($words as $word) {
-                    $word = addcslashes($word, '%_');
-                    $qb->where('r.search_phrase', 'like', '%' . $word . '%');
+        $collector = $this;
+        $qb = DB::table($this->dao->table . ' as r')
+            ->select('r.*')
+            ->when($this->searchPhrase !== null, function ($q) use ($collector) {
+                foreach (explode(' ', $collector->searchPhrase) as $word) {
+                    $qb->where('r.search_phrase', 'like', '%' . addcslashes($word, '%_') . '%');
                 }
-            }
-        }
-
-        $qb->when($this->name !== null, function (Builder $qb) {
-            $qb->whereIn('r.ror_id', function (Builder $qb) {
-                $qb->select('rs.ror_id')
-                    ->from($this->dao->settingsTable . ' as rs')
-                    ->where('rs.setting_name', '=', 'name')
-                    ->where('rs.setting_value', '=', $this->name);
-            });
-        });
-
-        if ($this->isActive !== null) {
-            $qb->where('r.is_active', '=', $this->isActive);
-        }
-
-        if ($this->ror !== null) {
-            $qb->where('r.ror', $this->ror);
-        }
-
-        if (!is_null($this->count)) {
-            $qb->limit($this->count);
-        }
-
-        if (!is_null($this->offset)) {
-            $qb->offset($this->offset);
-        }
+            })
+            ->when($this->name !== null, function (Builder $qb) {
+                $qb->whereIn('r.ror_id', function (Builder $qb) {
+                    $qb->select('rs.ror_id')
+                        ->from($this->dao->settingsTable . ' as rs')
+                        ->where('rs.setting_name', '=', 'name')
+                        ->where('rs.setting_value', '=', $this->name);
+                });
+            })
+            ->when($this->authorAffiliationIds !== null, function ($q) {
+                $q->whereIn('r.ror', DB::table('author_affiliations')->select(['ror'])->whereIn('author_affiliation_id', $this->authorAffiliationIds));
+            })
+            ->when($this->isActive !== null, fn ($q) => $q->where('r.is_active', $this->isActive))
+            ->when($this->ror !== null, fn ($q) => $q->where('r.ror', $this->ror))
+            ->when(!is_null($this->count), fn ($q) => $q->limit($this->count))
+            ->when(!is_null($this->offset), fn ($q) => $q->offset($this->offset));
 
         return $qb;
     }

--- a/classes/ror/DAO.php
+++ b/classes/ror/DAO.php
@@ -21,8 +21,8 @@ namespace PKP\ror;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\services\PKPSchemaService;
 
 /**
@@ -79,7 +79,7 @@ class DAO extends EntityDAO
         $row = DB::table($this->table)
             ->where($this->primaryKeyColumn, $id)
             ->first();
-        return $row ? $this->fromRow($row) : null;
+        return $row ? $this->fromRow($row, [$id], (object) []) : null;
     }
 
     /**
@@ -105,28 +105,10 @@ class DAO extends EntityDAO
             ->pluck('r.' . $this->primaryKeyColumn);
     }
 
-    /**
-     * Get a collection of rors matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->ror_id => $this->fromRow($row);
-            }
-        });
-    }
-
     /** @copydoc EntityDAO::fromRow() */
-    public function fromRow(object $row, ?callable $populator = null): Ror
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Ror
     {
-        return parent::fromRow($row, $populator);
+        return parent::fromRow($row, $ids, $cache, $query);
     }
 
     /** @copydoc EntityDAO::insert() */
@@ -172,7 +154,7 @@ class DAO extends EntityDAO
             ->where('ror', '=', $ror)
             ->first();
 
-        return $row ? $this->fromRow($row) : null;
+        return $row ? $this->fromRow($row, [$row->ror_id], (object) []) : null;
     }
 
     /**

--- a/classes/ror/DAO.php
+++ b/classes/ror/DAO.php
@@ -124,9 +124,9 @@ class DAO extends EntityDAO
     }
 
     /** @copydoc EntityDAO::fromRow() */
-    public function fromRow(object $row): Ror
+    public function fromRow(object $row, ?callable $populator = null): Ror
     {
-        return parent::fromRow($row);
+        return parent::fromRow($row, $populator);
     }
 
     /** @copydoc EntityDAO::insert() */

--- a/classes/search/engines/OpenSearchEngine.php
+++ b/classes/search/engines/OpenSearchEngine.php
@@ -127,7 +127,7 @@ class OpenSearchEngine extends ScoutEngine
             $funderNamesByLocale = [];
             $funderRors = [];
             $funderFilterKeys = [];
-            foreach (Funder::withSubmissionId($submission->getId())->orderBySeq()->get() as $funder) {
+            foreach ($submission->getData('funders') as $funder) {
                 $names = $funder->name;
                 if (is_array($names)) {
                     foreach ($names as $locale => $name) {

--- a/classes/section/DAO.php
+++ b/classes/section/DAO.php
@@ -21,7 +21,6 @@ namespace PKP\section;
 use APP\section\Section;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 use PKP\core\traits\EntityWithParent;
 
@@ -68,24 +67,6 @@ abstract class DAO extends EntityDAO
             ->getQueryBuilder()
             ->select($this->primaryKeyColumn)
             ->pluck($this->primaryKeyColumn);
-    }
-
-    /**
-     * Get a collection of sections matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->{$this->primaryKeyColumn} => $this->fromRow($row);
-            }
-        });
     }
 
     public function insert(Section $section): int

--- a/classes/submission/DAO.php
+++ b/classes/submission/DAO.php
@@ -204,9 +204,9 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): Submission
+    public function fromRow(object $row, ?callable $populator = null): Submission
     {
-        $submission = parent::fromRow($row);
+        $submission = parent::fromRow($row, $populator);
 
         $submission->setData(
             'publications',

--- a/classes/submission/DAO.php
+++ b/classes/submission/DAO.php
@@ -21,8 +21,8 @@ use APP\submission\Submission;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 use PKP\db\DAORegistry;
 use PKP\log\event\EventLogEntry;
@@ -107,24 +107,6 @@ class DAO extends EntityDAO
     }
 
     /**
-     * Get a collection of announcements matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->submission_id => $this->fromRow($row);
-            }
-        });
-    }
-
-    /**
      * Get the submission id by its url path
      */
     public function getIdByUrlPath(string $urlPath, int $contextId): ?int
@@ -204,9 +186,9 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row, ?callable $populator = null): Submission
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): Submission
     {
-        $submission = parent::fromRow($row, $populator);
+        $submission = parent::fromRow($row, $ids, $cache, $query);
 
         $submission->setData(
             'publications',

--- a/classes/submission/DAO.php
+++ b/classes/submission/DAO.php
@@ -21,10 +21,12 @@ use APP\submission\Submission;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 use PKP\core\interfaces\CollectorInterface;
 use PKP\core\traits\EntityWithParent;
 use PKP\db\DAORegistry;
+use PKP\funder\Funder;
 use PKP\log\event\EventLogEntry;
 use PKP\note\Note;
 use PKP\notification\Notification;
@@ -198,6 +200,14 @@ class DAO extends EntityDAO
                 ->getMany()
                 ->remember()
         );
+
+        $submission->setData('funders', LazyCollection::make(function () use ($row, $ids, $cache) {
+            $cache->funders ??= Funder::withSubmissionIds($ids)
+                ->orderBySeq()
+                ->get()
+                ->groupBy(fn ($funder) => $funder->submissionId);
+            yield from $cache->funders->get($row->submission_id) ?? [];
+        }));
 
         return $submission;
     }

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\user\Collector as UserCollector;
 
 /**
  * @template T of ReviewAssignment
@@ -140,40 +141,52 @@ class DAO extends EntityDAO
     public function getMany(Collector $query): LazyCollection
     {
         return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
+            $queryBuilder = $query->getQueryBuilder();
+            $settings = $reviewers = $doiObjects = null;
+
+            $rows = $queryBuilder->get();
+            $reviewIds = $rows->pluck('review_id')->all();
 
             foreach ($rows as $row) {
-                yield $row->review_id => $this->fromRow($row);
+                yield $row->review_id => $this->fromRow(
+                    $row,
+                    function (object $row, object $schema, ReviewAssignment $reviewAssignment) use ($reviewIds, &$settings, &$reviewers, &$doiObjects): void {
+                        $settings ??= DB::table('review_assignment_settings')
+                            ->whereIn('review_id', $reviewIds)
+                            ->get()
+                            ->groupBy('review_id');
+                        $settings->get($row->review_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $reviewAssignment, $schema));
+
+                        $reviewers ??= Repo::user()->getCollector()->filterByReviewIds($reviewIds)->filterByStatus(UserCollector::STATUS_ALL)->getMany();
+                        $reviewer = $reviewers->get($reviewAssignment->getReviewerId());
+                        $reviewAssignment->setData('reviewerFullName', $reviewer->getFullName());
+                        $reviewAssignment->setData('reviewerUserName', $reviewer->getUserName());
+
+                        $doiObjects ??= Repo::doi()->getCollector()->filterByReviewIds($reviewIds)->getMany();
+                        if ($doiId = $reviewAssignment->getData('doiId')) {
+                            $reviewAssignment->setData('doiObject', $doiObjects->get($doiId));
+                        }
+                    }
+                );
             }
         });
     }
 
-    /**
-     * @copydoc EntityDAO::fromRow()
-     */
-    public function fromRow(object $row, ?callable $populator = null): ReviewAssignment
+    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
     {
-        $reviewAssignment = parent::fromRow($row, $populator);
-        $reviewer = Repo::user()->get($reviewAssignment->getReviewerId(), true);
-        $reviewAssignment->setData(
-            'reviewerFullName',
-            $reviewer->getFullName()
-        );
-        $reviewAssignment->setData(
-            'reviewerUserName',
-            $reviewer->getUserName()
-        );
+        parent::individualPopulator($row, $schema, $object);
 
-        if (!empty($reviewAssignment->getData('doiId'))) {
-            $reviewAssignment->setData(
+        $reviewer = Repo::user()->get($object->getReviewerId(), true);
+        $object->setData('reviewerFullName', $reviewer->getFullName());
+        $object->setData('reviewerUserName', $reviewer->getUserName());
+
+        if (!empty($object->getData('doiId'))) {
+            $object->setData(
                 'doiObject',
-                Repo::doi()->get($reviewAssignment->getData('doiId'))
+                Repo::doi()->get($object->getData('doiId'))
             );
         }
-
-        return $reviewAssignment;
     }
 
     /**

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -153,9 +153,9 @@ class DAO extends EntityDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $row): ReviewAssignment
+    public function fromRow(object $row, ?callable $populator = null): ReviewAssignment
     {
-        $reviewAssignment = parent::fromRow($row);
+        $reviewAssignment = parent::fromRow($row, $populator);
         $reviewer = Repo::user()->get($reviewAssignment->getReviewerId(), true);
         $reviewAssignment->setData(
             'reviewerFullName',

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use PKP\core\EntityDAO;
 use PKP\core\interfaces\CollectorInterface;
+use PKP\core\traits\EntityWithParent;
 use PKP\user\Collector as UserCollector;
 
 /**
@@ -30,6 +31,8 @@ use PKP\user\Collector as UserCollector;
  */
 class DAO extends EntityDAO
 {
+    use EntityWithParent;
+
     /** @copydoc EntityDAO::$schema */
     public $schema = \PKP\services\PKPSchemaService::SCHEMA_REVIEW_ASSIGNMENT;
 
@@ -78,36 +81,19 @@ class DAO extends EntityDAO
 
     /** @copydoc EntityDAO::$settingsTable */
     public $settingsTable = 'review_assignment_settings';
+
+    public function getParentColumn(): string
+    {
+        return 'submission_id';
+    }
+
+
     /**
      * Instantiate a new DataObject
      */
     public function newDataObject(): ReviewAssignment
     {
         return app(ReviewAssignment::class);
-    }
-
-    /**
-     * Check if a review assignment exists
-     */
-    public function exists(int $id, ?int $submissionId): bool
-    {
-        return DB::table($this->table)
-            ->where($this->primaryKeyColumn, $id)
-            ->when($submissionId !== null, fn (Builder $query) => $query->where('submission_id', $submissionId))
-            ->exists();
-    }
-
-    /**
-     * Get a review assignment
-     */
-    public function get(int $id, ?int $submissionId = null): ?ReviewAssignment
-    {
-        $row = DB::table($this->table)
-            ->where($this->primaryKeyColumn, $id)
-            ->when($submissionId !== null, fn (Builder $query) => $query->where('submission_id', $submissionId))
-            ->first();
-
-        return $row ? $this->fromRow($row) : null;
     }
 
     /**

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -123,12 +123,16 @@ class DAO extends EntityDAO
     {
         $reviewAssignment = parent::fromRow($row, $ids, $cache, $query);
 
-        $cache->reviewers ??= Repo::user()->getCollector()->filterByReviewIds($ids)->filterByStatus(UserCollector::STATUS_ALL)->getMany();
+        $cache->reviewers ??= Repo::user()->getCollector()
+            ->filterByReviewIds($ids)->filterByStatus(UserCollector::STATUS_ALL)
+            ->getMany()->collect();
         $reviewer = $cache->reviewers->get($reviewAssignment->getReviewerId());
         $reviewAssignment->setData('reviewerFullName', $reviewer->getFullName());
         $reviewAssignment->setData('reviewerUserName', $reviewer->getUserName());
 
-        $cache->doiObjects ??= Repo::doi()->getCollector()->filterByReviewIds($ids)->getMany();
+        $cache->doiObjects ??= Repo::doi()->getCollector()
+            ->filterByReviewIds($ids)
+            ->getMany()->collect();
         if ($doiId = $reviewAssignment->getData('doiId')) {
             $reviewAssignment->setData('doiObject', $cache->doiObjects->get($doiId));
         }

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -19,7 +19,6 @@ use APP\publication\Publication;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
 use PKP\user\Collector as UserCollector;
 
@@ -133,55 +132,19 @@ class DAO extends EntityDAO
             ->pluck('ra.' . $this->primaryKeyColumn);
     }
 
-    protected function batchPopulator(object $row, object $schema, ReviewAssignment $reviewAssignment, array $reviewIds, object $cache): void
+    protected function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
     {
-        $cache->settings ??= DB::table('review_assignment_settings')
-            ->whereIn('review_id', $reviewIds)
-            ->get()
-            ->groupBy('review_id');
-        $cache->settings->get($row->review_id)
-            ?->each(fn ($row) => $this->populateSetting($row, $reviewAssignment, $schema));
+        parent::populate($row, $schema, $object, $ids, $cache);
 
-        $cache->reviewers ??= Repo::user()->getCollector()->filterByReviewIds($reviewIds)->filterByStatus(UserCollector::STATUS_ALL)->getMany();
-        $reviewer = $cache->reviewers->get($reviewAssignment->getReviewerId());
-        $reviewAssignment->setData('reviewerFullName', $reviewer->getFullName());
-        $reviewAssignment->setData('reviewerUserName', $reviewer->getUserName());
+        $cache->reviewers ??= Repo::user()->getCollector()->filterByReviewIds($ids)->filterByStatus(UserCollector::STATUS_ALL)->getMany();
+        $reviewer = $cache->reviewers->get($object->getReviewerId());
+        $object->setData('reviewerFullName', $reviewer->getFullName());
+        $object->setData('reviewerUserName', $reviewer->getUserName());
 
-        $cache->doiObjects ??= Repo::doi()->getCollector()->filterByReviewIds($reviewIds)->getMany();
-        if ($doiId = $reviewAssignment->getData('doiId')) {
-            $reviewAssignment->setData('doiObject', $cache->doiObjects->get($doiId));
+        $cache->doiObjects ??= Repo::doi()->getCollector()->filterByReviewIds($ids)->getMany();
+        if ($doiId = $object->getData('doiId')) {
+            $object->setData('doiObject', $cache->doiObjects->get($doiId));
         }
-    }
-
-    /**
-     * Get a collection of review assignments matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $queryBuilder = $query->getQueryBuilder();
-
-            $rows = $queryBuilder->get();
-            $reviewIds = $rows->pluck('review_id')->all();
-
-            $cache = (object) [];
-
-            foreach ($rows as $row) {
-                yield $row->review_id => $this->fromRow(
-                    $row,
-                    function (object $row, object $schema, ReviewAssignment $reviewAssignment) use ($reviewIds, $cache): void {
-                        $this->batchPopulator($row, $schema, $reviewAssignment, $reviewIds, $cache);
-                    }
-                );
-            }
-        });
-    }
-
-    protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
-    {
-        $this->batchPopulator($row, $schema, $object, [$row->review_id], (object) []);
     }
 
     /**

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -133,6 +133,26 @@ class DAO extends EntityDAO
             ->pluck('ra.' . $this->primaryKeyColumn);
     }
 
+    protected function batchPopulator(object $row, object $schema, ReviewAssignment $reviewAssignment, array $reviewIds, object $cache): void
+    {
+        $cache->settings ??= DB::table('review_assignment_settings')
+            ->whereIn('review_id', $reviewIds)
+            ->get()
+            ->groupBy('review_id');
+        $cache->settings->get($row->review_id)
+            ?->each(fn ($row) => $this->populateSetting($row, $reviewAssignment, $schema));
+
+        $cache->reviewers ??= Repo::user()->getCollector()->filterByReviewIds($reviewIds)->filterByStatus(UserCollector::STATUS_ALL)->getMany();
+        $reviewer = $cache->reviewers->get($reviewAssignment->getReviewerId());
+        $reviewAssignment->setData('reviewerFullName', $reviewer->getFullName());
+        $reviewAssignment->setData('reviewerUserName', $reviewer->getUserName());
+
+        $cache->doiObjects ??= Repo::doi()->getCollector()->filterByReviewIds($reviewIds)->getMany();
+        if ($doiId = $reviewAssignment->getData('doiId')) {
+            $reviewAssignment->setData('doiObject', $cache->doiObjects->get($doiId));
+        }
+    }
+
     /**
      * Get a collection of review assignments matching the configured query
      *
@@ -142,31 +162,17 @@ class DAO extends EntityDAO
     {
         return LazyCollection::make(function () use ($query) {
             $queryBuilder = $query->getQueryBuilder();
-            $settings = $reviewers = $doiObjects = null;
 
             $rows = $queryBuilder->get();
             $reviewIds = $rows->pluck('review_id')->all();
 
+            $cache = (object) [];
+
             foreach ($rows as $row) {
                 yield $row->review_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, ReviewAssignment $reviewAssignment) use ($reviewIds, &$settings, &$reviewers, &$doiObjects): void {
-                        $settings ??= DB::table('review_assignment_settings')
-                            ->whereIn('review_id', $reviewIds)
-                            ->get()
-                            ->groupBy('review_id');
-                        $settings->get($row->review_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $reviewAssignment, $schema));
-
-                        $reviewers ??= Repo::user()->getCollector()->filterByReviewIds($reviewIds)->filterByStatus(UserCollector::STATUS_ALL)->getMany();
-                        $reviewer = $reviewers->get($reviewAssignment->getReviewerId());
-                        $reviewAssignment->setData('reviewerFullName', $reviewer->getFullName());
-                        $reviewAssignment->setData('reviewerUserName', $reviewer->getUserName());
-
-                        $doiObjects ??= Repo::doi()->getCollector()->filterByReviewIds($reviewIds)->getMany();
-                        if ($doiId = $reviewAssignment->getData('doiId')) {
-                            $reviewAssignment->setData('doiObject', $doiObjects->get($doiId));
-                        }
+                    function (object $row, object $schema, ReviewAssignment $reviewAssignment) use ($reviewIds, $cache): void {
+                        $this->batchPopulator($row, $schema, $reviewAssignment, $reviewIds, $cache);
                     }
                 );
             }
@@ -175,18 +181,7 @@ class DAO extends EntityDAO
 
     protected function individualPopulator(object $row, object $schema, \PKP\core\DataObject $object): void
     {
-        parent::individualPopulator($row, $schema, $object);
-
-        $reviewer = Repo::user()->get($object->getReviewerId(), true);
-        $object->setData('reviewerFullName', $reviewer->getFullName());
-        $object->setData('reviewerUserName', $reviewer->getUserName());
-
-        if (!empty($object->getData('doiId'))) {
-            $object->setData(
-                'doiObject',
-                Repo::doi()->get($object->getData('doiId'))
-            );
-        }
+        $this->batchPopulator($row, $schema, $object, [$row->review_id], (object) []);
     }
 
     /**

--- a/classes/submission/reviewAssignment/DAO.php
+++ b/classes/submission/reviewAssignment/DAO.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\user\Collector as UserCollector;
 
 /**
@@ -132,19 +133,21 @@ class DAO extends EntityDAO
             ->pluck('ra.' . $this->primaryKeyColumn);
     }
 
-    protected function populate(object $row, object $schema, \PKP\core\DataObject $object, array $ids, object $cache): void
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): ReviewAssignment
     {
-        parent::populate($row, $schema, $object, $ids, $cache);
+        $reviewAssignment = parent::fromRow($row, $ids, $cache, $query);
 
         $cache->reviewers ??= Repo::user()->getCollector()->filterByReviewIds($ids)->filterByStatus(UserCollector::STATUS_ALL)->getMany();
-        $reviewer = $cache->reviewers->get($object->getReviewerId());
-        $object->setData('reviewerFullName', $reviewer->getFullName());
-        $object->setData('reviewerUserName', $reviewer->getUserName());
+        $reviewer = $cache->reviewers->get($reviewAssignment->getReviewerId());
+        $reviewAssignment->setData('reviewerFullName', $reviewer->getFullName());
+        $reviewAssignment->setData('reviewerUserName', $reviewer->getUserName());
 
         $cache->doiObjects ??= Repo::doi()->getCollector()->filterByReviewIds($ids)->getMany();
-        if ($doiId = $object->getData('doiId')) {
-            $object->setData('doiObject', $cache->doiObjects->get($doiId));
+        if ($doiId = $reviewAssignment->getData('doiId')) {
+            $reviewAssignment->setData('doiObject', $cache->doiObjects->get($doiId));
         }
+
+        return $reviewAssignment;
     }
 
     /**

--- a/classes/submission/reviewRound/authorResponse/AuthorResponse.php
+++ b/classes/submission/reviewRound/authorResponse/AuthorResponse.php
@@ -149,7 +149,10 @@ class AuthorResponse extends Model
                     ->pluck('author_id')
                     ->all();
 
-                return array_map(fn ($authorId) => Repo::Author()->get($authorId), $authorIds);
+                return Repo::author()->getCollector()
+                    ->filterByAuthorIds($authorIds)
+                    ->getMany()
+                    ->toArray();
             }
         )->shouldCache();
     }

--- a/classes/submissionFile/DAO.php
+++ b/classes/submissionFile/DAO.php
@@ -162,9 +162,9 @@ class DAO extends EntityDAO implements PKPPubIdPluginDAO
     /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $primaryRow): SubmissionFile
+    public function fromRow(object $primaryRow, ?callable $populator = null): SubmissionFile
     {
-        $submissionFile = parent::fromRow($primaryRow);
+        $submissionFile = parent::fromRow($primaryRow, $populator);
         $submissionFile->setData('submissionLocale', $primaryRow->submission_locale);
         $submissionFile->setData('path', $primaryRow->path);
         $submissionFile->setData('mimetype', $primaryRow->mimetype);

--- a/classes/submissionFile/DAO.php
+++ b/classes/submissionFile/DAO.php
@@ -24,8 +24,8 @@ use Exception;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\LazyCollection;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\db\DAORegistry;
 use PKP\plugins\PKPPubIdPluginDAO;
 use PKP\services\PKPSchemaService;
@@ -101,7 +101,7 @@ class DAO extends EntityDAO implements PKPPubIdPluginDAO
             ->when($submissionId !== null, fn (Builder $query) => $query->where('sf.submission_id', $submissionId))
             ->first();
 
-        return $row ? $this->fromRow($row) : null;
+        return $row ? $this->fromRow($row, [$id], (object) []) : null;
     }
 
     /**
@@ -142,29 +142,11 @@ class DAO extends EntityDAO implements PKPPubIdPluginDAO
     }
 
     /**
-     * Get a collection of announcements matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $rows = $query
-                ->getQueryBuilder()
-                ->get();
-
-            foreach ($rows as $row) {
-                yield $row->submission_file_id => $this->fromRow($row);
-            }
-        });
-    }
-
-    /**
      * @copydoc EntityDAO::fromRow()
      */
-    public function fromRow(object $primaryRow, ?callable $populator = null): SubmissionFile
+    public function fromRow(object $primaryRow, array $ids, object $cache, ?CollectorInterface $query = null): SubmissionFile
     {
-        $submissionFile = parent::fromRow($primaryRow, $populator);
+        $submissionFile = parent::fromRow($primaryRow, $ids, $cache, $query);
         $submissionFile->setData('submissionLocale', $primaryRow->submission_locale);
         $submissionFile->setData('path', $primaryRow->path);
         $submissionFile->setData('mimetype', $primaryRow->mimetype);

--- a/classes/user/Collector.php
+++ b/classes/user/Collector.php
@@ -59,6 +59,7 @@ class Collector implements CollectorInterface
     public ?array $userGroupIds = null;
     public ?array $roleIds = null;
     public ?array $userIds = null;
+    public ?array $reviewIds = null;
     public ?array $excludeUserIds = null;
     public ?array $workflowStageIds = null;
     public ?array $contextIds = null;
@@ -138,6 +139,15 @@ class Collector implements CollectorInterface
     public function filterByUserIds(?array $userIds): self
     {
         $this->userIds = $userIds;
+        return $this;
+    }
+
+    /**
+     * Filter by assigned review assignment IDs
+     */
+    public function filterByReviewIds(?array $reviewIds): self
+    {
+        $this->reviewIds = $reviewIds;
         return $this;
     }
 
@@ -441,6 +451,8 @@ class Collector implements CollectorInterface
             // Filters by user ID
             ->when($this->userIds !== null, fn (Builder $query) => $query->whereIn('u.user_id', $this->userIds))
             ->when($this->excludeUserIds !== null, fn (Builder $query) => $query->whereNotIn('u.user_id', $this->excludeUserIds))
+            // Filters by assigned reviews
+            ->when($this->reviewIds !== null, fn (Builder $query) => $query->join('review_assignments AS ra', 'ra.reviewer_id', 'u.user_id')->whereIn('ra.review_id', $this->reviewIds))
             // User enabled/disabled state
             ->when($this->status !== self::STATUS_ALL, fn (Builder $query) => $query->where('u.disabled', '=', $this->status === self::STATUS_DISABLED))
             // Adds limit and offset for pagination
@@ -827,7 +839,7 @@ class Collector implements CollectorInterface
             }
 
             $query->orderByRaw(sprintf('CONCAT(%s) %s', implode(', ', $coalesceExpressions), $this->orderDirection));
-            
+
         }
         return $this;
     }

--- a/classes/user/DAO.php
+++ b/classes/user/DAO.php
@@ -132,7 +132,7 @@ class DAO extends EntityDAO
             }
 
             foreach ($rows as $row) {
-                yield $row->user_id => $this->fromRow($row, $query->includeReviewerData);
+                yield $row->user_id => $this->fromRow($row, includeReviewerData: $query->includeReviewerData);
             }
         });
     }
@@ -249,9 +249,9 @@ class DAO extends EntityDAO
      * @copydoc EntityDAO::fromRow
      *
      */
-    public function fromRow(object $row, bool $includeReviewerData = false): DataObject
+    public function fromRow(object $row, ?callable $populator = null, bool $includeReviewerData = false): DataObject
     {
-        $user = parent::fromRow($row);
+        $user = parent::fromRow($row, $populator);
         if ($includeReviewerData) {
             $user->setData('lastAssigned', $row->last_assigned);
             $user->setData('incompleteCount', (int) $row->incomplete_count);

--- a/classes/user/DAO.php
+++ b/classes/user/DAO.php
@@ -127,20 +127,21 @@ class DAO extends EntityDAO
     {
         return LazyCollection::make(function () use ($query) {
             $queryBuilder = $query->getQueryBuilder();
-            $settings = null;
 
             $rows = $queryBuilder->get();
             $userIds = $rows->pluck('user_id')->all();
 
+            $cache = (object) [];
+
             foreach ($rows as $row) {
                 yield $row->user_id => $this->fromRow(
                     $row,
-                    function (object $row, object $schema, User $user) use ($userIds, &$settings): void {
-                        $settings ??= DB::table('user_settings')
+                    function (object $row, object $schema, User $user) use ($userIds, $cache): void {
+                        $cache->settings ??= DB::table('user_settings')
                             ->whereIn('user_id', $userIds)
                             ->get()
                             ->groupBy('user_id');
-                        $settings->get($row->user_id)
+                        $cache->settings->get($row->user_id)
                             ?->each(fn ($row) => $this->populateSetting($row, $user, $schema));
                     },
                     includeReviewerData: $query->includeReviewerData

--- a/classes/user/DAO.php
+++ b/classes/user/DAO.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use PKP\core\DataObject;
 use PKP\core\EntityDAO;
+use PKP\core\interfaces\CollectorInterface;
 use PKP\identity\Identity;
 use PKP\security\Role;
 
@@ -101,7 +102,7 @@ class DAO extends EntityDAO
             ->where($this->primaryKeyColumn, $id)
             ->first();
         /** @var User $user */
-        $user = $row ? $this->fromRow($row) : null;
+        $user = $row ? $this->fromRow($row, [$id], (object) []) : null;
         if (!$allowDisabled && $user?->getDisabled()) {
             return null;
         }
@@ -116,38 +117,6 @@ class DAO extends EntityDAO
         return DB::table($this->table)
             ->where($this->primaryKeyColumn, '=', $id)
             ->exists();
-    }
-
-    /**
-     * Get a collection of users matching the configured query
-     *
-     * @return LazyCollection<int,T>
-     */
-    public function getMany(Collector $query): LazyCollection
-    {
-        return LazyCollection::make(function () use ($query) {
-            $queryBuilder = $query->getQueryBuilder();
-
-            $rows = $queryBuilder->get();
-            $userIds = $rows->pluck('user_id')->all();
-
-            $cache = (object) [];
-
-            foreach ($rows as $row) {
-                yield $row->user_id => $this->fromRow(
-                    $row,
-                    function (object $row, object $schema, User $user) use ($userIds, $cache): void {
-                        $cache->settings ??= DB::table('user_settings')
-                            ->whereIn('user_id', $userIds)
-                            ->get()
-                            ->groupBy('user_id');
-                        $cache->settings->get($row->user_id)
-                            ?->each(fn ($row) => $this->populateSetting($row, $user, $schema));
-                    },
-                    includeReviewerData: $query->includeReviewerData
-                );
-            }
-        });
     }
 
     /**
@@ -262,10 +231,10 @@ class DAO extends EntityDAO
      * @copydoc EntityDAO::fromRow
      *
      */
-    public function fromRow(object $row, ?callable $populator = null, bool $includeReviewerData = false): DataObject
+    public function fromRow(object $row, array $ids, object $cache, ?CollectorInterface $query = null): DataObject
     {
-        $user = parent::fromRow($row, $populator);
-        if ($includeReviewerData) {
+        $user = parent::fromRow($row, $ids, $cache, $query);
+        if ($query?->includeReviewerData) {
             $user->setData('lastAssigned', $row->last_assigned);
             $user->setData('incompleteCount', (int) $row->incomplete_count);
             $user->setData('completeCount', (int) $row->complete_count);
@@ -390,7 +359,7 @@ class DAO extends EntityDAO
                     ->get();
             }
             foreach ($rows as $row) {
-                yield $row->user_id => $this->fromRow($row);
+                yield $row->user_id => $this->fromRow($row, [$row->user_id], (object) []);
             }
         });
     }

--- a/classes/user/DAO.php
+++ b/classes/user/DAO.php
@@ -126,13 +126,25 @@ class DAO extends EntityDAO
     public function getMany(Collector $query): LazyCollection
     {
         return LazyCollection::make(function () use ($query) {
-            $rows = $query->getQueryBuilder()->get();
-            if ($rows->isEmpty()) {
-                return;
-            }
+            $queryBuilder = $query->getQueryBuilder();
+            $settings = null;
+
+            $rows = $queryBuilder->get();
+            $userIds = $rows->pluck('user_id')->all();
 
             foreach ($rows as $row) {
-                yield $row->user_id => $this->fromRow($row, includeReviewerData: $query->includeReviewerData);
+                yield $row->user_id => $this->fromRow(
+                    $row,
+                    function (object $row, object $schema, User $user) use ($userIds, &$settings): void {
+                        $settings ??= DB::table('user_settings')
+                            ->whereIn('user_id', $userIds)
+                            ->get()
+                            ->groupBy('user_id');
+                        $settings->get($row->user_id)
+                            ?->each(fn ($row) => $this->populateSetting($row, $user, $schema));
+                    },
+                    includeReviewerData: $query->includeReviewerData
+                );
             }
         });
     }

--- a/classes/validation/ValidatorFactory.php
+++ b/classes/validation/ValidatorFactory.php
@@ -211,7 +211,7 @@ class ValidatorFactory
                         }
                     }
                 } else {
-                    if (is_null($object) && self::isEmpty($props[$requiredProp]) ||
+                    if (is_null($object) && self::isEmpty($props[$requiredProp] ?? null) ||
                             ($object && array_key_exists($requiredProp, $props) && self::isEmpty($props[$requiredProp]))) {
                         $validator->errors()->add($requiredProp, __('validator.required'));
                     }

--- a/controllers/grid/users/reviewer/form/AdvancedSearchReviewerForm.php
+++ b/controllers/grid/users/reviewer/form/AdvancedSearchReviewerForm.php
@@ -34,9 +34,9 @@ use PKP\mail\mailables\ReviewRequestSubsequent;
 use PKP\security\Role;
 use PKP\stageAssignment\StageAssignment;
 use PKP\submission\reviewAssignment\ReviewAssignment;
+use PKP\submission\reviewer\suggestion\ReviewerSuggestion;
 use PKP\submission\reviewRound\ReviewRound;
 use PKP\submission\reviewRound\ReviewRoundDAO;
-use PKP\submission\reviewer\suggestion\ReviewerSuggestion;
 
 class AdvancedSearchReviewerForm extends ReviewerForm
 {
@@ -87,7 +87,7 @@ class AdvancedSearchReviewerForm extends ReviewerForm
                 ReviewRequestSubsequent::getEmailTemplateKey()
             ])
             ->getMany()
-            ->mapWithKeys(function (EmailTemplate $item, int $key) use ($mailable) {
+            ->mapWithKeys(function (EmailTemplate $item, ?int $key) use ($mailable) {
                 return [$item->getData('key') => Mail::compileParams($item->getLocalizedData('body'), $mailable->viewData)];
             });
 

--- a/cypress/tests/integration/publicComents/PublicComments.cy.js
+++ b/cypress/tests/integration/publicComents/PublicComments.cy.js
@@ -30,7 +30,7 @@ describe('Public Comments Tests', function() {
 	it('should enable public commenting', () => {
 		cy.login('rvaca');
 
-		cy.visit('http://localhost:8000/index.php/publicknowledge/en/management/settings/website#content');
+		cy.visit('/index.php/publicknowledge/en/management/settings/website#content');
 		cy.get('[role="tab"]').contains('Comments').click();
 		cy.get('[name="enablePublicComments"]').check();
 		cy.get('button:visible').contains('Save').click();
@@ -45,7 +45,7 @@ describe('Public Comments Tests', function() {
 
 		usersToComment.forEach((user, index) => {
 			cy.login(user);
-			cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+			cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 			cy.contains('Version of Record 1.0')
 				.parent();
@@ -67,7 +67,7 @@ describe('Public Comments Tests', function() {
 	it('should allow moderator to approve a comment', () => {
 		cy.login('rvaca');
 		const commentText = `${testCommentText} - 3`;
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments#needsApproval');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments#needsApproval');
 
 		cy.contains('tr', commentText).should('contain.text', 'Hidden/Needs Approval');
 		openComment(commentText);
@@ -82,7 +82,7 @@ describe('Public Comments Tests', function() {
 	});
 
 	it('should allow unauthenticated users to view comments', () => {
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('Version of Record 1.0')
 			.parent()
@@ -92,7 +92,7 @@ describe('Public Comments Tests', function() {
 
 	it('should allow authenticated users to view comments', () => {
 		cy.login('eostrom');
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('Version of Record 1.0')
 			.parent()
@@ -102,7 +102,7 @@ describe('Public Comments Tests', function() {
 
 	it('should allow authenticated user to report a comment', () => {
 		cy.login('eostrom');
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('Version of Record 1.0')
 			.parent()
@@ -131,7 +131,7 @@ describe('Public Comments Tests', function() {
 
 	it('should not allow user to report their own comment', () => {
 		cy.login('jnovak');
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('Version of Record 1.0')
 			.parent()
@@ -145,7 +145,7 @@ describe('Public Comments Tests', function() {
 	});
 
 	it('should not allow unauthenticated user to delete or report comment', () => {
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('Version of Record 1.0')
 			.parent()
@@ -158,7 +158,7 @@ describe('Public Comments Tests', function() {
 
 	it('should not allow authenticated user to see delete option on comment they did not create', () => {
 		cy.login('jnovak');
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('Version of Record 1.0')
 			.parent()
@@ -173,7 +173,7 @@ describe('Public Comments Tests', function() {
 
 	it('should allow authenticated user to delete their own comment', () => {
 		cy.login('jnovak');
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('Version of Record 1.0')
 			.parent()
@@ -192,7 +192,7 @@ describe('Public Comments Tests', function() {
 	});
 
 	it('should allow the user to click the \'All comments\' button, which takes them to the section of the page that has the comments.', () => {
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		let rect = null;
 		let isInViewport = false;
@@ -227,7 +227,7 @@ describe('Public Comments Tests', function() {
 	});
 
 	it('should bring unauthenticated user through login flow before seeing comment form', () => {
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 		cy.get('.PkpCommentsNewInput textarea').should('not.exist');
 
 		cy.contains('.PkpScrollToCommentsLogInto', 'Log in to comment').click();
@@ -241,7 +241,7 @@ describe('Public Comments Tests', function() {
 
 	it('should allow moderator to view a comment', () => {
 		cy.login('rvaca');
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments');
 		const commentText = `${testCommentText} - 3`;
 
 		cy.contains('tr', commentText).should('exist');
@@ -267,7 +267,7 @@ describe('Public Comments Tests', function() {
 	it('should allow moderator to view reports for a comment', () => {
 		cy.login('rvaca');
 		const commentText = `${testCommentText} - 3`;
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments');
 
 		cy.contains('tr', commentText).should('exist');
 
@@ -298,7 +298,7 @@ describe('Public Comments Tests', function() {
 	it('should show only reported comments when moderator views comments under Reported tab', () => {
 		cy.login('rvaca');
 
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments#reported');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments#reported');
 
 		cy.contains('Loading', { timeout: 20000 }).should('not.exist');
 		cy.get('table tbody tr')
@@ -310,7 +310,7 @@ describe('Public Comments Tests', function() {
 
 	it('should show only approved comments when moderator views comments under Approved tab', () => {
 		cy.login('rvaca');
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments#approved');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments#approved');
 		
 		cy.contains('Loading', { timeout: 20000 }).should('not.exist');
 		cy.get('table tbody tr')
@@ -322,7 +322,7 @@ describe('Public Comments Tests', function() {
 
 	it('should show only unapproved comments when moderator views comments under Needs Approval tab', () => {
 		cy.login('rvaca');
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments#needsApproval');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments#needsApproval');
 
 		cy.contains('Loading', { timeout: 20000 }).should('not.exist');
 		cy.get('table tbody tr')
@@ -335,7 +335,7 @@ describe('Public Comments Tests', function() {
 	it('should allow moderator to delete report via side modal', () => {
 		cy.login('rvaca');
 		const commentText = `${testCommentText} - 3`;
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments');
 
 		openComment(commentText);
 		cy.wait(500);
@@ -363,7 +363,7 @@ describe('Public Comments Tests', function() {
 
 		//First have a user report the comment
 		cy.login('eostrom');
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 
 		cy.contains('a', 'All Comments').click();
 
@@ -390,7 +390,7 @@ describe('Public Comments Tests', function() {
 
 		// Then login as moderator and delete the report
 		cy.login('rvaca');
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments');
 
 		openComment(commentText);
 
@@ -414,7 +414,7 @@ describe('Public Comments Tests', function() {
 
 	it('should allow moderator to hide a comment', () => {
 		cy.login('rvaca');
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments#approved');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments#approved');
 		const commentText = `${testCommentText} - 3`;
 		cy.contains('tr', commentText).should('exist');
 
@@ -440,7 +440,7 @@ describe('Public Comments Tests', function() {
 
 	it('should allow moderator to delete comment via table row actions', () => {
 		cy.login('rvaca');
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments');
 
 		cy.contains('tr', `${testCommentText} - 3`).should('exist');
 
@@ -461,7 +461,7 @@ describe('Public Comments Tests', function() {
 	it('should allow moderator to delete a comment via side modal', () => {
 		cy.login('rvaca');
 		const commentText = `${testCommentText} - 2`;
-		cy.visit('index.php/publicknowledge/en/management/settings/userComments');
+		cy.visit('/index.php/publicknowledge/en/management/settings/userComments');
 
 		cy.contains('tr', commentText).should('exist');
 		openComment(commentText);
@@ -493,7 +493,7 @@ describe('Public Comments Tests', function() {
 		cy.get('.pkpWorkflow__publishModal button').contains('Publish').click();
 
 		// Navigate to publication and check that previous version has 'closed discussion' note, and does not have comment form
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 		cy.contains('a', 'All Comments').click();
 
 		cy.contains('div[role="region"]', 'Discussion is closed on this version, please comment on the latest version above.')
@@ -533,7 +533,7 @@ describe('Public Comments Tests', function() {
 	it('should disable public commenting', () => {
 		cy.login('rvaca');
 
-		cy.visit('http://localhost:8000/index.php/publicknowledge/en/management/settings/website#content');
+		cy.visit('/index.php/publicknowledge/en/management/settings/website#content');
 		cy.get('[role="tab"]').contains('Comments').click();
 		cy.get('[name="enablePublicComments"]').uncheck();
 		cy.get('button:visible').contains('Save').click();
@@ -541,7 +541,7 @@ describe('Public Comments Tests', function() {
 		cy.wait(500)
 
 		// Verify that the comment area does not exist
-		cy.visit('index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
+		cy.visit('/index.php/publicknowledge/en/article/view/mwandenga-signalling-theory');
 		cy.get('#pkpUserCommentsContainer').should('not.exist');
 		cy.contains('Comment on this publication').should('not.exist');
 	});

--- a/cypress/tests/integration/publicComments/PublicComments.cy.js
+++ b/cypress/tests/integration/publicComments/PublicComments.cy.js
@@ -1,5 +1,5 @@
 /**
- * @file cypress/tests/integration/publicComents/PublicComments.cy.js
+ * @file cypress/tests/integration/publicComments/PublicComments.cy.js
  *
  * copyright (c) 2025 Simon Fraser University
  * Copyright (c) 2025 John Willinsky

--- a/jobs/doi/DepositSubmission.php
+++ b/jobs/doi/DepositSubmission.php
@@ -67,7 +67,7 @@ class DepositSubmission extends BaseJob
 
         // Deposit Submission's associated Peer Review if Peer Review DOIs are enabled in Context and Agency, and the Submission was successfully deposited.
         if (
-            !$submissionDepositResults['hasErrors'] &&
+            empty($submissionDepositResults['hasErrors']) &&
             in_array(Repo::doi()::TYPE_PEER_REVIEW, $this->agency->getAllowedDoiTypes()) &&
             in_array(Repo::doi()::TYPE_PEER_REVIEW, $this->context->getData(Context::SETTING_ENABLED_DOI_TYPES))
         ) {

--- a/jobs/orcid/SendAuthorMail.php
+++ b/jobs/orcid/SendAuthorMail.php
@@ -34,6 +34,10 @@ class SendAuthorMail extends BaseJob implements ShouldBeUnique
         /** @var bool $updateAuthor If true, update the author fields in the database. Use only if not called from a function, which will already update the author. */
         private bool $updateAuthor = false
     ) {
+        // Convert LazyCollections to Collections for serialization
+        $author->setData('affiliations', $author->getData('affiliations')->collect());
+        $author->setContributorRoles($author->getContributorRoles()->collect());
+        $author->setCreditRoles($author->getCreditRoles()->collect());
     }
 
     /**

--- a/tests/jobs/submissions/UpdateSubmissionSearchJobTest.php
+++ b/tests/jobs/submissions/UpdateSubmissionSearchJobTest.php
@@ -48,8 +48,11 @@ class UpdateSubmissionSearchJobTest extends PKPTestCase
         /** @var UpdateSubmissionSearchJob $updateSubmissionSearchJob */
         $updateSubmissionSearchJob = unserialize($this->serializedJobData);
 
+        $fakePublication = new \APP\publication\Publication();
+        $fakePublication->setData('authors', collect());
+
         $fakeSubmission = new \APP\submission\Submission();
-        $fakeSubmission->setData('publications', collect([new \APP\publication\Publication()]));
+        $fakeSubmission->setData('publications', collect([$fakePublication]));
 
         // Mock the Submission facade to return a fake submission when Repo::submission()->get($id) is called
         $mock = Mockery::mock(app(\APP\submission\Repository::class))


### PR DESCRIPTION
Add support for batch loading using `getMany` to resolve N+1 query issues.

Strategy:
- Built support for `fromRow` to have a cache that persists for the duration of a batch load (e.g. a fetch via `getMany` )
- Centralized `getMany` into `EntityDAO` and removed it from all the subclasses (except for the user DAO, where there's a slight extension to conditionally fetch reviewer data based on the collector configuration)
- ~~Add support in the `fromRow` function for callers to (optionally) specify a "populator" callable, which is used to specify different strategies for populating an object:~~
  - ~~Entities can extend `fromRow` (as always) to add elements for any strategy (e.g. the submission locale in `lib/pkp/classes/publication/DAO.php`)~~
  - ~~Entities can extend `individualPopulator` (the default) to add elements that will be executed for each fetch (as before)~~
  - ~~Entities can implement and specify a closure (e.g. in `getMany` in the examples in this PR) allowing a set to be loaded once per `getMany` call and used as needed by `fromRow`.~~
- Minor optimization: remove extra query to get submission locale when fetching publication https://github.com/pkp/pkp-lib/pull/13179/changes/a4ceac020eb736306e454c158b5e04491f2cfe49
- Generalize a few fetch functions that previously only accepted a single ID to accept an array instead (to avoid having to double up the getter functions). Example: `filterByAuthorIds` in `classes/affiliation/Collector.php`
- Removed some unnecessary code duplication in `classes/log/event/DAO.php`
- Some rewriting of `getQueryBuilder` in `classes/ror/Collector.php` and `classes/citation/Collector.php` to use Conditionables