### PR TITLE
pkp/pkp-lib#13237 Restore type-aware empty value fallback for form field configs

### DIFF
--- a/classes/components/forms/Field.php
+++ b/classes/components/forms/Field.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/Field.php
  *
@@ -123,7 +124,7 @@ abstract class Field
             $config['isInert'] = $this->isInert;
         }
 
-        $config['value'] = $this->value ?? $this->default ?? null;
+        $config['value'] = $this->value ?? $this->default ?? $this->getEmptyValue();
 
         return $config;
     }
@@ -148,13 +149,20 @@ abstract class Field
     /**
      * Get a default empty value for this field type
      *
-     * The UI Library expects to receive a value property for each field. If it's
-     * a multilingual field, it expects the value property to contain keys for
-     * each locale in the form.
+     * The UI Library expects to receive a value property for each field, with a
+     * type matching what the field's component operates on (e.g. an array for
+     * multi-select fields). If it's a multilingual field, it expects the value
+     * property to contain keys for each locale in the form.
      *
      * This function will provide a default empty value so that a form can fill
      * in the empty values automatically.
      *
+     * Note: serializing `''`/`[]` instead of `null` for unset values is safe on
+     * the save path only because the API converts them back to `null` before
+     * anything is persisted (see the `ConvertEmptyStringsToNull` middleware in
+     * `PKPRoutingProvider` and `PKPBaseController::convertStringsToSchema()`).
+     * A raw `''` reaching `EntityUpdate::updateSettings()` would store an empty
+     * settings row where `null` deletes it.
      */
     public function getEmptyValue()
     {

--- a/classes/components/forms/FieldAffiliations.php
+++ b/classes/components/forms/FieldAffiliations.php
@@ -50,8 +50,15 @@ class FieldAffiliations extends Field
         $config = parent::getConfig();
 
         $config['authorId'] = $this->authorId;
-        $config['value'] = $this->value ?? $this->default ?? null;
 
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     */
+    public function getEmptyValue()
+    {
+        return [];
     }
 }

--- a/classes/components/forms/FieldAuthors.php
+++ b/classes/components/forms/FieldAuthors.php
@@ -47,8 +47,15 @@ class FieldAuthors extends Field
     public function getConfig()
     {
         $config = parent::getConfig();
-        $config['value'] = $this->value ?? $this->default ?? null;
         $config['addButtonLabel'] = $this->addButtonLabel;
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     */
+    public function getEmptyValue()
+    {
+        return [];
     }
 }

--- a/classes/components/forms/FieldBaseAutosuggest.php
+++ b/classes/components/forms/FieldBaseAutosuggest.php
@@ -80,4 +80,12 @@ abstract class FieldBaseAutosuggest extends Field
 
         return $config;
     }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     */
+    public function getEmptyValue()
+    {
+        return [];
+    }
 }

--- a/classes/components/forms/FieldCreditRoles.php
+++ b/classes/components/forms/FieldCreditRoles.php
@@ -16,7 +16,7 @@
 
 namespace PKP\components\forms;
 
-use APP\facades\Repo;;
+use APP\facades\Repo;
 use PKP\author\creditRole\CreditRoleDegree;
 
 class FieldCreditRoles extends Field
@@ -30,9 +30,16 @@ class FieldCreditRoles extends Field
     public function getConfig()
     {
         $config = parent::getConfig();
-        $config['value'] = $this->value ?? [];
         $config['options'] = $this->mapCreditRoles();
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     */
+    public function getEmptyValue()
+    {
+        return [];
     }
 
     /**

--- a/classes/components/forms/FieldFunder.php
+++ b/classes/components/forms/FieldFunder.php
@@ -37,8 +37,15 @@ class FieldFunder extends Field
         $config = parent::getConfig();
 
         $config['submissionId'] = $this->submissionId;
-        $config['value'] = $this->value ?? $this->default ?? null;
 
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     */
+    public function getEmptyValue()
+    {
+        return [];
     }
 }

--- a/classes/components/forms/FieldFunderGrants.php
+++ b/classes/components/forms/FieldFunderGrants.php
@@ -45,8 +45,15 @@ class FieldFunderGrants extends Field
     public function getConfig()
     {
         $config = parent::getConfig();
-        $config['value'] = $this->value ?? $this->default ?? null;
         $config['addButtonLabel'] = $this->addButtonLabel;
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     */
+    public function getEmptyValue()
+    {
+        return [];
     }
 }

--- a/classes/components/forms/FieldMetadataSetting.php
+++ b/classes/components/forms/FieldMetadataSetting.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/FieldMetadataSetting.php
  *
@@ -46,5 +47,15 @@ class FieldMetadataSetting extends FieldOptions
         $config['submissionOptions'] = $this->submissionOptions;
 
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     *
+     * This field holds a scalar tri-state setting, not a checkbox array.
+     */
+    public function getEmptyValue()
+    {
+        return $this->disabledValue;
     }
 }

--- a/classes/components/forms/FieldOptions.php
+++ b/classes/components/forms/FieldOptions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/FieldOptions.php
  *
@@ -46,5 +47,25 @@ class FieldOptions extends Field
         $config['options'] = $this->options;
 
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     *
+     * The value's runtime type is what selects the input mode client-side, so
+     * the empty value must match the mode the field was written for. A single
+     * checkbox whose option value is a boolean is a boolean on/off toggle, so
+     * its empty value is `false`; any other checkbox is a multi-select group,
+     * so its empty value is `[]`. For this detection to work, a boolean
+     * toggle's option must declare a real boolean value, e.g.
+     * `'options' => [['value' => true, 'label' => ...]]`.
+     */
+    public function getEmptyValue()
+    {
+        if ($this->type === 'radio') {
+            return '';
+        }
+        $option = count($this->options) === 1 ? reset($this->options) : null;
+        return is_bool($option['value'] ?? null) ? false : [];
     }
 }

--- a/classes/components/forms/FieldShowEnsuringLink.php
+++ b/classes/components/forms/FieldShowEnsuringLink.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/FieldShowEnsuringLink.php
  *
@@ -35,5 +36,15 @@ class FieldShowEnsuringLink extends FieldOptions
         $config['modalTitle'] = __('review.anonymousPeerReview.title');
 
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     *
+     * This field is a single-checkbox boolean toggle.
+     */
+    public function getEmptyValue()
+    {
+        return false;
     }
 }

--- a/classes/components/forms/FieldSlider.php
+++ b/classes/components/forms/FieldSlider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/FieldSlider.php
  *
@@ -78,4 +79,11 @@ class FieldSlider extends Field
         return $config;
     }
 
+    /**
+     * @copydoc Field::getEmptyValue()
+     */
+    public function getEmptyValue()
+    {
+        return $this->min;
+    }
 }

--- a/classes/components/forms/FieldUpload.php
+++ b/classes/components/forms/FieldUpload.php
@@ -93,4 +93,15 @@ class FieldUpload extends Field
 
         return $config;
     }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     *
+     * `null` is meaningful for uploads: the save handlers delete the stored
+     * file when the value is null (see `_saveFileParam()` implementations).
+     */
+    public function getEmptyValue()
+    {
+        return null;
+    }
 }

--- a/classes/components/forms/FieldUploadImage.php
+++ b/classes/components/forms/FieldUploadImage.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/FieldUploadImage.php
  *
@@ -48,13 +49,5 @@ class FieldUploadImage extends FieldUpload
         $config['altTextDescription'] = __('common.altTextInstructions');
 
         return $config;
-    }
-
-    /**
-     * @copydoc Field::getEmptyValue()
-     */
-    public function getEmptyValue()
-    {
-        return null;
     }
 }

--- a/classes/components/forms/FormComponent.php
+++ b/classes/components/forms/FormComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/FormComponent.php
  *
@@ -335,10 +336,10 @@ class FormComponent
     {
         $config = $field->getConfig();
 
-        // Add a value property if the field does not include one
-        if (!array_key_exists('value', $config)) {
-            $config['value'] = $field->isMultilingual ? [] : $field->getEmptyValue();
-        }
+        // Add a value property if the field does not include one. Field::getConfig()
+        // already falls back to Field::getEmptyValue(), so this only catches
+        // subclasses that assign their own null value in getConfig().
+        $config['value'] ??= $field->isMultilingual ? [] : $field->getEmptyValue();
         if ($field->isMultilingual) {
             if (!is_array($config['value'])) {
                 $config['value'] = [];

--- a/classes/components/forms/context/PKPContextStatisticsForm.php
+++ b/classes/components/forms/context/PKPContextStatisticsForm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/forms/context/PKPContextStatisticsForm.php
  *
@@ -79,7 +80,7 @@ class PKPContextStatisticsForm extends FormComponent
                         'label' => __('manager.settings.statistics.institutionUsageStats.enable'),
                     ],
                 ],
-                'value' => $context->getData('enableInstitutionUsageStats') !== null ? $context->getData('enableInstitutionUsageStats') : $site->getData('enableInstitutionUsageStats'),
+                'value' => $context->getData('enableInstitutionUsageStats') ?? $site->getData('enableInstitutionUsageStats'),
             ]));
         }
         if ($site->getData('isSushiApiPublic') !== null && $site->getData('isSushiApiPublic')) {
@@ -92,7 +93,7 @@ class PKPContextStatisticsForm extends FormComponent
                         'label' => __('manager.settings.statistics.publicSushiApi.public'),
                     ],
                 ],
-                'value' => $context->getData('isSushiApiPublic') !== null ? $context->getData('isSushiApiPublic') : $site->getData('isSushiApiPublic'),
+                'value' => $context->getData('isSushiApiPublic') ?? $site->getData('isSushiApiPublic'),
             ]));
         }
     }

--- a/classes/components/forms/context/PKPMetadataSettingsForm.php
+++ b/classes/components/forms/context/PKPMetadataSettingsForm.php
@@ -172,7 +172,7 @@ class PKPMetadataSettingsForm extends FormComponent
                 'label' => __('manager.setup.competingInterests'),
                 'options' => [
                     [
-                        'value' => 'true',
+                        'value' => true,
                         'label' => __('manager.setup.competingInterests.requireAuthors'),
                     ],
                 ],
@@ -195,7 +195,7 @@ class PKPMetadataSettingsForm extends FormComponent
                 'label' => __('submission.citations.structured.citationsMetadataLookup'),
                 'options' => [
                     [
-                        'value' => 'true',
+                        'value' => true,
                         'label' => __('manager.setup.metadata.citationsMetadataLookup.enable')
                     ]
                 ],
@@ -234,7 +234,7 @@ class PKPMetadataSettingsForm extends FormComponent
                 'description' => __('manager.setup.metadata.funders.funderGrantValidation.description'),
                 'options' => [
                     [
-                        'value' => 'true',
+                        'value' => true,
                         'label' => __('manager.setup.metadata.funders.funderGrantValidation.enable')
                     ]
                 ],

--- a/classes/components/forms/context/PKPNotifyUsersForm.php
+++ b/classes/components/forms/context/PKPNotifyUsersForm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/context/PKPNotifyUsersForm.php
  *
@@ -16,7 +17,6 @@
 namespace PKP\components\forms\context;
 
 use APP\core\Application;
-use APP\facades\Repo;
 use PKP\components\forms\FieldOptions;
 use PKP\components\forms\FieldRichTextarea;
 use PKP\components\forms\FieldText;
@@ -84,7 +84,7 @@ class PKPNotifyUsersForm extends FormComponent
                 'value' => 0,
                 'options' => [
                     [
-                        'value' => 1,
+                        'value' => true,
                         'label' => __('manager.setup.notifyUsers.copyDetails', ['email' => $currentUser->getEmail()]),
                     ],
                 ]

--- a/tests/classes/components/forms/FieldConfigTest.php
+++ b/tests/classes/components/forms/FieldConfigTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * @file tests/classes/components/forms/FieldConfigTest.php
+ *
+ * Copyright (c) 2026 Simon Fraser University
+ * Copyright (c) 2026 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class FieldConfigTest
+ *
+ * @ingroup tests_classes_components_forms
+ *
+ * @brief Test the serialized field config value fallback chain:
+ *  value ?? default ?? getEmptyValue()
+ */
+
+namespace PKP\tests\classes\components\forms;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PKP\components\forms\Field;
+use PKP\components\forms\FieldMetadataSetting;
+use PKP\components\forms\FieldOptions;
+use PKP\components\forms\FieldSlider;
+use PKP\components\forms\FieldText;
+use PKP\components\forms\FieldUpload;
+use PKP\components\forms\FormComponent;
+use PKP\context\Context;
+use PKP\tests\PKPTestCase;
+
+#[CoversClass(Field::class)]
+#[CoversClass(FormComponent::class)]
+class FieldConfigTest extends PKPTestCase
+{
+    public function testValueFallsBackToEmptyValue()
+    {
+        $config = (new FieldText('title'))->getConfig();
+        self::assertSame('', $config['value']);
+    }
+
+    public function testValueTakesPrecedenceOverDefaultAndEmptyValue()
+    {
+        $config = (new FieldText('title', ['value' => 'saved', 'default' => 'preset']))->getConfig();
+        self::assertSame('saved', $config['value']);
+    }
+
+    public function testDefaultTakesPrecedenceOverEmptyValue()
+    {
+        $config = (new FieldText('title', ['default' => 'preset']))->getConfig();
+        self::assertSame('preset', $config['value']);
+    }
+
+    public function testFalsyValuesAreNotClobbered()
+    {
+        // The null coalescing chain must only fall through on null, never on
+        // other falsy values: an explicit false/0/''/[] is real data.
+        self::assertSame(false, (new FieldOptions('toggle', ['value' => false, 'default' => true]))->getConfig()['value']);
+        self::assertSame(0, (new FieldText('num', ['value' => 0, 'default' => 5]))->getConfig()['value']);
+        self::assertSame('', (new FieldText('str', ['value' => '', 'default' => 'x']))->getConfig()['value']);
+        self::assertSame([], (new FieldOptions('list', ['value' => [], 'default' => ['a']]))->getConfig()['value']);
+    }
+
+    public function testFieldOptionsEmptyValueDependsOnDetectedMode()
+    {
+        $toggleOptions = [['value' => true, 'label' => 'Enable']];
+        $groupOptions = [
+            ['value' => 'a', 'label' => 'A'],
+            ['value' => 'b', 'label' => 'B'],
+        ];
+
+        // A single checkbox bound to a boolean option value is a boolean
+        // on/off toggle
+        self::assertSame(false, (new FieldOptions('toggle', ['options' => $toggleOptions]))->getConfig()['value']);
+        self::assertSame(false, (new FieldOptions('inverted', ['options' => [['value' => false, 'label' => 'Hide']]]))->getConfig()['value']);
+
+        // Any other checkbox is a multi-select group: several options, or a
+        // single option holding a data value (e.g. a dynamic options list
+        // reduced to one entry)
+        self::assertSame([], (new FieldOptions('checkboxes', ['options' => $groupOptions]))->getConfig()['value']);
+        self::assertSame([], (new FieldOptions('single', ['options' => [['value' => 12, 'label' => 'Section']]]))->getConfig()['value']);
+        self::assertSame([], (new FieldOptions('empty'))->getConfig()['value']);
+
+        // A radio holds a scalar
+        self::assertSame('', (new FieldOptions('radios', ['type' => 'radio', 'options' => $toggleOptions]))->getConfig()['value']);
+
+        // Multilingual options are keyed by locale, so the boolean toggle
+        // convention cannot be detected there
+        $multilingualField = new FieldOptions('multilingual', [
+            'isMultilingual' => true,
+            'options' => ['en' => $toggleOptions],
+        ]);
+        self::assertSame([], $multilingualField->getEmptyValue());
+    }
+
+    public function testFieldSliderEmptyValueIsMin()
+    {
+        $config = (new FieldSlider('days', ['min' => 3, 'max' => 10]))->getConfig();
+        self::assertSame(3, $config['value']);
+    }
+
+    public function testFieldUploadEmptyValueIsNull()
+    {
+        // null is meaningful for uploads: the save handlers delete the stored
+        // file when the value is null.
+        $config = (new FieldUpload('file', ['options' => ['url' => 'http://example.com']]))->getConfig();
+        self::assertNull($config['value']);
+    }
+
+    public function testFieldMetadataSettingEmptyValueIsDisabledValue()
+    {
+        $config = (new FieldMetadataSetting('keywords'))->getConfig();
+        self::assertSame(Context::METADATA_DISABLE, $config['value']);
+    }
+
+    public function testMultilingualFieldConfigFillsEveryLocale()
+    {
+        $form = $this->getForm();
+        $field = new FieldText('title', ['isMultilingual' => true]);
+        $config = $form->getFieldConfig($field);
+        self::assertSame(['en' => '', 'fr_CA' => ''], $config['value']);
+    }
+
+    public function testMultilingualFieldConfigKeepsExistingLocaleValues()
+    {
+        $form = $this->getForm();
+        $field = new FieldText('title', ['isMultilingual' => true, 'value' => ['en' => 'Saved']]);
+        $config = $form->getFieldConfig($field);
+        self::assertSame(['en' => 'Saved', 'fr_CA' => ''], $config['value']);
+    }
+
+    public function testFieldConfigPreservesIntentionalNull()
+    {
+        // A field whose getEmptyValue() returns null must keep null through
+        // FormComponent::getFieldConfig().
+        $form = $this->getForm();
+        $field = new FieldUpload('file', ['options' => ['url' => 'http://example.com']]);
+        $config = $form->getFieldConfig($field);
+        self::assertNull($config['value']);
+    }
+
+    public function testFieldConfigFillsEmptyValueWhenSubclassEmitsNull()
+    {
+        // A subclass that assigns its own null value in getConfig() bypasses
+        // the fallback in Field::getConfig(); getFieldConfig() must catch it.
+        $form = $this->getForm();
+        $field = new class ('custom') extends Field {
+            public $component = 'field-custom';
+
+            public function getConfig()
+            {
+                $config = parent::getConfig();
+                $config['value'] = null;
+                return $config;
+            }
+
+            public function getEmptyValue()
+            {
+                return ['shaped'];
+            }
+        };
+        $config = $form->getFieldConfig($field);
+        self::assertSame(['shaped'], $config['value']);
+    }
+
+    protected function getForm(): FormComponent
+    {
+        return new FormComponent('testForm', 'PUT', 'http://example.com', [
+            ['key' => 'en', 'label' => 'English'],
+            ['key' => 'fr_CA', 'label' => 'French'],
+        ]);
+    }
+}


### PR DESCRIPTION
Part of https://github.com/pkp/pkp-lib/issues/13237

- Restores the `value ?? default ?? getEmptyValue()` fallback chain in `Field::getConfig()` — the `getEmptyValue()` step had been unreachable since #8263 left the chain ending in `?? null`, so fields without a value/default serialized `value: null`, which several UI Library components cannot operate on.
- Makes the fallback in `FormComponent::getFieldConfig()` live again (`??=`) as a safety net for subclasses that assign their own null value; the multilingual per-locale fill is unchanged.
- Adds type-correct `getEmptyValue()` overrides: `FieldSlider` → `min` (behavior-identical: the component renders the min label for both `null` and `min`), `FieldUpload` → `null` (moved up from `FieldUploadImage`; `null` triggers file deletion in the save handlers), `FieldBaseAutosuggest` → `[]`, `FieldMetadataSetting` → `disabledValue`, `FieldShowEnsuringLink` → `false`, and `[]` for the array-shaped fields (`FieldAuthors`, `FieldAffiliations`, `FieldFunder`, `FieldFunderGrants`, `FieldCreditRoles`), whose now-redundant `$config['value']` reassignments are removed.
- `FieldOptions` detects the field mode: a single checkbox whose option value is a real boolean is a boolean on/off toggle (`false`); any other checkbox is a multi-select group (`[]`); radio holds a scalar (`''`). The value's runtime type is what selects the input mode client-side, so the empty value must match the mode the field was written for. Dynamic option lists that collapse to one entry carry id/string option values and are therefore never misdetected.
- Normalizes mistyped option values on boolean toggles (int `1`, string `'true'` → `true`) so the detection applies to them; these declared values are inert in boolean checkbox mode, so this has no runtime effect.
- Adds `FieldConfigTest` covering the fallback ordering (explicit `false`/`0`/`''`/`[]` are never clobbered), the per-type empty values, the multilingual locale fill, and null preservation for uploads.

Serialized `''`/`[]` (instead of `null`) is safe on the save path: the `ConvertEmptyStringsToNull` middleware plus `PKPBaseController::convertStringsToSchema()` normalize them back before `EntityUpdate::updateSettings()`; multilingual fields have shipped `''` for unset locales this way for years.

Companion OJS PR to follow in the issue description.