### PR TITLE
pkp/pkp-lib#12375 Honour the URL locale when resolving the current locale (stable-3_5_0)

### DIFF
--- a/classes/core/PKPPageRouter.php
+++ b/classes/core/PKPPageRouter.php
@@ -504,15 +504,22 @@ class PKPPageRouter extends PKPRouter
         $contextPath = $this->_getRequestedUrlParts(Core::getContextPath(...), $request);
         $urlLocale = $this->_getRequestedUrlParts(Core::getLocalization(...), $request);
         $multiLingual = count($this->_getContextAndLocales($request, $contextPath)[1]) > 1;
-        // Quit if there's no new locale to be set and the request URL is already well-formed
-        if (!$setLocale && ($multiLingual ? $urlLocale === Locale::getLocale() : !$urlLocale)) {
-            return;
-        }
 
         $session = $request->getSession();
         $currentLocale = $session->get('currentLocale') ?? '';
         if (!Locale::isSupported($currentLocale ?? '')) {
             $currentLocale = null;
+        }
+
+        // Quit if there's no new locale to be set and the request URL is already well-formed.
+        // Still sync the session/cookie to the URL locale so it survives session resets and
+        // session-disabled requests, which never get a chance to write it themselves otherwise.
+        if (!$setLocale && ($multiLingual ? $urlLocale === Locale::getLocale() : !$urlLocale)) {
+            if ($multiLingual && $urlLocale !== $currentLocale) {
+                $session->put('currentLocale', $urlLocale);
+                $request->setCookieVar('currentLocale', $urlLocale);
+            }
+            return;
         }
 
         $newLocale = $setLocale ?? $urlLocale;

--- a/classes/core/PKPRequest.php
+++ b/classes/core/PKPRequest.php
@@ -361,6 +361,14 @@ class PKPRequest
     }
 
     /**
+     * Get the CGI PATH_INFO of the current request, e.g. "/context/locale/page/op".
+     */
+    public function getPathInfo(): string
+    {
+        return $_SERVER['PATH_INFO'] ?? '';
+    }
+
+    /**
      * Get the server hostname in the request.
      *
      * @param $default Default hostname (defaults to localhost if null)

--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -136,7 +136,13 @@ class Locale implements LocaleInterface
 
         $request = $this->_getRequest();
 
-        $locale = $request->getUserVar('setLocale')
+        // The setLocale request var is only honoured while sessions are disabled (install,
+        // CLI, unit tests - see PKPApplication::__construct()), where the cookie/session
+        // can't be relied on and the new locale must take effect immediately, in the same
+        // request, before it's written out. Trusting it unconditionally let a stray
+        // ?setLocale= on any ordinary URL permanently override the URL's own locale segment
+        // and loop forever against PKPPageRouter::_setLocale() (see pkp/pkp-lib#12375).
+        $locale = (PKPSessionGuard::isSessionDisable() ? $request->getUserVar('setLocale') : null)
             ?: $this->_getUrlLocale()
             ?: $request->getSession()->get('currentLocale')
             ?: $request->getCookieVar('currentLocale')

--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -137,6 +137,7 @@ class Locale implements LocaleInterface
         $request = $this->_getRequest();
 
         $locale = $request->getUserVar('setLocale')
+            ?: $this->_getUrlLocale()
             ?: $request->getSession()->get('currentLocale')
             ?: $request->getCookieVar('currentLocale')
             ?: $this->getPreferredLocale();
@@ -144,6 +145,22 @@ class Locale implements LocaleInterface
         $this->setLocale($locale);
 
         return $this->locale;
+    }
+
+    /**
+     * Get the locale segment of the request URL, if it is one this installation supports.
+     *
+     * Since 3.5 the locale is part of the URL, but getLocale() only consulted
+     * setLocale/session/cookie. A client that keeps no cookies (crawlers, uptime monitors,
+     * curl) therefore never matched the locale in the URL, and PKPPageRouter::_setLocale()
+     * redirected it to the very same URL forever - an infinite 302 loop on every supported
+     * non-primary locale. Honouring the URL also makes the page render in the requested
+     * language on the first hit, with no redirect.
+     */
+    private function _getUrlLocale(): ?string
+    {
+        $locale = Core::getLocalization($_SERVER['PATH_INFO'] ?? '');
+        return $locale !== '' && $this->isSupported($locale) ? $locale : null;
     }
 
     /**

--- a/classes/i18n/Locale.php
+++ b/classes/i18n/Locale.php
@@ -159,7 +159,7 @@ class Locale implements LocaleInterface
      */
     private function _getUrlLocale(): ?string
     {
-        $locale = Core::getLocalization($_SERVER['PATH_INFO'] ?? '');
+        $locale = Core::getLocalization($this->_getRequest()->getPathInfo());
         return $locale !== '' && $this->isSupported($locale) ? $locale : null;
     }
 

--- a/pages/install/InstallHandler.php
+++ b/pages/install/InstallHandler.php
@@ -44,6 +44,10 @@ class InstallHandler extends Handler
         $this->validate(null, $request);
         $this->setupTemplate($request);
 
+        // FIXME: Likely unreachable - PKPPageRouter::route() calls _setLocale() for every
+        // page='install' request before the handler runs, and _setLocale() always redirects
+        // (and exits) whenever $_GET['setLocale'] is set - see PKPPageRouter.php:216-221 and
+        // pkp/pkp-lib#12375. Left in place pending confirmation before removal.
         if (($setLocale = $request->getUserVar('setLocale')) != null && Locale::isLocaleValid($setLocale)) {
             $request->setCookieVar('currentLocale', $setLocale);
         }
@@ -112,6 +116,7 @@ class InstallHandler extends Handler
         $this->validate(null, $request);
         $this->setupTemplate($request);
 
+        // FIXME: Likely unreachable - see the identical note in index() above.
         if (($setLocale = $request->getUserVar('setLocale')) != null && Locale::isLocaleValid($setLocale)) {
             $request->setCookieVar('currentLocale', $setLocale);
         }


### PR DESCRIPTION
Backport of #13124 to `stable-3_5_0` (issue #12375), as requested by @bozana.

Same five commits, cherry-picked with no conflicts: the URL-locale resolution in `Locale::getLocale()` plus Bozana's follow-ups (`PKPRequest::getPathInfo()`, session/cookie sync without redirect, `setLocale` request var only while sessions are disabled, dead-code markers in `InstallHandler`).

Tested on OJS 3.5.0.3: cookie-less requests to `/en` and `/es` return 200 with the right `<html lang>` on the first request; unsupported locales still redirect to the primary one; the language switch and authenticated sessions are unaffected.

Companion OJS PR: submodule update against `stable-3_5_0`.