### PR TITLE
pkp/dev-team#322 [Edtiorial UI] | Review UI - "Author Response" button leads to page without an email form

### DIFF
--- a/classes/components/RequestReviewResponsePage.php
+++ b/classes/components/RequestReviewResponsePage.php
@@ -180,13 +180,14 @@ class RequestReviewResponsePage
      */
     private function getLocales(): array
     {
-        return array_map(
+        // Re-index so the locales encode as a JSON array, not an object
+        return array_values(array_map(
             fn ($locale) => [
                 'locale' => $locale,
                 'name' => Locale::getMetadata($locale)->getDisplayName(),
             ],
             $this->locales,
-        );
+        ));
     }
 
 

--- a/controllers/grid/admin/languages/AdminLanguageGridHandler.php
+++ b/controllers/grid/admin/languages/AdminLanguageGridHandler.php
@@ -241,10 +241,10 @@ class AdminLanguageGridHandler extends LanguageGridHandler
 
             $installedLocales = $site->getInstalledLocales();
             if (in_array($locale, $installedLocales)) {
-                $installedLocales = array_diff($installedLocales, [$locale]);
+                $installedLocales = array_values(array_diff($installedLocales, [$locale]));
                 $site->setInstalledLocales($installedLocales);
                 $supportedLocales = $site->getSupportedLocales();
-                $supportedLocales = array_diff($supportedLocales, [$locale]);
+                $supportedLocales = array_values(array_diff($supportedLocales, [$locale]));
                 $site->setSupportedLocales($supportedLocales);
                 $siteDao = DAORegistry::getDAO('SiteDAO'); /** @var SiteDAO $siteDao */
                 $siteDao->updateObject($site);
@@ -404,7 +404,7 @@ class AdminLanguageGridHandler extends LanguageGridHandler
         }
 
         $site = $request->getSite();
-        $site->setSupportedLocales($newSupportedLocales);
+        $site->setSupportedLocales(array_values($newSupportedLocales));
 
         $siteDao = DAORegistry::getDAO('SiteDAO'); /** @var SiteDAO $siteDao */
         $siteDao->updateObject($site);
@@ -434,7 +434,8 @@ class AdminLanguageGridHandler extends LanguageGridHandler
                 $localeList = $context->getData($settingName);
 
                 if (is_array($localeList)) {
-                    $params[$settingName] = array_intersect($localeList, $siteSupportedLocales);
+                    // array_intersect() preserves keys, so re-index to keep this a JSON array
+                    $params[$settingName] = array_values(array_intersect($localeList, $siteSupportedLocales));
                 }
             }
             if (!in_array($primaryLocale, $siteSupportedLocales)) {


### PR DESCRIPTION
Request Author Response fails to load when a journal's `supportedLocales` is stored as a JSON object (`{"1":"en"}`) instead of an array. The composer gets locales as an object, so `this.locales.filter()` throws an error.

The reason why `supportedLocales` can sometimes be stored as a JSON object instead of an array of strings is because of disabling/removing a locale site-wide that is still used by a journal. Removing a locale at the site level filters the remaining locales using `array_diff()` / `array_intersect()` / `unset()`, which preserve the keys. That's why the indexes end up being stored as keys in a JSON object.

Using `array_values()` around the values will reset the indexes and ensure it's stored as an array of strings.