### PR TITLE
Use the private temporary directory for review PDFs

### DIFF
--- a/api/v1/reviews/PKPReviewController.php
+++ b/api/v1/reviews/PKPReviewController.php
@@ -343,7 +343,9 @@ class PKPReviewController extends PKPBaseController
         $submissionCommentsPrivate = $submissionCommentDao->getReviewerCommentsByReviewerId($submissionId, $reviewAssignment->getReviewerId(), $reviewId, false);
         $title = $submission->getCurrentPublication()->getLocalizedTitle(null, 'html');
         $cleanTitle = str_replace('&nbsp;', ' ', strip_tags($title));
+        $fileManager = new TemporaryFileManager();
         $mpdf = new Mpdf([
+            'tempDir' => $fileManager->getBasePath(),
             'default_font' => 'NotoSansSC',
             'mode' => '+aCJK',
             'autoScriptToLang' => true,
@@ -405,7 +407,6 @@ class PKPReviewController extends PKPBaseController
         $mpdf->WriteHTML($reviewHtml);
         $exportFileName = "submission_review_{$submissionId}-{$reviewId}.pdf";
         $pdfContent = $mpdf->Output($exportFileName, 'S');
-        $fileManager = new TemporaryFileManager();
         $tempFilename = $fileManager->getBasePath() . $exportFileName;
         $fileManager->writeFile($tempFilename, $pdfContent);
         $user = Application::get()->getRequest()->getUser();


### PR DESCRIPTION
Fixes #13305

Review PDF export currently lets mPDF use its default temporary directory under `vendor`. This fails when dependencies are correctly deployed as read-only for the PHP runtime user.

This change creates the existing `TemporaryFileManager` before mPDF and passes its private base path as `tempDir`. The same manager continues to store the completed PDF.

## Testing

- `php -l api/v1/reviews/PKPReviewController.php`
- `git diff --check`
- PHP CS Fixer dry runs with the project configuration and PSR-12 rules reported only pre-existing formatting around the arrow function at line 185, outside this change
- Tested with OJS 3.5.0-5 and PHP 8.2 in a real installation with `vendor` set to `0555`:
  - before the change, mPDF failed because its vendor cache was not writable;
  - after the change, the authenticated export created the mPDF cache under `files_dir/temp/mpdf` and the completed PDF under `files_dir/temp`;
  - the download returned HTTP 200 and the PDF opened successfully;
  - the vendor cache remained unchanged.

mPDF creates its cache directory with mode `0777` by default. The test deployment restricted it to `0700` separately; that permission hardening is outside this PR's scope.
