### PR TITLE
Fix insecure file extension/MIME validation allowing disguised executable uploads

### DIFF
--- a/api/v1/submissions/MediaFilesController.php
+++ b/api/v1/submissions/MediaFilesController.php
@@ -255,7 +255,7 @@ class MediaFilesController extends PKPBaseController
                         throw new \Exception(__('api.404.resourceNotFound'));
                     }
 
-                    $extension = $fileManager->parseFileExtension($temporaryFile->getOriginalFileName());
+                    $extension = $fileManager->parseFileExtension($temporaryFile->getOriginalFileName(), $temporaryFile->getFilePath());
                     $fileId = app()->get('file')->add(
                         $temporaryFile->getFilePath(),
                         $submissionDir . '/' . uniqid() . '.' . $extension

--- a/api/v1/submissions/PKPSubmissionFileController.php
+++ b/api/v1/submissions/PKPSubmissionFileController.php
@@ -330,7 +330,7 @@ class PKPSubmissionFileController extends PKPBaseController
         }
 
         $fileManager = new FileManager();
-        $extension = $fileManager->parseFileExtension($_FILES['file']['name']);
+        $extension = $fileManager->parseFileExtension($_FILES['file']['name'], $_FILES['file']['tmp_name']);
 
         $submissionDir = Repo::submissionFile()
             ->getSubmissionDir(
@@ -479,7 +479,7 @@ class PKPSubmissionFileController extends PKPBaseController
             }
 
             $fileManager = new FileManager();
-            $extension = $fileManager->parseFileExtension($_FILES['file']['name']);
+            $extension = $fileManager->parseFileExtension($_FILES['file']['name'], $_FILES['file']['tmp_name']);
             $submissionDir = Repo::submissionFile()
                 ->getSubmissionDir(
                     $request->getContext()->getId(),

--- a/classes/file/FileManager.php
+++ b/classes/file/FileManager.php
@@ -52,6 +52,40 @@ class FileManager
     public const DOCUMENT_TYPE_URL = 'url';
 
     /**
+     * File extensions that common web server configurations (Apache/PHP,
+     * IIS/ASP, CGI handlers, etc.) may treat as executable/interpretable
+     * content rather than inert data. Files claiming these extensions are
+     * never allowed to keep them, regardless of client-supplied filename.
+     */
+    public const DANGEROUS_EXTENSIONS = [
+        'php', 'php1', 'php2', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8',
+        'phtml', 'phtm', 'pht', 'phar', 'phps', 'pgif', 'inc',
+        'cgi', 'fcgi', 'pl', 'py', 'pyc', 'pyo', 'rb',
+        'sh', 'bash', 'csh', 'ksh',
+        'asp', 'aspx', 'asa', 'asax', 'ascx', 'ashx', 'asmx', 'cer', 'cfc', 'cfm', 'cfml',
+        'jsp', 'jspx', 'jsw', 'jsv', 'jhtml',
+        'htaccess', 'htpasswd',
+        'exe', 'bat', 'cmd', 'com', 'dll', 'so', 'msi', 'vbs', 'vbe', 'jse', 'wsf', 'wsh', 'ps1', 'scr',
+    ];
+
+    /**
+     * MIME types (as detected from actual file content via finfo, not the
+     * client-supplied name or Content-Type header) that indicate script or
+     * executable content. A file whose real content matches one of these,
+     * regardless of the extension the uploader claims, is not safe to store
+     * under its original extension.
+     */
+    public const DANGEROUS_MIME_TYPES = [
+        'text/x-php', 'application/x-php', 'application/x-httpd-php', 'application/x-httpd-php-source',
+        'text/x-shellscript', 'application/x-sh', 'application/x-csh',
+        'text/x-python', 'text/x-script.python',
+        'text/x-perl', 'application/x-perl',
+        'text/x-ruby',
+        'application/x-executable', 'application/x-dosexec', 'application/x-elf', 'application/x-mach-binary',
+        'application/x-msdownload', 'application/x-msdos-program',
+    ];
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -692,21 +726,33 @@ class FileManager
     }
 
     /**
-     * Parse the file extension from a filename/path.
+     * Parse the file extension from a filename/path, and, when the path to
+     * the actual uploaded content is available, verify it against the
+     * file's real (content-detected) MIME type -- not the client-supplied
+     * filename or Content-Type header, which are both trivially spoofable.
      *
-     * @param string $fileName
+     * This guards against disguised executables (e.g. a PHP webshell
+     * renamed to "manuscript.docx", or given an extension like ".phtml" or
+     * ".pht" that a naive extension blacklist would miss) ending up stored
+     * with an extension that a web server may treat as executable.
+     *
+     * @param string $fileName The client-supplied file name
+     * @param ?string $filePath Path to the actual uploaded file content, if available,
+     *   used to verify the real MIME type (like Laravel's UploadedFile::getMimeType())
      *
      * @return string
      */
-    public function parseFileExtension($fileName)
+    public function parseFileExtension($fileName, ?string $filePath = null)
     {
         $fileParts = explode('.', $fileName);
         if (is_array($fileParts) && count($fileParts) > 1) {
             $fileExtension = $fileParts[count($fileParts) - 1];
         }
 
-        // FIXME Check for evil
-        if (!isset($fileExtension) || stristr($fileExtension, 'php') || strlen($fileExtension) > 6 || !preg_match('/^\w+$/', $fileExtension)) {
+        if (!isset($fileExtension)
+                || strlen($fileExtension) > 6
+                || !preg_match('/^\w+$/', $fileExtension)
+                || in_array(strtolower($fileExtension), self::DANGEROUS_EXTENSIONS, true)) {
             $fileExtension = 'txt';
         }
 
@@ -715,7 +761,27 @@ class FileManager
             $fileExtension = substr($fileName, -6);
         }
 
+        // Verify the actual file content, when available, so a disguised
+        // executable can't slip through under an extension that isn't on
+        // the blacklist above (e.g. renamed to look like a document).
+        if ($filePath !== null && is_readable($filePath) && $this->isDangerousMimeType(PKPString::mime_content_type($filePath))) {
+            $fileExtension = 'txt';
+        }
+
         return $fileExtension;
+    }
+
+    /**
+     * Determine whether a (content-detected) MIME type indicates script or
+     * executable content that should never be trusted with its original
+     * file extension, regardless of what the uploader claims it is.
+     */
+    public function isDangerousMimeType(?string $mimeType): bool
+    {
+        if (!$mimeType) {
+            return false;
+        }
+        return in_array(strtolower($mimeType), self::DANGEROUS_MIME_TYPES, true);
     }
 
     /**

--- a/classes/file/TemporaryFileManager.php
+++ b/classes/file/TemporaryFileManager.php
@@ -98,7 +98,7 @@ class TemporaryFileManager extends PrivateFileManager
     public function handleUpload($fileName, $userId)
     {
         // Get the file extension, then rename the file.
-        $fileExtension = $this->parseFileExtension($this->getUploadedFileName($fileName));
+        $fileExtension = $this->parseFileExtension($this->getUploadedFileName($fileName), $this->getUploadedFilePath($fileName));
 
         if (!$this->fileExists($this->getBasePath(), 'dir')) {
             // Try to create destination directory

--- a/classes/jats/Repository.php
+++ b/classes/jats/Repository.php
@@ -146,7 +146,7 @@ class Repository
         $existingJatsFile = $this->getJatsFile($publicationId, $submissionId, $genres->toArray());
 
         $fileManager = new FileManager();
-        $extension = $fileManager->parseFileExtension($fileName);
+        $extension = $fileManager->parseFileExtension($fileName, $fileTmpName);
 
         $submissionDir = Repo::submissionFile()
             ->getSubmissionDir(

--- a/classes/submissionFile/Repository.php
+++ b/classes/submissionFile/Repository.php
@@ -890,7 +890,7 @@ abstract class Repository
         $submission = Repo::submission()->get($newPublication->getData('submissionId'));
 
         $fileManager = new FileManager();
-        $extension = $fileManager->parseFileExtension($oldFile->path);
+        $extension = $fileManager->parseFileExtension($oldFile->path, Config::getVar('files', 'files_dir') . '/' . $oldFile->path);
 
         $submissionDir = Repo::submissionFile()
             ->getSubmissionDir(

--- a/controllers/wizard/fileUpload/form/SubmissionFilesUploadForm.php
+++ b/controllers/wizard/fileUpload/form/SubmissionFilesUploadForm.php
@@ -189,7 +189,7 @@ class SubmissionFilesUploadForm extends PKPSubmissionFilesUploadBaseForm
 
         // Upload the file.
         $fileManager = new FileManager();
-        $extension = $fileManager->parseFileExtension($_FILES['uploadedFile']['name']);
+        $extension = $fileManager->parseFileExtension($_FILES['uploadedFile']['name'], $_FILES['uploadedFile']['tmp_name']);
 
         $submissionDir = Repo::submissionFile()->getSubmissionDir($request->getContext()->getId(), $this->getData('submissionId'));
         $fileId = app()->get('file')->add(

--- a/tests/classes/file/FileManagerTest.php
+++ b/tests/classes/file/FileManagerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * @file tests/classes/file/FileManagerTest.php
+ *
+ * Copyright (c) 2014-2026 Simon Fraser University
+ * Copyright (c) 2000-2026 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class FileManagerTest
+ *
+ * @ingroup tests_classes_file
+ *
+ * @see FileManager
+ *
+ * @brief Tests for the FileManager class, in particular the extension/MIME
+ *   type safety checks performed on uploaded files.
+ */
+
+namespace PKP\tests\classes\file;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PKP\file\FileManager;
+use PKP\tests\PKPTestCase;
+
+#[CoversClass(FileManager::class)]
+class FileManagerTest extends PKPTestCase
+{
+    private FileManager $fileManager;
+
+    /** @var string[] Temporary files created during a test, cleaned up in tearDown() */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fileManager = new FileManager();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $tempFile) {
+            @unlink($tempFile);
+        }
+        $this->tempFiles = [];
+        parent::tearDown();
+    }
+
+    /**
+     * Create a temporary file with the given contents and track it for cleanup.
+     */
+    private function createTempFile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'fmtest');
+        file_put_contents($path, $contents);
+        $this->tempFiles[] = $path;
+        return $path;
+    }
+
+    public static function safeExtensionProvider(): array
+    {
+        return [
+            'plain text' => ['notes.txt', 'txt'],
+            'word document' => ['manuscript.docx', 'docx'],
+            'pdf' => ['report.pdf', 'pdf'],
+            'uppercase extension' => ['IMAGE.JPG', 'JPG'],
+            'no extension' => ['README', 'txt'],
+            'tar.gz archive' => ['archive.tar.gz', 'tar.gz'],
+        ];
+    }
+
+    #[DataProvider('safeExtensionProvider')]
+    public function testParseFileExtensionAllowsSafeExtensions(string $fileName, string $expectedExtension): void
+    {
+        $this->assertEquals($expectedExtension, $this->fileManager->parseFileExtension($fileName));
+    }
+
+    public static function dangerousExtensionProvider(): array
+    {
+        return [
+            'php' => ['shell.php'],
+            'uppercase PHP' => ['shell.PHP'],
+            'php5' => ['shell.php5'],
+            // Regression coverage: these bypassed the old stristr($ext, 'php')
+            // check because they don't contain the substring "php".
+            'phtml' => ['shell.phtml'],
+            'pht' => ['shell.pht'],
+            'phar' => ['shell.phar'],
+            'phps' => ['shell.phps'],
+            'cgi' => ['shell.cgi'],
+            'perl script' => ['shell.pl'],
+            'python script' => ['shell.py'],
+            'shell script' => ['shell.sh'],
+            'jsp' => ['shell.jsp'],
+            'asp' => ['shell.asp'],
+            'apache config' => ['x.htaccess'],
+            'windows executable' => ['payload.exe'],
+            'path traversal chars' => ['evil.p;hp'],
+            'overly long extension' => ['file.abcdefg'],
+        ];
+    }
+
+    #[DataProvider('dangerousExtensionProvider')]
+    public function testParseFileExtensionBlocksDangerousExtensions(string $fileName): void
+    {
+        $this->assertEquals('txt', $this->fileManager->parseFileExtension($fileName));
+    }
+
+    /**
+     * A PHP webshell renamed with a "safe" extension must still be caught
+     * once the real file content is available for inspection -- this is
+     * the core of the fix for the file upload vulnerability where a
+     * disguised executable could be uploaded under an innocuous name.
+     */
+    public function testParseFileExtensionDetectsDisguisedPhpContentByRealMimeType(): void
+    {
+        $webshell = $this->createTempFile("<?php system(\$_GET['cmd']); ?>");
+
+        $this->assertEquals(
+            'txt',
+            $this->fileManager->parseFileExtension('vacation-photo.jpg', $webshell)
+        );
+    }
+
+    /**
+     * A file with a genuinely safe extension and matching real content
+     * must still be accepted once content inspection is enabled.
+     */
+    public function testParseFileExtensionAllowsGenuineContentMatchingExtension(): void
+    {
+        $pdf = $this->createTempFile("%PDF-1.4\n%real pdf-ish content\n");
+
+        $this->assertEquals(
+            'pdf',
+            $this->fileManager->parseFileExtension('report.pdf', $pdf)
+        );
+    }
+
+    /**
+     * When no file path is supplied, parseFileExtension() must fall back to
+     * the extension-only check without erroring.
+     */
+    public function testParseFileExtensionWithoutFilePathStillWorks(): void
+    {
+        $this->assertEquals('docx', $this->fileManager->parseFileExtension('manuscript.docx'));
+    }
+
+    public function testIsDangerousMimeTypeDetectsScriptAndExecutableTypes(): void
+    {
+        $this->assertTrue($this->fileManager->isDangerousMimeType('text/x-php'));
+        $this->assertTrue($this->fileManager->isDangerousMimeType('application/x-httpd-php'));
+        $this->assertTrue($this->fileManager->isDangerousMimeType('application/x-sh'));
+        $this->assertTrue($this->fileManager->isDangerousMimeType('application/x-dosexec'));
+    }
+
+    public function testIsDangerousMimeTypeAllowsOrdinaryDocumentTypes(): void
+    {
+        $this->assertFalse($this->fileManager->isDangerousMimeType('application/pdf'));
+        $this->assertFalse($this->fileManager->isDangerousMimeType('image/jpeg'));
+        $this->assertFalse($this->fileManager->isDangerousMimeType('text/plain'));
+        $this->assertFalse($this->fileManager->isDangerousMimeType(null));
+    }
+}


### PR DESCRIPTION
## 🔴 CRITICAL SECURITY FIX — Arbitrary File Upload / Remote Code Execution

**Severity: Critical.** This vulnerability is not theoretical — it has already been
exploited against real, production OJS installations. **Multiple universities,
including several in Indonesia, have had their journal websites compromised
through this exact weakness and hijacked to host online gambling ("judi
online" / "judol") spam pages.** These gambling pages get indexed by search
engines under the institution's own domain, causing serious reputational and
SEO damage that is difficult to reverse.

### The problem

`FileManager::parseFileExtension()` in `classes/file/FileManager.php` is
responsible for deciding what file extension an uploaded file is allowed to
keep. For years it has carried the comment `// FIXME Check for evil`, and its
actual check was this:

```php
if (!isset($fileExtension) || stristr($fileExtension, 'php') || strlen($fileExtension) > 6 || !preg_match('/^\w+$/', $fileExtension)) {
    $fileExtension = 'txt';
}

In plain terms, this only blocks a file extension if it contains the letters
"php" somewhere in it. That is easy to get around:

- .phtml, .pht, .phar, .phps — all still executed as PHP by many
  default web server configurations, and none of them contain "php" as a
  substring, so they were never blocked.
- Other server-executable extensions such as .cgi, .pl, .py, .sh,
  .jsp, .asp, .htaccess were not checked at all.
- Most importantly: the check never looks at the actual content of the
  uploaded file. It only ever looks at the filename the uploader typed in.
  A PHP webshell renamed to something harmless-looking like photo.jpg or
  cover-letter.docx was accepted without question.

Any user role that can upload a file (submission files, temporary files,
media files, etc.) could exploit this to plant an executable webshell on the
server, leading to full remote code execution — which is exactly the
technique used to deface OJS sites with gambling spam.

The fix

1. Replaced the substring check with a real denylist. Extensions are now
   compared exactly (case-insensitive) against FileManager::DANGEROUS_EXTENSIONS,
   a list covering PHP variants, CGI/Perl/Python/Ruby scripts, ASP/JSP
   variants, .htaccess/.htpasswd, native executables, and more.
2. Added real, content-based MIME type verification — the same approach
   Laravel's UploadedFile uses. parseFileExtension() now accepts an
   optional file path; when given, it uses PHP's finfo (via
   PKPString::mime_content_type()) to inspect the file's actual binary
   content, not the filename or the client-supplied Content-Type header.
   If the real content looks like a script or executable
   (FileManager::DANGEROUS_MIME_TYPES), the file is forced to a safe
   .txt extension no matter what name the uploader gave it.
3. Updated every upload code path (submission files, temporary files,
   media files, JATS imports, file versioning) to pass the real uploaded
   file path through, so the new content check is actually applied
   everywhere, not just extension parsing.
4. The change is backward compatible — the new parameter is optional, so
   nothing breaks if a call site isn't updated yet, it just still benefits
   from the stronger extension denylist.

Test plan

- [x] Added tests/classes/file/FileManagerTest.php:
  - Legitimate files (.docx, .pdf, .tar.gz, no extension) keep working
    as before.
  - Extensions that previously bypassed the check (.phtml, .pht,
    .phar, .phps, .cgi, .pl, .py, .sh, .jsp, .asp,
    .htaccess, .exe, etc.) are now rejected.
  - A PHP payload disguised with an innocent filename (e.g.
    vacation-photo.jpg) is caught by real content inspection.
  - Genuine files with matching content/extension still pass.
  - No file path provided falls back safely to the extension-only check.
- [x] Verified manually that the previously-bypassable extensions are
  blocked and normal document uploads are unaffected.
- [ ] Full suite to be run inside a complete OJS/OMP/OPS checkout with
  lib/pkp pinned to this branch.

Why this needs urgent attention

The weakness has sat in the codebase, publicly visible, marked with a
FIXME comment, for years — and it is already being actively exploited
against live journals. We'd ask that this be reviewed and merged with
priority, and considered for backport to all currently supported release
branches, given active exploitation is already occurring in the wild.