### PR TITLE
Fix unix socket handling in installer

### DIFF
--- a/classes/install/PKPInstall.php
+++ b/classes/install/PKPInstall.php
@@ -220,6 +220,7 @@ class PKPInstall extends Installer
                 'database' => [
                     'driver' => $this->getParam('databaseDriver'),
                     'host' => $this->getParam('databaseHost'),
+                    'unix_socket' => $this->getParam('unixSocket') ?? '',
                     'username' => $this->getParam('databaseUsername'),
                     'password' => $this->getParam('databasePassword'),
                     'name' => $this->getParam('databaseName')

--- a/classes/install/form/InstallForm.php
+++ b/classes/install/form/InstallForm.php
@@ -171,6 +171,7 @@ class InstallForm extends MaintenanceForm
             'adminEmail',
             'databaseDriver',
             'databaseHost',
+            'unixSocket',
             'databaseUsername',
             'databasePassword',
             'databaseName',


### PR DESCRIPTION
## Problem / Motivation
The installer accepts a `unixSocket` parameter, but `InstallForm::readInputData()` does not retain it. As a result, installations that need a custom MySQL or MariaDB Unix socket cannot pass that setting through the web installer.

## Why it matters
Some deployments connect to the database through a non-default Unix socket rather than TCP. The installer should keep that setting both while connecting and in the generated configuration.

## What changed
- Retain `unixSocket` with the other database connection inputs in `InstallForm`.
- Write the value as `database.unix_socket` when generating the configuration file.
- Use an empty string when the parameter is omitted so the configuration parser never receives `null`.

## Tests
- Ran PHP 8.4 syntax checks on both changed files.
- Ran `git diff --check`.
- Ran targeted assertions for the form-to-config mapping and omitted-value fallback.
- Ran a focused `ConfigParser` check with an active `unix_socket` entry and an empty value.

No automated test was added for this small parameter-mapping change.

## Manual verification
Traced the installer flow from submitted form input through `PKPInstall::createConfig()`. A full installer run was not performed locally because it requires an application runtime and database.

<!-- no-visual-delta -->
**Why no screenshot:** This changes installer connection parameter handling without a rendered UI change.

Fixes #13153